### PR TITLE
Adding en_GB locale

### DIFF
--- a/plone/app/locales/locales/en_GB/LC_MESSAGES/plonelocales.po
+++ b/plone/app/locales/locales/en_GB/LC_MESSAGES/plonelocales.po
@@ -10,7 +10,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Language-Code: en-gb\n"
-"Language-Name: English\n"
+"Language-Name: English (United Kingdom)\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 


### PR DESCRIPTION
UK uses a different date structure then American English ('day, month' vs
'month, day'), so we added the `en_GB` locale with the dates appropriately
changed.

We noticed that some .po files use `X-Is-Fallback-For`, for instance in the
`pt` locale you have:

```
"X-Is-Fallback-For: pt-ao pt-cv pt-gw pt-mz pt-st pt-pt\n"
```

As far as we tried it out, adding a similar line to the `en` locale didn't
change anything (the translations from `en` are automatically taken if they do
not exist in `en_GB` even if the `X-Is-Fallback-For` directive isn't included).
If it would be appropriate to add it, drop a comment.
