### PR TITLE
Updated French translation

### DIFF
--- a/plone/app/locales/locales/fr/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/fr/LC_MESSAGES/plone.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plone-fr\n"
 "POT-Creation-Date: 2013-11-18 09:29+0000\n"
-"PO-Revision-Date: 2013-11-18 11:38+0100\n"
-"Last-Translator: Thomas Desvenain <thomasdesvenain@ecreall.com>\n"
+"PO-Revision-Date: 2014-05-02 12:45-0500\n"
+"Last-Translator: Yves Moisan <ymoisan@videotron.ca>\n"
 "Language-Team: French <plone-fr@lists.plone.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -308,7 +308,7 @@ msgstr ""
 
 #: plone.app.controlpanel/plone/app/controlpanel/ram.py:27
 msgid "A maximum number of cached values."
-msgstr "Nombres maximum de valeurs en cache."
+msgstr "Nombre maximum de valeurs en cache."
 
 #: plone.app.contentrules/plone/app/contentrules/actions/move.py:157
 msgid "A move action can move an object to a different folder."
@@ -371,19 +371,19 @@ msgstr "Ce portlet liste les éléments en attente de modération."
 
 #: CMFPlone/profiles/default/portlets.xml
 msgid "A portlet which can render a log-in box"
-msgstr "Ce portlet affiche un champ de connexion."
+msgstr "Ce portlet affiche un champ de connexion"
 
 #: CMFPlone/profiles/default/portlets.xml
 msgid "A portlet which can render a navigation tree"
-msgstr "Ce portlet affiche un arbre de navigation."
+msgstr "Ce portlet affiche un arbre de navigation"
 
 #: plone.app.openid/plone/app/openid/profiles/default/portlets.xml
 msgid "A portlet which can render an OpenID log-in box"
-msgstr "Ce portlet affiche un champ de connexion OpenID."
+msgstr "Ce portlet affiche un champ de connexion OpenID"
 
 #: plone.portlet.collection/plone/portlet/collection/profiles/default/portlets.xml
 msgid "A portlet which displays the results of a collection query"
-msgstr "Ce portlet affiche les éléments d'une collection."
+msgstr "Ce portlet affiche les éléments d'une collection"
 
 #: CMFPlone/profiles/default/portlets.xml
 msgid "A portlet which shows a search box."
@@ -464,7 +464,7 @@ msgid ""
 "A workflow state condition can restrict rules to objects in particular "
 "workflow states"
 msgstr ""
-"Une condition de type \"état de publication\" permet à la règle de ne "
+"Une condition de type « état de publication » permet à la règle de ne "
 "s'appliquer qu'aux contenus dans certains états de publication."
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/wftransition.py:59
@@ -791,7 +791,7 @@ msgstr "La date de début de l'événement doit être antérieure à celle de fi
 
 #: plone.app.controlpanel/plone/app/controlpanel/ram.py:35
 msgid "An interval between cache cleanups in seconds."
-msgstr "Un interval de temps entre les nettoyages du cache en secondes."
+msgstr "Un intervalle de temps entre les nettoyages du cache en secondes."
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 msgid "An item's description"
@@ -1097,7 +1097,7 @@ msgstr "Commentaire"
 #: CMFPlone/profiles/default/workflows/intranet_folder_workflow/definition.xml
 #: CMFPlone/profiles/default/workflows/intranet_workflow/definition.xml
 msgid "Comment about the last transition"
-msgstr "Commentaires à propose de la dernière transition"
+msgstr "Commentaires à propos de la dernière transition"
 
 #: CMFPlone/skins/plone_form_scripts/discussion_reply.cpy:67
 msgid "Comment added."
@@ -1212,7 +1212,7 @@ msgstr "Contributeur"
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
 msgid "Contributor withdraws submitted content"
-msgstr "Contributeur retire le contenu soumis"
+msgstr "Le contributeur retire le contenu soumis"
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:143
 msgid "Contributors"
@@ -1231,7 +1231,7 @@ msgstr "Copier ou couper un ou plusieurs éléments."
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
 msgid "Copy submitted for publication - pending approval"
-msgstr "Copie soumis pour publication - en attente d'approbation"
+msgstr "Copie soumise pour publication - en attente d'approbation"
 
 #: plone/app/theming/browser/mapper.pt:1082
 msgid "Copy to clipboard"
@@ -1243,7 +1243,7 @@ msgstr "Copier vers dossier"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/copy.py:47
 msgid "Copy to folder ${folder}."
-msgstr "Copié dans le dossier ${folder}"
+msgstr "Copier dans le dossier ${folder}"
 
 #: CMFPlone/skins/plone_deprecated/prefs_group_edit.py:28
 #: plone.app.controlpanel/plone/app/controlpanel/usergroups.py:473
@@ -1306,7 +1306,7 @@ msgstr "Critère sur l'auteur actuel"
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:434
 msgid "Current User"
-msgstr "Utilisateur logué"
+msgstr "Utilisateur actuel"
 
 #: CMFPlone/browser/templates/plone-upgrade.pt:93
 msgid "Current active configuration"
@@ -1408,10 +1408,10 @@ msgid ""
 "enabled by default unless explicitly turned off here or by the relevant "
 "installer."
 msgstr ""
-"Défini les types qui pourront être recherchés dans le formulaire de "
-"recherche avancée. Notez que si des nouveaux types de contenu sont "
-"installés, ils sont activés par défaut jusqu'à ce qu'ils soient "
-"explicitement désactivés ici ou par un script d'installation adéquat."
+"Types qui pourront être recherchés dans le formulaire de recherche avancée. "
+"Notez que si des nouveaux types de contenu sont installés, ils sont activés "
+"par défaut jusqu'à ce qu'ils soient explicitement désactivés ici ou par un "
+"script d'installation adéquat."
 
 #: plone.app.controlpanel/plone/app/controlpanel/search.py:41
 msgid "Define the types to be shown in the site and searched"
@@ -1867,7 +1867,7 @@ msgid ""
 "mail actions or enter an email in the portal properties"
 msgstr ""
 "Erreur lors de l'envoi d'un email par la règle de contenu. Vous devez "
-"indiquer une adresse d'émetteur pour l'action 'email' ou indiquer l'email "
+"indiquer une adresse d'émetteur pour l'action « email » ou indiquer l'email "
 "par défaut dans les propriétés du site."
 
 #. Default: "Errors"
@@ -2166,7 +2166,7 @@ msgid ""
 "rule selectors."
 msgstr ""
 "Masquer le mockup HTML et les panneaux du contenu. Les utiliser pour trouver "
-"et vérifier les selecteurs de règle."
+"et vérifier les sélecteurs de règles."
 
 #. Default: "History"
 #: CMFPlone/profiles/default/types/Document.xml
@@ -2294,7 +2294,7 @@ msgid ""
 msgstr ""
 "Si activé, le formulaire contient un champ pour rechercher seulement dans le "
 "titre. Notez que le formulaire contient déjà un champ pour rechercher dans "
-"tout le texte"
+"tout le texte."
 
 #: plone.app.controlpanel/plone/app/controlpanel/search.py:110
 msgid ""
@@ -2303,7 +2303,7 @@ msgid ""
 "the user clicks on the label of the search option, the option is expanded."
 msgstr ""
 "Si activé, les options de recherche rarement utilisées, comme par exemple "
-"pour l'état du workflow, sont réduites par défaut et seul le libellé de "
+"pour l'état du processus, sont réduites par défaut et seul le libellé de "
 "l'option de recherche est visible. Si l'utilisateur clique sur le libellé de "
 "l'option de recherche, l'option est développée."
 
@@ -2736,7 +2736,7 @@ msgid ""
 "caps lock is not enabled."
 msgstr ""
 "L'identification a échoué. Le courriel et le mot de passe sont sensibles aux "
-"majuscules et minuscules, désactivez le verrouillage des majuscules de votre "
+"majuscules et minuscules. Désactivez le verrouillage des majuscules de votre "
 "clavier le cas échéant."
 
 #: CMFPlone/skins/plone_login/logged_in.cpy:28
@@ -2746,7 +2746,7 @@ msgid ""
 "caps lock is not enabled."
 msgstr ""
 "L'identification a échoué. Le nom et le mot de passe sont sensibles aux "
-"majuscules et minuscules, désactivez le verrouillage des majuscules de votre "
+"majuscules et minuscules. Désactivez le verrouillage des majuscules de votre "
 "clavier le cas échéant."
 
 #: CMFPlone/skins/plone_login/login_form_validate.vpy:68
@@ -3005,7 +3005,7 @@ msgid ""
 "Move the content to the pending state where it will be reviewed by an editor "
 "by publication."
 msgstr ""
-"Déplace le contenu dans l'état en attente d'approbation où il sera reviewé "
+"Déplace le contenu dans l'état en attente d'approbation où il sera révisé "
 "par un rédacteur pour publication."
 
 #: plone.app.contentrules/plone/app/contentrules/actions/configure.zcml
@@ -3096,7 +3096,7 @@ msgstr "Nouveau thème"
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
 msgid "New version created but not ready for publication"
-msgstr "Nouvelle version créée mais non prêt pour publication"
+msgstr "Nouvelle version créée mais non prête pour publication"
 
 #. Default: "New..."
 #: type action defined on Smart Folder TempFolder
@@ -3546,7 +3546,7 @@ msgid ""
 msgstr ""
 "Plone génère les courriels en utilisant cette adresse comme adresse de "
 "réponse. Elle est aussi utilisée comme adresse de destination pour le "
-"formulaire de contact et la fonctionnalité 'Envoyer un courriel de test'."
+"formulaire de contact et la fonctionnalité « Envoyer un courriel de test »."
 
 #: plone.app.controlpanel/plone/app/controlpanel/mail.py:72
 msgid ""
@@ -3695,7 +3695,7 @@ msgstr "Passe votre élément privé en brouillon interne."
 #: CMFPlone/profiles/default/workflows/intranet_folder_workflow/definition.xml
 #: CMFPlone/profiles/default/workflows/intranet_workflow/definition.xml
 msgid "Provides access to workflow history"
-msgstr "Fournit l'accés à l'historique du processus du publication"
+msgstr "Fournit l'accès à l'historique du processus du publication"
 
 #. Default: "Public Draft"
 #: workflow state defined in folder_workflow - id visible plone_workflow
@@ -4190,7 +4190,7 @@ msgstr "Envoyer courriel"
 #. Default: "Send this page to somebody"
 #: action defined in portal_actions
 msgid "Send this page to somebody"
-msgstr "Envoyer cette page par courier électronique"
+msgstr "Envoyer cette page par courrier électronique"
 
 #. Default: "Sending the item back will return the item to the original author instead of publishing it. You should preferably include a reason for why it was not published."
 #: CMFPlone/profiles/default/workflows/intranet_workflow/definition.xml
@@ -4201,7 +4201,7 @@ msgid ""
 "publishing it. You should preferably include a reason for why it was not "
 "published."
 msgstr ""
-"Renvoyer cet éléments à l'auteur au lieu de le publier. Il est préférable "
+"Renvoyer cet élément à l'auteur au lieu de le publier. Il est préférable "
 "d'ajouter la raison du rejet de la publication."
 
 #: CMFPlone/interfaces/syndication.py:182
@@ -4431,11 +4431,11 @@ msgstr "Trier les résultats de la recherche selon le critère choisi"
 
 #: plone.app.collection/plone/app/collection/collection.py:44
 msgid "Sort the collection on this index"
-msgstr "Trié la collection sur cet index"
+msgstr "Trier la collection sur cet index"
 
 #: plone.app.collection/plone/app/collection/collection.py:56
 msgid "Sort the results in reversed order"
-msgstr "Trié les résultats dans l'ordre inverse"
+msgstr "Trier les résultats dans l'ordre inverse"
 
 #: CMFPlone/profiles/default/portal_atct.xml
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
@@ -4807,7 +4807,7 @@ msgstr ""
 #: plone.app.portlets/plone/app/portlets/portlets/classic.py:23
 msgid "The macro containing the portlet. Leave blank if there is no macro."
 msgstr ""
-"La macro qui contient la portlet. Laissez vide s'il n'y a pas de macro."
+"La macro qui contient le portlet. Laissez vide s'il n'y a pas de macro."
 
 #: CMFPlone/browser/templates/plone-addsite.pt:73
 msgid "The main language of the site."
@@ -4827,7 +4827,7 @@ msgstr "Nom du groupe."
 
 #: CMFPlone/skins/plone_deprecated/search_form.pt:404
 msgid "The number of results that is displayed on one page."
-msgstr "Le nombre de résultats qui s'affiche sur une seule page."
+msgstr "Le nombre de résultats qui s'affichent sur une seule page."
 
 #: plonetheme.classic/plonetheme/classic/configure.zcml
 msgid "The old theme used in Plone 3 and earlier."
@@ -4841,7 +4841,7 @@ msgstr "L'ordre d'un élément dans son dossier parent"
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 msgid "The person that created an item"
-msgstr "La personne qui a créée l'élément"
+msgstr "La personne qui a créé l'élément"
 
 #. Default: "The roles and users with View permission on an item"
 #: CMFPlone/profiles/default/portal_atct.xml
@@ -5102,8 +5102,8 @@ msgid ""
 "These tags, and their content are completely blocked when a page is saved or "
 "rendered."
 msgstr ""
-"Ces balises ainsi quel leurs contenus sont supprimés lors de "
-"l'enregistrement ou de l'affichage."
+"Ces balises ainsi que leur contenu sont supprimées lors de l'enregistrement "
+"ou de l'affichage."
 
 #: CMFPlone/skins/plone_prefs/prefs_install_products_form.pt:210
 msgid "This add-on has been removed from the file system."
@@ -5171,7 +5171,7 @@ msgstr "Cette règle n'est assignée à aucun dossier."
 #: plone.app.controlpanel/plone/app/controlpanel/site.py:25
 msgid "This shows up in the title bar of browsers and in syndication feeds."
 msgstr ""
-"Ce texte est affiché dans la barre de titre des navigateur et dans les flux "
+"Ce texte est affiché dans la barre de titre des navigateurs et dans les flux "
 "de syndication."
 
 #: CMFPlone/browser/templates/plone-overview.pt:46
@@ -6316,7 +6316,7 @@ msgstr ""
 msgid "description-contentrules-mailsub"
 msgstr ""
 "Certains contenus dans le sujet, source courriel, destinataire du courriel "
-"et le message peut être remplacé par des variables \"$&#123;&#125;\" du "
+"et le message peuvent être remplacés par des variables \"$&#123;&#125;\" du "
 "tableau ci-dessous."
 
 #. Default: "Access keys are a navigation device enabling you to get around this web site using your keyboard."
@@ -6414,7 +6414,7 @@ msgid "description_cancel"
 msgstr ""
 "Annuler le brouillon supprimera cette copie de travail et les modifications "
 "en cours seront perdues. La version en cours de ce contenu deviendra "
-"déverrouillé."
+"déverrouillée."
 
 #. Default: "Before you start exploring, you need to change your original password. This ensures that the password you received via email cannot be used in a malicious manner."
 #: CMFPlone/skins/plone_login/login_password.cpt:31
@@ -7264,7 +7264,7 @@ msgstr "Où ?"
 #: plone.app.controlpanel/plone/app/controlpanel/usergroups.py:386
 msgid "failed_passwords_msg"
 msgstr ""
-"Une ré-initialisation de mot de passe n'a pu être envoyé aux utilisateurs "
+"Une ré-initialisation de mot de passe n'a pu être envoyée aux utilisateurs "
 "suivants : ${user_ids}"
 
 #: plone.app.querystring/plone/app/querystring/results.pt:63
@@ -7860,7 +7860,8 @@ msgid "help_absolute_prefix"
 msgstr ""
 "Si votre thème utilise des chemins relatifs pour les images, feuilles de "
 "style ou autre ressources, vous pouvez saisir un préfixe pour vous assurer "
-"que ces ressources seront accessible quel que soit la page venant de Plone."
+"que ces ressources seront accessibles quelle que soit la page venant de "
+"Plone."
 
 #. Default: "Select the restriction policy in this location."
 #: CMFPlone/skins/plone_forms/folder_constraintypes_form.cpt:77
@@ -8123,7 +8124,7 @@ msgstr ""
 #: plone/app/theming/browser/controlpanel.pt:521
 msgid "help_ext_links_open_new_window"
 msgstr ""
-"Si l'option est activé, tous les liens externes dans la zone de contenu "
+"Si l'option est activée, tous les liens externes dans la zone de contenu "
 "seront ouverts dans une nouvelle fenêtre"
 
 #. Default: "If you are unsure of which format to use, just select Plain Text and type the document as you usually do."
@@ -8132,7 +8133,7 @@ msgstr ""
 msgid "help_format_wysiwyg"
 msgstr ""
 "Si vous ne savez pas quel format utiliser, sélectionnez « Texte simple » et "
-"entrez votre texte comme vous l'habitude de le faire."
+"entrez votre texte comme vous avez l'habitude de le faire."
 
 #. Default: "Enter full name, e.g. John Smith."
 #: plone.app.users/plone/app/users/userdataschema.py:46
@@ -8260,8 +8261,8 @@ msgstr ""
 #: CMFPlone/skins/plone_deprecated/personalize_form.cpt:324
 msgid "help_look"
 msgstr ""
-"Vous pouvez choisir ici l'apparence par défaut du site, parmis les "
-"différents styles disponibles."
+"Vous pouvez choisir ici l'apparence par défaut du site, parmi les différents "
+"styles disponibles."
 
 #. Default: "If enabled all external links will be marked with link type specific icons."
 #: plone/app/theming/browser/controlpanel.pt:506
@@ -8773,10 +8774,10 @@ msgstr "Noms d'hôte à ne pas thémer"
 msgid "hostname_blacklist_description"
 msgstr ""
 "S'il y a des noms d'hôte que vous souhaitez voir non thémés, vous pouvez les "
-"lister ici. C'est utile durant le développement de thème, pour comparer la "
-"version thémé et non thémé du site. Dans certains cas, vous pouvez vouloir "
-"garder une version non thémé du site pour que les administrateurs puissent "
-"utiliser une version \"de base\" de Plone."
+"lister ici. Cela est utile durant le développement de thème, pour comparer "
+"la version thémée et non thémée du site. Dans certains cas, vous pouvez "
+"vouloir garder une version non thémée du site pour que les administrateurs "
+"puissent utiliser une version \"de base\" de Plone."
 
 #. Default: "HTML"
 #: Archetypes/skins/archetypes/wysiwyg_support.pt:40
@@ -8820,7 +8821,7 @@ msgstr "n'est pas une url valide."
 
 #: validation/validators/BaseValidators.py:28
 msgid "is not a valid us phone number."
-msgstr "n'est pas un numéro de téléphone états-uniens valide."
+msgstr "n'est pas un numéro de téléphone états-unien valide."
 
 #: validation/validators/BaseValidators.py:34
 msgid "is not a valid zip code."
@@ -10185,7 +10186,7 @@ msgstr "Pas de processus documentaire"
 #. Default: "Generate tabs for items other than folders."
 #: CMFPlone/skins/plone_deprecated/prefs_navigation_form.cpt:85
 msgid "label_nonfolderish_tabs_tabs_enable"
-msgstr "Générer les onglets à partir des éléments autre que les dossiers."
+msgstr "Générer les onglets à partir des éléments autres que les dossiers."
 
 #. Default: "Number of exceptions to keep"
 #: CMFPlone/skins/plone_prefs/prefs_error_log_form.pt:137
@@ -11186,7 +11187,7 @@ msgstr "L'élément n'est pas accessible"
 #: plone.app.linkintegrity/plone/app/linkintegrity/browser/update.py:18
 msgid "linkintegrity_update_info"
 msgstr ""
-"L'information d'intérité des liens a été mise à jour pour ${count} élément"
+"L'information d'intégrité des liens a été mise à jour pour ${count} élément"
 "(s)."
 
 #. Default: "Clicking the below button will cause link integrity information to be updated. This might take a while, especially for bigger sites..."
@@ -11477,7 +11478,7 @@ msgstr "Filtrer les résultats"
 #: plone/app/theming/interfaces.py:108
 msgid "network_urls_allowed"
 msgstr ""
-"Si activé, les urls (http, https) seront authorisées dans le fichier de "
+"Si activé, les urls (http, https) seront autorisées dans le fichier de "
 "règles et cette configuration."
 
 #. Default: "This item does not have any body text, click the edit tab to change it."
@@ -11971,8 +11972,8 @@ msgstr "Paramètres d'envoi des courriels"
 #: CMFPlone/skins/plone_content/author.cpt:152
 msgid "text_no_member_email"
 msgstr ""
-"Vous n'avez pas d'adresse courriel, vous n'avons donc pas accès au "
-"formulaire de contact. Veuillez éditer vos préférences personnelles."
+"Vous n'avez pas d'adresse courriel, vous n'avez donc pas accès au formulaire "
+"de contact. Veuillez éditer vos préférences personnelles."
 
 #. Default: "No items have been published."
 #: CMFPlone/skins/plone_templates/recently_published.pt:84
@@ -12063,7 +12064,7 @@ msgstr ""
 "\n"
 "Ceci est un message de test envoyé depuis le panneau de configuration "
 "\"Envoi de courriels\" de Plone. La réception de ce message (à l'adresse "
-"indiquée sur le champ \"Expéditeur\") inique que votre serveur email "
+"indiquée sur le champ \"Expéditeur\") indique que votre serveur email "
 "fonctionne!\n"
 "\n"
 "Cordialement,\n"
@@ -12099,7 +12100,7 @@ msgstr "Créer une copie de ${theme_name}"
 #. Default: "Are you sure you want to delete ${theme_name}"
 #: plone/app/theming/browser/controlpanel.pt:608
 msgid "theming_controlpanel_delete_confirm"
-msgstr "Êtes vous certain de vouloir supprimer ${theme_name}"
+msgstr "Êtes-vous certain de vouloir supprimer ${theme_name}"
 
 #. Default: "This operation cannot be undone. Note that filesystem themes cannot be deleted from within Plone."
 #: plone/app/theming/browser/controlpanel.pt:611
@@ -12681,7 +12682,7 @@ msgstr "Politique de versionnement :"
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 "Affecter un nouveau processus à un type de contenu peut prendre beaucoup de "
-"temps, et va ralentir significativement le site durant cette opération."
+"temps et va ralentir significativement le site durant cette opération."
 
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99


### PR DESCRIPTION
Hi Folks.  I have some spare time and decided to browse through the plone.po file (5.0 branch) looking for typos or other obvious mistakes.  I have just done that and some cleanup.  I have refrained from doing any substantial modifications, as I understand this is not my work and I have limited knowledge of both Plone and its community.  I am pasting below (in French) some of my observations on the translation as a whole.  I'd be willing to iron things out e.g. at a sprint (upcoming Plone Midwest ?).

Chaînes non touchées / commentaires généraux

Absolute prefix : Selon http://docs.diazo.org/en/latest/compiler.html c'est une chaîne de caractères arbitraire qui préfixe un chemin relatif, donc la traduction "Préfixe chemin absolu" semble au moins dans ce cas inadéquate.  Pourquoi pas simplement "Préfixe" ?

log = action de journalisation ?

email : courriel ou "adresse électronique" selon le contexte; la traduction française est inconsistante : parfois "mail", parfois "email", parfois "adresse courriel".

Éditer/modifier : utilisation inconsistante dans la traduction.  Selon l'OQLF, éditer de même que les mots de la même famille (édition, etc.) sont maintenant acceptés en français. (http://www.granddictionnaire.com/ficheOqlf.aspx?Id_Fiche=2074861)

login : http://www.granddictionnaire.com/ficheOqlf.aspx?Id_Fiche=8382074 : nom d'utilisateur

Do not send the email to the user that did the action -> N'envoie pas de courriel à l'utilisateur qui a fait l'action.  Faudrait voir le contexte.

mockup ??

icône : http://www.granddictionnaire.com/ficheOqlf.aspx?Id_Fiche=2077238 dit que c'est un nom féminin et que c'est "le choix des grands concepteurs qui ont opté pour la graphie avec l'accent circonflexe sur le o et le genre féminin" ; genre = masculin

url  :http://www.granddictionnaire.com/ficheOqlf.aspx?Id_Fiche=26515499

si fourni, si activé; je crois que c'est la forme adjectivale (donc on doit faire l'accord) qui doit primer; sinon rephraser, p. ex. "Si l'option est activée" plutôt que "si activé".  exemple patent : "Si fourni, l'entête et le pied seront des hyperliens vers cette URL."

"Un champ obligatoire n'a pas été renseigné." pour "Input is required but not given." rempli ?

Inconsistance dans l'emploi du nombre;  Ex "Le (ou les) élément(s) a (ont) été collé(s)." Parfois "élément(s) ont été collé(s)"

Inconsistance dans l'accentuation des premières lettres; ex "États des événements à afficher." et "Edition ..."

inconsistance "Aucunes modifications effectuées." vs "Aucune image trouvée dans la collection."

"Plugins en dépendances de ce plugin" plugins qui dépendent de ...

"Requêter ceci n'est pas possible" ???

"Afficher le rendu du corps" pour "render body" ???  Afficher le contenu principal ?

"Il y a d'autres résultats, proches de votre recherche."  précisez votre recherche

Inconsistance : \" et ' vs «  »
