### PR TITLE
Small fix in the search form translation.

### DIFF
--- a/plone/app/locales/locales/de/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/plone.po
@@ -5589,7 +5589,7 @@ msgstr "Die unten angegeben Einstellungsmöglichkeiten kontrollieren die Präsen
 #. Default: "This search form enables you to find content on the site by specifying one or more search terms. <br /> Remember that you can use the quick search anytime, it's normally good enough, this search form is just if you want to be more specific."
 #: CMFPlone/skins/plone_deprecated/search_form.pt:19
 msgid "description_advanced_search"
-msgstr "Mit diesem Suchformular können Sie diese Website nach einem oder mehreren Suchbegriffen durchsuchen.<br />Denken Sie daran, dass Sie jederzeit auch die Schnellsuche benutzen können. Sie liefert im Allgemeinen gute Ergebnisse. Dieses Suchformular ist geeignet, wenn Sie etwas sehr spezielles suchen."
+msgstr "Mit diesem Suchformular können Sie diese Website nach einem oder mehreren Suchbegriffen durchsuchen.<br />Denken Sie daran, dass Sie jederzeit auch die Schnellsuche benutzen können. Sie liefert im Allgemeinen gute Ergebnisse. Dieses Suchformular ist geeignet, wenn Sie etwas sehr Spezielles suchen."
 
 #. Default: "If you want to contact this author, fill in the form below."
 #: CMFPlone/skins/plone_content/author.cpt:178


### PR DESCRIPTION
"Spezielles" is a noun, it must be written with a capital letter.
