### PR TITLE
Add default value to faulty message id

### DIFF
--- a/plone/app/locales/locales/af/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/af/LC_MESSAGES/plone.po
@@ -4687,6 +4687,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/ar/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/ar/LC_MESSAGES/plone.po
@@ -4663,6 +4663,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/bg/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/bg/LC_MESSAGES/plone.po
@@ -4669,6 +4669,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/bn/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/bn/LC_MESSAGES/plone.po
@@ -4669,6 +4669,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/ca/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/ca/LC_MESSAGES/plone.po
@@ -4675,6 +4675,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/cs/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/cs/LC_MESSAGES/plone.po
@@ -4690,6 +4690,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/cy/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/cy/LC_MESSAGES/plone.po
@@ -4658,6 +4658,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/da/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/da/LC_MESSAGES/plone.po
@@ -4816,6 +4816,7 @@ msgstr "Emnerne blev kopieret"
 msgid "Successfully cut items"
 msgstr "Emnerne blev klippet"
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr "Emnerne blev slettet"

--- a/plone/app/locales/locales/el/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/el/LC_MESSAGES/plone.po
@@ -4662,6 +4662,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/en/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/en/LC_MESSAGES/plone.po
@@ -4530,6 +4530,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/en_AU/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/en_AU/LC_MESSAGES/plone.po
@@ -4531,6 +4531,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/eo/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/eo/LC_MESSAGES/plone.po
@@ -4666,6 +4666,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/es/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/es/LC_MESSAGES/plone.po
@@ -4669,6 +4669,7 @@ msgstr "Elementos copiados con éxito"
 msgid "Successfully cut items"
 msgstr "Elementos cortados con éxito"
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr "Elementos eliminados con éxito"

--- a/plone/app/locales/locales/et/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/et/LC_MESSAGES/plone.po
@@ -4690,6 +4690,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/eu/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/eu/LC_MESSAGES/plone.po
@@ -4668,6 +4668,7 @@ msgstr "Elementuak ongi kopiatu dira"
 msgid "Successfully cut items"
 msgstr "Elementuak ongi ebaki dira"
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr "Elementuak ongi ezabatu dira"

--- a/plone/app/locales/locales/fa/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/fa/LC_MESSAGES/plone.po
@@ -4668,6 +4668,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/fi/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/fi/LC_MESSAGES/plone.po
@@ -4660,6 +4660,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/fr/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/fr/LC_MESSAGES/plone.po
@@ -4675,6 +4675,7 @@ msgstr "Éléments copiés avec succès"
 msgid "Successfully cut items"
 msgstr "Éléments coupés avec succès"
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr "Éléments supprimés avec succès"

--- a/plone/app/locales/locales/fu/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/fu/LC_MESSAGES/plone.po
@@ -4681,6 +4681,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/gl/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/gl/LC_MESSAGES/plone.po
@@ -4665,6 +4665,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/he/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/he/LC_MESSAGES/plone.po
@@ -4667,6 +4667,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/hi/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/hi/LC_MESSAGES/plone.po
@@ -4665,6 +4665,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/hr/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/hr/LC_MESSAGES/plone.po
@@ -4667,6 +4667,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/hu/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/hu/LC_MESSAGES/plone.po
@@ -4675,6 +4675,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/hy/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/hy/LC_MESSAGES/plone.po
@@ -4665,6 +4665,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/id/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/id/LC_MESSAGES/plone.po
@@ -4665,6 +4665,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/it/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/it/LC_MESSAGES/plone.po
@@ -4674,6 +4674,7 @@ msgstr "Elementi copiati con successo"
 msgid "Successfully cut items"
 msgstr "Elementi tagliati con successo"
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr "Elementi eliminati con successo"

--- a/plone/app/locales/locales/ja/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/ja/LC_MESSAGES/plone.po
@@ -4682,6 +4682,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/ka/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/ka/LC_MESSAGES/plone.po
@@ -4658,6 +4658,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/kn/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/kn/LC_MESSAGES/plone.po
@@ -4661,6 +4661,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/ko/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/ko/LC_MESSAGES/plone.po
@@ -4667,6 +4667,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/lt/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/lt/LC_MESSAGES/plone.po
@@ -4675,6 +4675,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/lv/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/lv/LC_MESSAGES/plone.po
@@ -4657,6 +4657,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/mi/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/mi/LC_MESSAGES/plone.po
@@ -4658,6 +4658,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/mk_MK/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/mk_MK/LC_MESSAGES/plone.po
@@ -4664,6 +4664,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/my/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/my/LC_MESSAGES/plone.po
@@ -4667,6 +4667,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/nl/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/nl/LC_MESSAGES/plone.po
@@ -4544,6 +4544,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/nn/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/nn/LC_MESSAGES/plone.po
@@ -4666,6 +4666,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/no/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/no/LC_MESSAGES/plone.po
@@ -4668,6 +4668,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/pl/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/pl/LC_MESSAGES/plone.po
@@ -4679,6 +4679,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/plone.pot
+++ b/plone/app/locales/locales/plone.pot
@@ -4537,6 +4537,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/pt/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/pt/LC_MESSAGES/plone.po
@@ -4669,6 +4669,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/pt_BR/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/pt_BR/LC_MESSAGES/plone.po
@@ -4676,6 +4676,7 @@ msgstr "Itens copiados com sucesso"
 msgid "Successfully cut items"
 msgstr "Itens cortados com sucesso"
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr "Itens deletados com sucesso"

--- a/plone/app/locales/locales/rm/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/rm/LC_MESSAGES/plone.po
@@ -4655,6 +4655,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/ro/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/ro/LC_MESSAGES/plone.po
@@ -4671,6 +4671,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/ru/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/ru/LC_MESSAGES/plone.po
@@ -4672,6 +4672,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/sk/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/sk/LC_MESSAGES/plone.po
@@ -4658,6 +4658,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/sl/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/sl/LC_MESSAGES/plone.po
@@ -4663,6 +4663,7 @@ msgstr "Uspešno prekopirani predmeti"
 msgid "Successfully cut items"
 msgstr "Uspešno izrezani predmeti"
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr "Uspešno zbrisani predmeti"

--- a/plone/app/locales/locales/sm/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/sm/LC_MESSAGES/plone.po
@@ -4658,6 +4658,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/sq/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/sq/LC_MESSAGES/plone.po
@@ -4666,6 +4666,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/sr/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/sr/LC_MESSAGES/plone.po
@@ -4675,6 +4675,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/sr_Latn/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/sr_Latn/LC_MESSAGES/plone.po
@@ -4675,6 +4675,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/sv/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/sv/LC_MESSAGES/plone.po
@@ -4694,6 +4694,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/ta/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/ta/LC_MESSAGES/plone.po
@@ -4667,6 +4667,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/te/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/te/LC_MESSAGES/plone.po
@@ -4669,6 +4669,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/th/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/th/LC_MESSAGES/plone.po
@@ -4654,6 +4654,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/to/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/to/LC_MESSAGES/plone.po
@@ -4658,6 +4658,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/tr/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/tr/LC_MESSAGES/plone.po
@@ -4665,6 +4665,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/uk/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/uk/LC_MESSAGES/plone.po
@@ -4670,6 +4670,7 @@ msgstr "Успішно скопійовані об’єкти"
 msgid "Successfully cut items"
 msgstr "Успішно вирізані об’єкти"
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr "Успішно видалені об’єкти"

--- a/plone/app/locales/locales/vi/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/vi/LC_MESSAGES/plone.po
@@ -4657,6 +4657,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/zh_CN/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/zh_CN/LC_MESSAGES/plone.po
@@ -4669,6 +4669,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/zh_HK/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/zh_HK/LC_MESSAGES/plone.po
@@ -4747,6 +4747,7 @@ msgstr ""
 msgid "Successfully cut items"
 msgstr ""
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr ""

--- a/plone/app/locales/locales/zh_TW/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/zh_TW/LC_MESSAGES/plone.po
@@ -4667,6 +4667,7 @@ msgstr "成功拷貝項目"
 msgid "Successfully cut items"
 msgstr "成功剪下項目"
 
+#. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:46
 msgid "Successfully delete items"
 msgstr "成功刪除項目"


### PR DESCRIPTION
The message id "Successfully delete items" is erroneous; it should read
"Successfully deleted items".

Ideally the message id would be changed.  While this is possible and
probably should be done in the future, this imposes problems, because
the source of that id is another package; we would impose a new version
dependency.

Thus, what we can do immediately, is to apply a default value which will
be used for all languages which lack an own translation, and act as a
hint to translators.