### PR TITLE
Fixes one formatting markup in pt-br translation

### DIFF
--- a/plone/app/locales/locales/pt_BR/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/pt_BR/LC_MESSAGES/plone.po
@@ -4885,7 +4885,7 @@ msgstr "Estes nomes de classes não são permitidos."
 
 #: CMFPlone/skins/plone_scripts/folder_delete.cpy:60
 msgid "These items are locked for editing: ${lockeditems}."
-msgstr "Estes itens estão travados para edição: $(lockeditems)."
+msgstr "Estes itens estão travados para edição: ${lockeditems}."
 
 #: plone.app.controlpanel/plone/app/controlpanel/filter.py:50
 msgid ""


### PR DESCRIPTION
diff --git a/plone/app/locales/locales/pt_BR/LC_MESSAGES/plone.po b/plone/app/locales/locales/pt_BR/LC_MESSAGES/plone.po
index d895f4d..3dbe93e 100644
--- a/plone/app/locales/locales/pt_BR/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/pt_BR/LC_MESSAGES/plone.po
@@ -4885,7 +4885,7 @@ msgstr "Estes nomes de classes não são permitidos."

 #: CMFPlone/skins/plone_scripts/folder_delete.cpy:60
 msgid "These items are locked for editing: ${lockeditems}."
-msgstr "Estes itens estão travados para edição: $(lockeditems)."
+msgstr "Estes itens estão travados para edição: ${lockeditems}."
