### PR TITLE
Add p.formwidget.namedfile translations to plone i18n

### DIFF
--- a/plone/app/locales/locales/af/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/af/LC_MESSAGES/plone.po
@@ -3596,6 +3596,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6452,10 +6456,18 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr "Daar is nog outydse poortjies hier gedefinieer. Kliek die knoppie om hulle na die nuwe style poortjies op te dateer."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
 msgstr "Lewer kommentaar"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
+msgstr ""
 
 #. Default: "Add new fieldset…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:13
@@ -6465,6 +6477,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6489,6 +6509,10 @@ msgstr "Moet hierdie vouer met al sy inhoud regtig uitgevee word?"
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6626,6 +6650,14 @@ msgstr "Skrap"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
 msgstr "Keur goed"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
+msgstr ""
 
 #. Default: "Cancel"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:101
@@ -6792,6 +6824,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6820,6 +6860,10 @@ msgstr "Verwyder gekose lÃªer"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Verwyder gekose prent"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7372,6 +7416,14 @@ msgstr "Jy is geregistreer as 'n lid."
 msgid "description_you_can_log_on_now"
 msgstr "Kliek die knoppie om dadelik in te teken."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7398,6 +7450,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7467,6 +7523,14 @@ msgstr "${name} word benodig, korrigeer asseblief."
 msgid "error_vocabulary"
 msgstr "Waardes soos ${val} word nie toegelaat vir 'n woordeskat van element ${label} nie"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7485,6 +7549,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8750,8 +8829,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Indien al die volgende voorwaardes geld:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10998,6 +11100,10 @@ msgstr "Terwyl koekie-gebasseerde identiteitstawing afgeskakel is, is koekie-geb
 msgid "login_portlet_disabled"
 msgstr "'Cookie' aanmelding afgeskakel. Aanmeld-poortjie nie beskikbaar nie."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11083,6 +11189,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11108,6 +11262,10 @@ msgstr "Jy moet 'n wagwoord stel of kies om 'n e-pos te stuur."
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11127,6 +11285,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Geen kommentaar."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11152,6 +11344,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "of laai 'n lêer op (bestaande inhoud sal vervang word)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11160,6 +11372,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11179,6 +11395,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11205,6 +11429,10 @@ msgstr "Moenie blok nie"
 msgid "portlets_value_use_parent"
 msgstr "Gebruik behouer se instellings"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11228,6 +11456,34 @@ msgstr "publiseer"
 msgid "published"
 msgstr "gepubliseer"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11239,6 +11495,18 @@ msgstr ""
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Lees verder..."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11258,6 +11526,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Onthou asb. om uit te teken of jou webleser af te sluit as jy klaar is."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11288,6 +11560,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11413,6 +11689,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11663,6 +11963,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Gister"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12026,6 +12330,10 @@ msgstr "Weergawe beleid"
 msgid "types_controlpanel_warn_remap"
 msgstr "Om die werksvloei van 'n tipe te verander sal 'n tydjie duur en terwyl die inhoud opgedateer word kan dit die werf beduidend stadiger maak."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12091,6 +12399,22 @@ msgstr "Taal neutraal (werfstandaard)"
 msgid "warning_contentrules_disabled"
 msgstr "Inhoudsreëls is globaal afgeskakel. Geen toegekende reëls sal uitvoer voordat hulle weer aangeskakel is nie. Gebruik die ${controlpanel_link} om hulle weer te aktiveer."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12100,6 +12424,54 @@ msgstr "Beleid..."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Hierdie item word sedert ${created} deur ${creator} in ${working_copy} gewysig."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/ar/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/ar/LC_MESSAGES/plone.po
@@ -3579,6 +3579,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6428,9 +6432,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr "توجد مداخل قديمة محددة هنا . إضغظ على الزر لتحويلها إلى مداخل ذات أساليب جديدة"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6441,6 +6453,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6465,6 +6485,10 @@ msgstr "هل تريد فعلاً حذف هذا المجلد و كل محتويا
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6602,6 +6626,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6769,6 +6801,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6797,6 +6837,10 @@ msgstr "حذف الملف الحالي"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "احذف الصورة الحالية"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7357,6 +7401,14 @@ msgstr "لقد تم تسجيلك"
 msgid "description_you_can_log_on_now"
 msgstr "إضغظ على الزر لتسجيل دخولك حالأً"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7383,6 +7435,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7453,6 +7509,14 @@ msgstr "${name} مطلوب , المرجو التصحيح"
 msgid "error_vocabulary"
 msgstr "هذه القيمة ${val} غير مسموح بها في عناصر المعجم ${label}"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7471,6 +7535,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8744,8 +8823,31 @@ msgstr "لغة تاشير النص الفائق(HTML)"
 msgid "if_all_conditions_met"
 msgstr "إذا إلتقت كل الشروط الأتية :"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11001,6 +11103,10 @@ msgstr "عندما يكون تصريح الكوكيز معطلا, الدخول �
 msgid "login_portlet_disabled"
 msgstr "استيثاق الكوكيز غير مشغّل .تسجيل دخول المدخل غير متوفر."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11086,6 +11192,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11111,6 +11265,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11130,6 +11288,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "ﻻ تعليقات."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11155,6 +11347,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "أو إرفع ملف (المضمون المتوفر سوف يتم نقله)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11163,6 +11375,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11182,6 +11398,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11208,6 +11432,10 @@ msgstr "لا تغلق"
 msgid "portlets_value_use_parent"
 msgstr "استعمل اعدادات الابوية"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11231,6 +11459,34 @@ msgstr "نشر"
 msgid "published"
 msgstr "منشور"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11243,6 +11499,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "قراءة المزيد..."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11262,6 +11530,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "يرجى تسجيل الخروج أو إغلاق متصفّحك بعد الانتهاء."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11292,6 +11564,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11421,6 +11697,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11672,6 +11972,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "أمس"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12037,6 +12341,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr "تغيير سير العمل لنوع ما سيستغرق مدة معيّنة ,و تجديد المضمون  قد يُبطئ موقع الويب بطريقة ملحوظة "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12102,6 +12410,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr "القواعد غير مُشغّلة كلياً , لن تُنفذ القواعد الغير المخصصة حتى يتم إعادة تشغيلها . إستعمل ${controlpanel_link} ليتم تشغيلها مرة أخرى."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 #, fuzzy
@@ -12112,6 +12436,54 @@ msgstr "الإعداد المحلي للسياسات سير العمل"
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "هذا العنصر محرّر من طرف ${creator} في  ${working_copy} المحرر في ${created}"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/bg/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/bg/LC_MESSAGES/plone.po
@@ -3578,6 +3578,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "Не са намерени изображения в тази колекция."
@@ -6434,9 +6438,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr "Тук има стари портлети. Щракнете бутона за да ги преобразувате в нови."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6447,6 +6459,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6472,6 +6492,10 @@ msgstr "Наистина ли искате да изтриете тази пап
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
 msgstr "по азбучен ред"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
+msgstr ""
 
 #. Default: "<any>"
 #: Archetypes/ArchetypeTool.py:848
@@ -6607,6 +6631,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6774,6 +6806,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr "дата (първо новите)"
@@ -6802,6 +6842,10 @@ msgstr "Изтриване на текущия файл"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Изтриване на текущото изображение"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7352,6 +7396,14 @@ msgstr "Вече сте регистриран потребител."
 msgid "description_you_can_log_on_now"
 msgstr "Щракнете на бутона за влизане."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7378,6 +7430,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7447,6 +7503,14 @@ msgstr "${name} е задължително, моля коригирайте."
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7465,6 +7529,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8727,8 +8806,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Ако всички тези условия са спазени:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10969,6 +11071,10 @@ msgstr "Докато авторизацията чрез бисквитки е �
 msgid "login_portlet_disabled"
 msgstr "Авторизацията чрез бисквитки е забранена. Портлета за вход не е наличен."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11054,6 +11160,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11079,6 +11233,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11098,6 +11256,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Няма коментари."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11123,6 +11315,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "или заредете файл (съществуващото съдържание ще бъде заменено)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11131,6 +11343,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11150,6 +11366,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11176,6 +11400,10 @@ msgstr "Без блокиране"
 msgid "portlets_value_use_parent"
 msgstr "Използване на настройки от горно ниво"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11199,6 +11427,34 @@ msgstr "Публикуване"
 msgid "published"
 msgstr "публикуван"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11210,6 +11466,18 @@ msgstr ""
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Прочетете повече"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11229,6 +11497,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Не забравяйте да излезете или спрете вашия браузър като свършите."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11259,6 +11531,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11384,6 +11660,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11634,6 +11934,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Вчера"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -11997,6 +12301,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12062,6 +12370,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12071,6 +12395,54 @@ msgstr "Локална политика"
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Тази позиция е била редактирана от ${creator} в ${working_copy}, създадено на ${created}."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/bn/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/bn/LC_MESSAGES/plone.po
@@ -3575,6 +3575,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6434,9 +6438,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6447,6 +6459,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6471,6 +6491,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6609,6 +6633,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6776,6 +6808,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6803,6 +6843,10 @@ msgstr ""
 #. Default: "Delete current image"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
 msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
@@ -7359,6 +7403,14 @@ msgstr "আপনি একজন সদ্যস্যহিসাবে রে
 msgid "description_you_can_log_on_now"
 msgstr "আবিলম্বে লগ-ইন হতে বোতাম ক্লিক করুন"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7385,6 +7437,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7454,6 +7510,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7472,6 +7536,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8746,8 +8825,31 @@ msgstr "এইচ টি এম এল"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10999,6 +11101,10 @@ msgstr "কুকি অথেন্টিফিকেশন ডিসেবল 
 msgid "login_portlet_disabled"
 msgstr "কুকি অথেন্টিকেশন ডিসেবলড৤ লগইন পোর্টলেট উপলব্ধ নয়৤"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11084,6 +11190,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11109,6 +11263,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11128,6 +11286,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "নো কমেন্টস"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11153,6 +11345,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11161,6 +11373,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11180,6 +11396,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11206,6 +11430,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11229,6 +11457,34 @@ msgstr "পাবলিশ"
 msgid "published"
 msgstr "পাবলিশড্"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11241,6 +11497,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "পড়ুন আরও"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11260,6 +11528,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "আপনার কাজ শেষ হলে অনুগ্রহ করে আপনার ব্রাউজার থেকে লগ আউট করুন বা এগজিট করুন"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11290,6 +11562,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11416,6 +11692,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11669,6 +11969,10 @@ msgstr "টাইম_সেপারেটর"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "গতকাল"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12031,6 +12335,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12096,6 +12404,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12104,6 +12428,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/ca/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/ca/LC_MESSAGES/plone.po
@@ -3584,6 +3584,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "No s'han trobat imatges en aquesta col·lecció."
@@ -6441,10 +6445,18 @@ msgstr "Prefix de l'adreça URL absoluta"
 msgid "action_convert_legacy_portlets"
 msgstr "Hi han portlets heretats definits aquí. Cliqueu el botó per convertir-los al nou estil de portlets."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
 msgstr "Comenta"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
+msgstr ""
 
 #. Default: "Add new fieldset…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:13
@@ -6454,6 +6466,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6479,6 +6499,10 @@ msgstr "Segur que voleu suprimir aquesta carpeta i tot el seu contingut?"
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
 msgstr "alfabèticament"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
+msgstr ""
 
 #. Default: "<any>"
 #: Archetypes/ArchetypeTool.py:848
@@ -6615,6 +6639,14 @@ msgstr "Esborra"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
 msgstr "Publica"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
+msgstr ""
 
 #. Default: "Cancel"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:101
@@ -6781,6 +6813,14 @@ msgstr "Tema actual"
 msgid "current_theme_description"
 msgstr "Nom del tema actual, p. ex. l'aplicat més recentment"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr "data (més recent primer)"
@@ -6809,6 +6849,10 @@ msgstr "Suprimeix el fitxer actual"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Suprimeix la imatge actual"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7364,6 +7408,14 @@ msgstr "Heu estat registrats com a membre en aquest portal."
 msgid "description_you_can_log_on_now"
 msgstr "Feu clic al botó per a entrar."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7392,6 +7444,10 @@ msgstr "Editar comentari"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
 msgstr "Editar commentari"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
+msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
 #: plone.app.openid/plone/app/openid/skins/ploneopenid/login_form.cpt:156
@@ -7460,6 +7516,14 @@ msgstr "${name} és necessari, si us plau, corregiu-lo."
 msgid "error_vocabulary"
 msgstr "Els valors ${val} no estan permesos pel vocabulari de l'element ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7478,6 +7542,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8744,8 +8823,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Si es compleixen totes les condicions següents:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10992,6 +11094,10 @@ msgstr "Com que l'autenticació per galetes està inhabilitada, l'accés basat e
 msgid "login_portlet_disabled"
 msgstr "L'autenticació mitjançant galetes està inhabilitada. El portlet d'inici de sessió no està disponible."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11089,6 +11195,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11114,6 +11268,10 @@ msgstr "Heu d'establir una contrasenya o optar per enviar un correu electrònic.
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 #, fuzzy
@@ -11134,6 +11292,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "No hi ha comentaris."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11159,6 +11351,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "o mostra un fitxer (el contingut existent es sobreescriurà)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11168,6 +11380,10 @@ msgstr "expressions de paràmetres"
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
 msgstr "Pots definir paràmetres aquí, que es passaran al tema compilat. En el teu fitxer de regles, pots fer una referencia a un paràmetre amb $name. Els paràmetres son definits usant expresions TALES, les quals evaluen a una cadena de text, un numero, un boleà o None. Les variables disponibles són `context`, `request`, `portal`, `portal_state`,  i `context_state`.\""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
+msgstr ""
 
 #. Default: "pending"
 #: workflow state defined in plone_workflow - title Pending
@@ -11186,6 +11402,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11212,6 +11436,10 @@ msgstr "Mostra sempre"
 msgid "portlets_value_use_parent"
 msgstr "Utilitza la configuració del pare"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11235,6 +11463,34 @@ msgstr "publica"
 msgid "published"
 msgstr "publicat"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11246,6 +11502,18 @@ msgstr "Llegir de la xarxa"
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Llegir Més"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11265,6 +11533,10 @@ msgstr "rellevància"
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "No oblidi desconnectar-se o tancar el navegador un cop hagi finalitzat."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11296,6 +11568,10 @@ msgstr "Fitxer de regles"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
 msgstr "Camí al fitxer de regles"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
+msgstr ""
 
 #. Default: "Select Prefix"
 #: plone.app.registry/plone/app/registry/browser/records.pt:62
@@ -11420,6 +11696,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11670,6 +11970,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Ahir"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12033,6 +12337,10 @@ msgstr "Política de les versions:"
 msgid "types_controlpanel_warn_remap"
 msgstr "Canviar el circuit de treball d'un tipus de contingut pot trigar temps, i pot ralentitzar la resposta d'aquest lloc significantment mentre el contingut és actualitzat a la nova configuració."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12098,6 +12406,22 @@ msgstr "Idioma neutre (el predeterminat al lloc)"
 msgid "warning_contentrules_disabled"
 msgstr "Les regles de contingut estan deshabilitades globalment. No s'executarà cap regla fins que es tornin a habilitar. Utilitzeu el ${controlpanel_link} per habilitar-les de nou."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12107,6 +12431,54 @@ msgstr "Política..."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Aquest element està essent editat per ${creator} en ${working_copy} creat el ${created}. "
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/cs/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/cs/LC_MESSAGES/plone.po
@@ -3599,6 +3599,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "Nebyly nalezeny žádné obrázky."
@@ -6455,10 +6459,18 @@ msgstr "Absolutní URL prefix"
 msgid "action_convert_legacy_portlets"
 msgstr "Zde jsou definovány tradiční portlety. Klikněte na tlačítko pro jejich převedení do portletů v novém stylu."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
 msgstr "Přidat komentář"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
+msgstr ""
 
 #. Default: "Add new fieldset…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:13
@@ -6468,6 +6480,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6493,6 +6513,10 @@ msgstr "Opravdu chcete vymazat tuto složku a celý její obsah?"
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
 msgstr "abecedně"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
+msgstr ""
 
 #. Default: "<any>"
 #: Archetypes/ArchetypeTool.py:848
@@ -6629,6 +6653,14 @@ msgstr "Odebrat"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
 msgstr "Schválit"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
+msgstr ""
 
 #. Default: "Cancel"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:101
@@ -6795,6 +6827,14 @@ msgstr "Aktuální vzhled"
 msgid "current_theme_description"
 msgstr "Název aktuálního vzhledu, tj. to, které bylo poslední zvoleno."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr "datum (nejaktuálnější budou první)"
@@ -6823,6 +6863,10 @@ msgstr "Odstranit aktuální soubor"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Odstranit aktuální obrázek"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7374,6 +7418,14 @@ msgstr "Vaše uživatelská registrace proběhla."
 msgid "description_you_can_log_on_now"
 msgstr "Chcete-li se přihlásit ihned, použijte následující tlačítko."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7401,6 +7453,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7470,6 +7526,14 @@ msgstr "Vyplnění pole ${name} je povinné, zadejte požadovaný údaj."
 msgid "error_vocabulary"
 msgstr "Není možné použít hodnotu ${val} jako hodnotu pole ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7488,6 +7552,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8751,9 +8830,32 @@ msgstr "Značkování HTML"
 msgid "if_all_conditions_met"
 msgstr "Pokud jsou splněny následující podmínky:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
 msgstr "počet znaků"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
+msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
 #: plone.app.layout/plone/app/layout/dashboard/dashboard.py:32
@@ -10998,6 +11100,10 @@ msgstr "Přihlašování pomocí souborů cookie není k dispozici, pokud je ov�
 msgid "login_portlet_disabled"
 msgstr "Ověřování soubory cookie je zakázáno. Přihlašovací portlet proto není k dispozici."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11099,6 +11205,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11124,6 +11278,10 @@ msgstr "Musíte nastavit heslo nebo zvolit možnost pro zaslání emailu."
 msgid "msg_text_too_long"
 msgstr "Text je příliš dlouhý. (maximálně ${max} znaků)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 #, fuzzy
@@ -11144,6 +11302,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Nejsou žádné komentáře."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11169,6 +11361,26 @@ msgstr "nebo"
 msgid "or_upload_a_file"
 msgstr "nebo nahrajte soubor (existující obsah jím bude nahrazen)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11178,6 +11390,10 @@ msgstr "Parametry"
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
 msgstr "Zde můžete definovat parametry, které budou předány do vzhledu. Na tyto parametry se lze odkazovat v souboru s pravidly pomocí $nazev. Parametry se definují TALES výrazy. Dostupné proměnné jsou: context, request, portal, portal_state, and context_state. Zadejte jeden parametr na každý řádek: nazev = vyraz."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
+msgstr ""
 
 #. Default: "pending"
 #: workflow state defined in plone_workflow - title Pending
@@ -11196,6 +11412,14 @@ msgstr "plone.app.collection"
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11222,6 +11446,10 @@ msgstr "Zobrazit vždy"
 msgid "portlets_value_use_parent"
 msgstr "Použít nastavení nadřazené složky"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11245,6 +11473,34 @@ msgstr "Zveřejnění"
 msgid "published"
 msgstr "zveřejněno"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11256,6 +11512,18 @@ msgstr "Načítat ze sítě"
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Více..."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11275,6 +11543,10 @@ msgstr "relevance"
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Po ukončení práce se nezapomeňte odhlásit nebo zavřít prohlížeč."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11306,6 +11578,10 @@ msgstr "Soubor s pravidly"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
 msgstr "Cesta k souboru s pravidly"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
+msgstr ""
 
 #. Default: "Select Prefix"
 #: plone.app.registry/plone/app/registry/browser/records.pt:62
@@ -11442,6 +11718,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11692,6 +11992,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Včera"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12055,6 +12359,10 @@ msgstr "Nastavení verzování:"
 msgid "types_controlpanel_warn_remap"
 msgstr "Změna pracovního postupu typu může trvat nějaký čas a může značně zpomalit portál během aktualizace obsahu na parametry nových nastavení."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12120,6 +12428,22 @@ msgstr "Nezávislé na jazyku (výchozí pro portál)"
 msgid "warning_contentrules_disabled"
 msgstr "Pravidla pro obsah jsou vypnuta pro celý portál. Žádná přiřazená pravidla nebudou aplikována, dokud nebudou pravidla pro celý portál znovu zapnuta. Pro jejich zapnutí použijte ${controlpanel_link}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12129,6 +12453,54 @@ msgstr "Zásady..."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Tato položka byla editována uživatelem ${creator} v ${working_copy}. Datum vytvoření ${created}."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/cy/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/cy/LC_MESSAGES/plone.po
@@ -3574,6 +3574,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6424,9 +6428,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6437,6 +6449,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6462,6 +6482,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6602,6 +6626,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6769,6 +6801,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6797,6 +6837,10 @@ msgstr "Dileu'r ffeil bresennol"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Dileu'r ddelwedd bresennol"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7350,6 +7394,14 @@ msgstr "Rydych wedi eich cofrestru."
 msgid "description_you_can_log_on_now"
 msgstr "Cliciwch y botwm i fewngofnodi'n syth."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7376,6 +7428,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7445,6 +7501,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7463,6 +7527,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8739,8 +8818,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11001,6 +11103,10 @@ msgstr "Tra fo dilysu cookie wedi ei anablu, nid yw mewngofnodi ar sail cookie a
 msgid "login_portlet_disabled"
 msgstr "Mae dilysu cookie wedi ei anablu. Nid yw'r porthol mewngofnodi ar gael."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11086,6 +11192,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11111,6 +11265,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11130,6 +11288,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Dim sylwadau."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11155,6 +11347,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "neu lwytho ffeil i fyny (bydd y cynnwys presennol yn cael ei newid)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11163,6 +11375,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11182,6 +11398,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11208,6 +11432,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11231,6 +11459,34 @@ msgstr "cyhoeddi"
 msgid "published"
 msgstr "cyhoeddwyd"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11243,6 +11499,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "Darllen Rhagor"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11262,6 +11530,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Allgofnodwch neu adael eich porwr pan rydych wedi gorffen."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11292,6 +11564,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11420,6 +11696,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11673,6 +11973,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Ddoe"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12035,6 +12339,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12100,6 +12408,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 #, fuzzy
@@ -12109,6 +12433,54 @@ msgstr "Polisi"
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/da/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/da/LC_MESSAGES/plone.po
@@ -3668,6 +3668,10 @@ msgstr "Intet indhold skal migreres."
 msgid "No email address is registered for member: ${member_id}"
 msgstr "${member_id} har ingen registreret email-adresse"
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr "Ingen fil valgt"
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "Ingen billeder blev fundet."
@@ -6614,10 +6618,18 @@ msgstr "Absolut URL præfiks"
 msgid "action_convert_legacy_portlets"
 msgstr "Der er nedarvede portletter defineret her. Klik på knappen for at konvertere dem til new-style portlets."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
 msgstr "Gem"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
+msgstr ""
 
 #. Default: "Add new fieldset…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:13
@@ -6627,6 +6639,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6664,6 +6684,10 @@ msgstr "Er du sikker på, at du ønsker at slette denne mappe og alt indhold i d
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
 msgstr "alfabetisk"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
+msgstr ""
 
 #. Default: "<any>"
 #: Archetypes/ArchetypeTool.py:848
@@ -6839,6 +6863,14 @@ msgstr "Slet"
 msgid "bulkactions_publish"
 msgstr "Godkend"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
+msgstr ""
+
 #. Default: "Cancel"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:101
 msgid "cancel_form_button"
@@ -7004,6 +7036,14 @@ msgstr "Nuværende theme"
 msgid "current_theme_description"
 msgstr "Navnet på det nuværende theme, dvs. det theme, der senest er slået til."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr "dato (nyeste først)"
@@ -7039,6 +7079,10 @@ msgstr "Slet denne fil"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Slet dette billede"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7722,6 +7766,14 @@ msgstr "Du er nu registreret som bruger."
 msgid "description_you_can_log_on_now"
 msgstr "Klik på \"Log ind\" for at logge ind med det samme."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7749,6 +7801,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7824,6 +7880,14 @@ msgstr "${name} mangler, ret venligst"
 msgid "error_vocabulary"
 msgstr "Værdien ${val} er ikke tilladt"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7843,6 +7907,21 @@ msgstr ""
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
 msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr "Behold nuværende fil"
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr "Fjern nuværende fil"
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
+msgstr "Erstat med ny fil"
 
 #: CMFPlone/browser/templates/search.pt:283
 #: plone.app.querystring/plone/app/querystring/results.pt:71
@@ -9400,9 +9479,32 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Hvis alle af de følgende betingelser er opfyldt"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr "Behold nuværende billede"
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr "Fjern nuværende billede"
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr "Erstat med nyt billede"
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
 msgstr "i tegn"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
+msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
 #: plone.app.layout/plone/app/layout/dashboard/dashboard.py:32
@@ -12161,6 +12263,10 @@ msgstr "Når cookie verificering er slået fra, er det ikke muligt at cookie-bas
 msgid "login_portlet_disabled"
 msgstr "Cookie verificering er slået fra. Login portlet ikke tilgængelig."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -12257,6 +12363,54 @@ msgstr "migrér plones standard-indholdstyper til Dexterity."
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr "afsnittet om migrering i dokumentationen til plone.app.contenttypes"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -12282,6 +12436,10 @@ msgstr "Du skal vælge et kodeord eller vælge at sende en email."
 msgid "msg_text_too_long"
 msgstr "Teksten er for lang. (Maks. ${max} tegn.)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -12304,6 +12462,40 @@ msgstr "nej"
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Ingen kommentarer."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr "Ingen fil"
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr "Intet billede"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -12329,6 +12521,26 @@ msgstr "eller"
 msgid "or_upload_a_file"
 msgstr "eller upload en fil (eksisterende indhold vil blive erstattet)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -12338,6 +12550,10 @@ msgstr "Parameter-udtryk"
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
 msgstr "Her kan du indtaste parametre, der vil blive sendt til det kompilerede theme. I din regel-fil kan du referere til disse parametre med $navn. Parametrene skrives som TALES-udtryk, og skal evaluere til en basal python type string, number, boolean eller None. Følgende variable er tilgængelige `context`, `request`, `portal`, `portal_state` og `context_state`."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
+msgstr ""
 
 #. Default: "pending"
 #. defined in plone_workflow, title: Pending
@@ -12362,6 +12578,14 @@ msgstr "plone.app.collection"
 msgid "plone.app.iterate: Test fixture"
 msgstr "plone.app.iterate: Test fixture"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
+msgstr ""
+
 #: plone.protect/plone/protect/configure.zcml:31
 msgid "plone.protect configuration"
 msgstr "plone.protect configuration"
@@ -12385,6 +12609,10 @@ msgstr "Vis altid"
 #: plone.app.portlets/plone/app/portlets/browser/templates/edit-manager-contextual.pt:78
 msgid "portlets_value_use_parent"
 msgstr "Brug indstillinger fra ovenstående"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
 
 #. Default: "private"
 #. defined in plone_workflow, title: Private
@@ -12416,6 +12644,34 @@ msgstr "publicer"
 msgid "published"
 msgstr "Publiceret"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -12427,6 +12683,18 @@ msgstr "Tillad netværksadgang"
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Læs mere"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #. <div i18n:translate="registered_disabled" tal:condition="python: not auth">
@@ -12454,6 +12722,10 @@ msgstr "Relevans"
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Husk at logge ud efter brug."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -12488,6 +12760,10 @@ msgstr "Regel-fil"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
 msgstr "Sti til regel-filen"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
+msgstr ""
 
 #. Default: "Select Prefix"
 #: plone.app.registry/plone/app/registry/browser/records.pt:62
@@ -12643,6 +12919,30 @@ msgstr "Tilføj tags"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
 msgstr "Fjern tags"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
+msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
 msgid "test wc workflow"
@@ -12938,6 +13238,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "I går"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. <a href="#" i18n:attributes="title title_actions_menu;" i18n:translate="label_actions_menu" tal:attributes="href string:${parent_folder/absolute_url}/folder_contents;" title="Actions">
 #. Default: "Actions for the current content item"
@@ -13318,6 +13622,10 @@ msgstr "Versioneringspolitik"
 msgid "types_controlpanel_warn_remap"
 msgstr "At ændre arbejdsgange for en indholdstype kan tage et stykke tid, og kan medføre at Plone kører væsentligt langsommere imens."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -13385,6 +13693,22 @@ msgstr "Sprogneutralt (standard)"
 msgid "warning_contentrules_disabled"
 msgstr "Regler for indhold bliver slået fra globalt. Ingen tildelte regler vil blive udført før de er slået til igen. Brug ${controlpanel_link} for at slå dem til igen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -13394,6 +13718,54 @@ msgstr "Regler"
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Dette indholdsobjekt bliver redigeret af ${creator} i ${working_copy} oprettet ${created}."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/de/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/plone.po
@@ -3587,6 +3587,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr "Keine Datei angegeben"
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "Keine Bilder in dieser Kollektion gefunden."
@@ -6443,6 +6447,7 @@ msgstr "Absoluter URL Prefix"
 msgid "action_convert_legacy_portlets"
 msgstr "Hier werden veraltete Portlets definiert. Klicken Sie auf die Schaltfläche »Portlets konvertieren«, um Portlets im neuen Stil zu erzeugen."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
 msgid "add"
 msgstr "Hinzufügen"
 
@@ -6451,6 +6456,7 @@ msgstr "Hinzufügen"
 msgid "add_comment_button"
 msgstr "Kommentieren"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
 msgid "add_date"
 msgstr "Termin hinzufügen"
 
@@ -6464,9 +6470,11 @@ msgstr ""
 msgid "add_new_field_hellip"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
 msgid "add_rules"
 msgstr "Hinzufügen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
 msgid "additional_date"
 msgstr "Weitere Termine"
 
@@ -6494,6 +6502,7 @@ msgstr "Möchten Sie wirklich diesen Ordner und seinen Inhalt löschen?"
 msgid "alphabetically"
 msgstr "alphabetisch"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
 msgid "already_added"
 msgstr "Das Datum wurde bereits hinzugefügt"
 
@@ -6633,9 +6642,11 @@ msgstr "Löschen"
 msgid "bulkactions_publish"
 msgstr "Veröffentlichen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
 msgid "bysetpos"
 msgstr "BYSETPOS wird nicht unterstützt"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
 msgid "cancel"
 msgstr "Abbrechen"
 
@@ -6804,9 +6815,11 @@ msgstr "Aktuelles Design"
 msgid "current_theme_description"
 msgstr "Der Name des aktuellen Designs."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
 msgid "daily_interval_1"
 msgstr "Wiederholung :"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
 msgid "daily_interval_2"
 msgstr "Tage"
 
@@ -6839,6 +6852,7 @@ msgstr "Lösche aktuelle Datei"
 msgid "delete_image"
 msgstr "Lösche aktuelles Bild"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
 msgid "delete_rules"
 msgstr "Löschen"
 
@@ -7392,9 +7406,11 @@ msgstr "Sie wurden als Benutzer registriert."
 msgid "description_you_can_log_on_now"
 msgstr "Sie können sich nun anmelden."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
 msgid "display_activate"
 msgstr "Wiederholt sich alle "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
 msgid "display_unactivate"
 msgstr "Keine Wiederholungen"
 
@@ -7427,6 +7443,7 @@ msgstr ""
 msgid "edit_comment_form_title"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
 msgid "edit_rules"
 msgstr "Bearbeiten"
 
@@ -7497,9 +7514,11 @@ msgstr "${name} erfordert eine Eingabe."
 msgid "error_vocabulary"
 msgstr "Der Wert ${val} ist für das Element mit der Bezeichnung ${label} nicht erlaubt."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
 msgid "except"
 msgstr ", ausser für"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
 msgid "exclude"
 msgstr "Ausgenommen"
 
@@ -7522,6 +7541,21 @@ msgstr ""
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
 msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr "Vorhandene Datei behalten"
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr "Vorhandene Datei löschen"
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
+msgstr "Mit neuer Datei ersetzen"
 
 #: CMFPlone/browser/templates/search.pt:283
 #: plone.app.querystring/plone/app/querystring/results.pt:71
@@ -8784,13 +8818,30 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Wenn alle Bedingungen erfüllt sind:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr "Vorhandenes Bild behalten"
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr "Vorhandenes Bild entfernen"
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr "Mit neuem Bild ersetzen"
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
 msgid "include"
 msgstr "Eingeschlossen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
 msgid "including"
 msgstr ", und auch "
 
@@ -11033,6 +11084,7 @@ msgstr "Solange Cookie-Authentifikation ausgeschaltet ist, ist das Cookie-basier
 msgid "login_portlet_disabled"
 msgstr "Cookie-Authentifikation ist ausgeschaltet. Anmelden nicht möglich."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
 msgid "long_date_format"
 msgstr "dddd mmmm dd, yyyy"
 
@@ -11137,36 +11189,51 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
 msgid "monthly_day_of_month_1"
 msgstr "Tag"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
 msgid "monthly_day_of_month_1_human"
 msgstr "am Tag"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
 msgid "monthly_day_of_month_2"
 msgstr "des Monats"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
 msgid "monthly_day_of_month_3"
 msgstr "Monat(e)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
 msgid "monthly_interval_1"
 msgstr "Wiederholt sich alle:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
 msgid "monthly_interval_2"
 msgstr "Monat(e)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
 msgid "monthly_repeat_on"
 msgstr "Wiederholt sich:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
 msgid "monthly_weekday_of_month_1"
 msgstr "Den"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
 msgid "monthly_weekday_of_month_1_human"
 msgstr "am"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
 msgid "monthly_weekday_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
 msgid "monthly_weekday_of_month_3"
 msgstr "im Monat"
 
@@ -11195,6 +11262,7 @@ msgstr "Sie müssen ein Passwort wählen oder eine E-Mail anfordern."
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
 msgid "multiple_day_of_month"
 msgstr "Dieses Widget unterstützt keine mehrfach angelegten Tage in monatlicher oder jährlicher Wiederholung"
 
@@ -11219,21 +11287,37 @@ msgstr ""
 msgid "no_comments"
 msgstr "Keine Kommentare"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
 msgid "no_end_after_n_occurrences"
 msgstr "Error: The \"After N occurrences\"-field must be between 1 and 1000"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
 msgid "no_end_date"
 msgstr "Fehler: Das Terminende ist nicht gesetzt. Bitte geben Sie einen korrekten Wert ein."
 
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr "Keine Datei"
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr "Kein Bild"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
 msgid "no_repeat_every"
 msgstr "Fehler: Der Wert von \"Wiederholt sich alle:\" muss zwischen 1 und 1000 liegen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
 msgid "no_repeat_on"
 msgstr "Fehler: \"Wiederholt sich:\" muss selektiert sein"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
 msgid "no_rule"
 msgstr "Keine RRULE in RRULE Daten"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
 msgid "no_template_match"
 msgstr "No matching recurrence template"
 
@@ -11261,18 +11345,23 @@ msgstr "oder"
 msgid "or_upload_a_file"
 msgstr "oder laden Sie eine Datei hoch (der bestehende Text wird ersetzt)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
 msgid "order_indexes_first"
 msgstr "ersten"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
 msgid "order_indexes_fourth"
 msgstr "vierten"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
 msgid "order_indexes_last"
 msgstr "letzten"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
 msgid "order_indexes_second"
 msgstr "zweiten"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
 msgid "order_indexes_third"
 msgstr "dritten"
 
@@ -11286,6 +11375,7 @@ msgstr "Parameter Ausdrücke"
 msgid "parameter_expressions_description"
 msgstr "Sie können Parameter angeben, die an ihr Design weitergeleitet werden. In ihrer Regeldatei können sie auf mittels $  Prefix auf ihre Parameter referenzieren. Parameter sind TALES Ausdrücke, welche zu einem einfachen Typ oder \"None\" evaluieren sollte. In dem Ausdruck sind \"context\", \"request\", \"portal\", \"portal_state\" und \"context_state\" Verfügbar. Definieren Sie eine Variable pro Zeile in folgendem Format: \"variable = ausdruck\"."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
 msgid "past_end_date"
 msgstr "Fehler: Das Terminende kann nicht vor dem Terminanfang sein."
 
@@ -11306,6 +11396,14 @@ msgstr "plone.app.collection"
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11332,6 +11430,7 @@ msgstr "Immer zeigen"
 msgid "portlets_value_use_parent"
 msgstr "Übernehmen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
 msgid "preview"
 msgstr "Ausgewählte Termine"
 
@@ -11358,24 +11457,31 @@ msgstr "veröffentlichen"
 msgid "published"
 msgstr "veröffentlicht"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
 msgid "range"
 msgstr "Ende der Wiederholung:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
 msgid "range_by_end_date"
 msgstr "Bis "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
 msgid "range_by_end_date_human"
 msgstr "endet am "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
 msgid "range_by_occurrences_1"
 msgstr "Endet nach"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
 msgid "range_by_occurrences_1_human"
 msgstr "endet nach"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
 msgid "range_by_occurrences_2"
 msgstr "Ereigniss(en)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
 msgid "range_no_end"
 msgstr "Niemals"
 
@@ -11391,12 +11497,15 @@ msgstr "Vom Netzwerk lesen"
 msgid "read_more"
 msgstr "Mehr…"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
 msgid "recurrence_start"
 msgstr "Beginn der Wiederholung"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
 msgid "recurrence_type"
 msgstr "Wiederholt sich:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
 msgid "refresh"
 msgstr "Aktualisieren"
 
@@ -11419,6 +11528,7 @@ msgstr "Relevanz"
 msgid "remember_to_log_out"
 msgstr "Vergessen Sie nicht, sich wieder abzumelden oder Ihren Browser zu schließen, wenn Sie fertig sind."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
 msgid "remove"
 msgstr "Entfernen"
 
@@ -11453,6 +11563,7 @@ msgstr "Regeldatei"
 msgid "rules_file_path"
 msgstr "Dateipfad zur Regeldatei"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
 msgid "save"
 msgstr "Speichern"
 
@@ -11588,21 +11699,27 @@ msgstr "Hinzuzufügende Stichwörter"
 msgid "tags_to_remove"
 msgstr "Zu entfernende Stichwörter"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
 msgid "template_daily"
 msgstr "Täglich"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
 msgid "template_mondayfriday"
 msgstr "Montags und Freitags"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
 msgid "template_monthly"
 msgstr "Monatlich"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
 msgid "template_weekdays"
 msgstr "Wochentags"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
 msgid "template_weekly"
 msgstr "Wöchentlich"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
 msgid "template_yearly"
 msgstr "Jährlich"
 
@@ -11855,6 +11972,7 @@ msgstr ":"
 msgid "time_yesterday"
 msgstr "Gestern"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
 msgid "title"
 msgstr "Wiederholung"
 
@@ -12220,6 +12338,7 @@ msgstr "Versionierungsrichtlinie"
 msgid "types_controlpanel_warn_remap"
 msgstr "Das Ändern des Arbeitsablaufs eines Artikeltypen kann einige Zeit dauern und Ihre Website in dieser Zeit deutlich verlangsamen."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
 msgid "unsupported_features"
 msgstr "Warning: This event uses recurrence features not supported by this widget. Saving the recurrence may change the recurrence in unintended ways: "
 
@@ -12288,15 +12407,19 @@ msgstr "Sprachneutral (Standardeinstellung)"
 msgid "warning_contentrules_disabled"
 msgstr "Regeln sind global abgeschaltet. Keine der zugewiesenen Regeln werden ausgeführt. Benutzen Sie die ${controlpanel_link} um die Regeln wieder zu aktivieren."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
 msgid "weekly_interval_1"
 msgstr "Wiederholt sich alle:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
 msgid "weekly_interval_2"
 msgstr "Woche(n)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
 msgid "weekly_weekdays"
 msgstr "Wiederholt sich alle:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
 msgid "weekly_weekdays_human"
 msgstr "am: "
 
@@ -12310,39 +12433,51 @@ msgstr "Richtlinie..."
 msgid "working_copy_info"
 msgstr "Dieser Artikel wird gerade von ${creator} in der am ${created} erzeugten ${working_copy} bearbeitet."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
 msgid "yearly_day_of_month_1"
 msgstr "Jeden"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
 msgid "yearly_day_of_month_1_human"
 msgstr "am"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
 msgid "yearly_day_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
 msgid "yearly_day_of_month_3"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
 msgid "yearly_interval_1"
 msgstr "Wiederholt sich alle:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
 msgid "yearly_interval_2"
 msgstr "Jahr(e)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
 msgid "yearly_repeat_on"
 msgstr "Wiederholt sich:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
 msgid "yearly_weekday_of_month_1"
 msgstr "Den"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
 msgid "yearly_weekday_of_month_1_human"
 msgstr "am"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
 msgid "yearly_weekday_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
 msgid "yearly_weekday_of_month_3"
 msgstr "von"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
 msgid "yearly_weekday_of_month_4"
 msgstr " "
 

--- a/plone/app/locales/locales/el/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/el/LC_MESSAGES/plone.po
@@ -3577,6 +3577,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6428,9 +6432,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6441,6 +6453,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6465,6 +6485,10 @@ msgstr "Θέλετε πραγματικά να διαγράψετε τον φά�
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6602,6 +6626,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6769,6 +6801,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6797,6 +6837,10 @@ msgstr "Διαγραφή τρέχοντος αρχείου"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Διαγραφή τρέχουσας εικόνας"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7349,6 +7393,14 @@ msgstr "Γίνατε μέλος."
 msgid "description_you_can_log_on_now"
 msgstr "Πιέστε το κουμπί για να συνδεθείτε αμέσως."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7375,6 +7427,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7445,6 +7501,14 @@ msgstr "Το ${name} είναι απαραίτητο πεδίο, παρακαλ�
 msgid "error_vocabulary"
 msgstr "Η τιμή ${val} δέν είναι στις επιτρεπόμενες τιμές του πεδίου ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7463,6 +7527,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8737,8 +8816,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11007,6 +11109,10 @@ msgstr "Όταν η πιστοποίηση των cookies είναι απενε�
 msgid "login_portlet_disabled"
 msgstr "Η πιστοποίηση των cookies είναι απενεργοποιημένη. Το πλαίσιο σύνδεσης δεν είναι διαθέσιμο."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11092,6 +11198,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11117,6 +11271,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11136,6 +11294,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Χωρίς σχόλια."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11161,6 +11353,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "ή ανεβάστε ένα αρχείο (το υπάρχον περιεχόμενο θα αντικατασταθεί)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11169,6 +11381,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11188,6 +11404,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11214,6 +11438,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11237,6 +11465,34 @@ msgstr "δημοσίευση"
 msgid "published"
 msgstr "δημοσιευμένο"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11249,6 +11505,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "Διαβάστε περισσότερα..."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11268,6 +11536,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Παρακαλούμε αποσυνδεθείτε ή κλείστε τον φυλλομετρητή σας όταν τελειώσετε."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11298,6 +11570,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11429,6 +11705,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11682,6 +11982,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Χθες"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12046,6 +12350,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12111,6 +12419,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 #, fuzzy
@@ -12120,6 +12444,54 @@ msgstr "Πολιτική"
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/en/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/en/LC_MESSAGES/plone.po
@@ -3497,6 +3497,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6267,6 +6271,7 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
 msgid "add"
 msgstr "Add"
 
@@ -6275,6 +6280,7 @@ msgstr "Add"
 msgid "add_comment_button"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
 msgid "add_date"
 msgstr "Add date"
 
@@ -6288,9 +6294,11 @@ msgstr ""
 msgid "add_new_field_hellip"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
 msgid "add_rules"
 msgstr "Add"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
 msgid "additional_date"
 msgstr "Additional date"
 
@@ -6318,6 +6326,7 @@ msgstr ""
 msgid "alphabetically"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
 msgid "already_added"
 msgstr "This date was already added"
 
@@ -6457,9 +6466,11 @@ msgstr ""
 msgid "bulkactions_publish"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
 msgid "bysetpos"
 msgstr "BYSETPOS is not supported"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
 msgid "cancel"
 msgstr "Cancel"
 
@@ -6628,9 +6639,11 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
 msgid "daily_interval_1"
 msgstr "Repeat every:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
 msgid "daily_interval_2"
 msgstr "days"
 
@@ -6663,6 +6676,7 @@ msgstr ""
 msgid "delete_image"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
 msgid "delete_rules"
 msgstr "Delete"
 
@@ -7214,9 +7228,11 @@ msgstr ""
 msgid "description_you_can_log_on_now"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
 msgid "display_activate"
 msgstr "Repeats every "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
 msgid "display_unactivate"
 msgstr "Does not repeat"
 
@@ -7248,6 +7264,7 @@ msgstr ""
 msgid "edit_comment_form_title"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
 msgid "edit_rules"
 msgstr "Edit"
 
@@ -7318,9 +7335,11 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
 msgid "except"
 msgstr ", except for"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
 msgid "exclude"
 msgstr "Exclude"
 
@@ -7342,6 +7361,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8593,13 +8627,30 @@ msgstr ""
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
 msgid "include"
 msgstr "Include"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
 msgid "including"
 msgstr ", and also "
 
@@ -10835,6 +10886,7 @@ msgstr ""
 msgid "login_portlet_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
 msgid "long_date_format"
 msgstr "dddd mmmm dd, yyyy"
 
@@ -10923,36 +10975,51 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
 msgid "monthly_day_of_month_1"
 msgstr "Day"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
 msgid "monthly_day_of_month_1_human"
 msgstr "on day"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
 msgid "monthly_day_of_month_2"
 msgstr "of the month"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
 msgid "monthly_day_of_month_3"
 msgstr "month(s)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
 msgid "monthly_interval_1"
 msgstr "Repeat every:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
 msgid "monthly_interval_2"
 msgstr "month(s)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
 msgid "monthly_repeat_on"
 msgstr "Repeat on:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
 msgid "monthly_weekday_of_month_1"
 msgstr "The"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
 msgid "monthly_weekday_of_month_1_human"
 msgstr "on the"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
 msgid "monthly_weekday_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
 msgid "monthly_weekday_of_month_3"
 msgstr "of the month"
 
@@ -10981,6 +11048,7 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
 msgid "multiple_day_of_month"
 msgstr "This widget does not support multiple days in monthly or yearly recurrence"
 
@@ -11004,21 +11072,37 @@ msgstr ""
 msgid "no_comments"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
 msgid "no_end_after_n_occurrences"
 msgstr "Error: The \"After N occurrences\"-field must be between 1 and 1000"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
 msgid "no_end_date"
 msgstr "Error: End date is not set. Please set a correct value"
 
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
 msgid "no_repeat_every"
 msgstr "Error: The \"Repeat every\"-field must be between 1 and 1000"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
 msgid "no_repeat_on"
 msgstr "Error: \"Repeat on\"-value must be selected"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
 msgid "no_rule"
 msgstr "No RRULE in RRULE data"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
 msgid "no_template_match"
 msgstr "No matching recurrence template"
 
@@ -11046,18 +11130,23 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
 msgid "order_indexes_first"
 msgstr "first"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
 msgid "order_indexes_fourth"
 msgstr "fourth"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
 msgid "order_indexes_last"
 msgstr "last"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
 msgid "order_indexes_second"
 msgstr "second"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
 msgid "order_indexes_third"
 msgstr "third"
 
@@ -11071,6 +11160,7 @@ msgstr ""
 msgid "parameter_expressions_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
 msgid "past_end_date"
 msgstr "Error: End date cannot be before start date"
 
@@ -11091,6 +11181,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11117,6 +11215,7 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
 msgid "preview"
 msgstr "Selected dates"
 
@@ -11143,24 +11242,31 @@ msgstr ""
 msgid "published"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
 msgid "range"
 msgstr "End recurrence:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
 msgid "range_by_end_date"
 msgstr "Until "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
 msgid "range_by_end_date_human"
 msgstr "ends on "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
 msgid "range_by_occurrences_1"
 msgstr "Ending after"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
 msgid "range_by_occurrences_1_human"
 msgstr "ends after"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
 msgid "range_by_occurrences_2"
 msgstr "occurrence(s)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
 msgid "range_no_end"
 msgstr "Never"
 
@@ -11176,12 +11282,15 @@ msgstr ""
 msgid "read_more"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
 msgid "recurrence_start"
 msgstr "Start of the recurrence"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
 msgid "recurrence_type"
 msgstr "Repeats:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
 msgid "refresh"
 msgstr "Refresh"
 
@@ -11204,6 +11313,7 @@ msgstr ""
 msgid "remember_to_log_out"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
 msgid "remove"
 msgstr "Remove"
 
@@ -11238,6 +11348,7 @@ msgstr ""
 msgid "rules_file_path"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
 msgid "save"
 msgstr "Save"
 
@@ -11366,21 +11477,27 @@ msgstr ""
 msgid "tags_to_remove"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
 msgid "template_daily"
 msgstr "Daily"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
 msgid "template_mondayfriday"
 msgstr "Monday and Friday"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
 msgid "template_monthly"
 msgstr "Monthly"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
 msgid "template_weekdays"
 msgstr "Weekday"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
 msgid "template_weekly"
 msgstr "Weekly"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
 msgid "template_yearly"
 msgstr "Yearly"
 
@@ -11632,6 +11749,7 @@ msgstr ""
 msgid "time_yesterday"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
 msgid "title"
 msgstr "Repeat"
 
@@ -11995,6 +12113,7 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
 msgid "unsupported_features"
 msgstr "Warning: This event uses recurrence features not supported by this widget. Saving the recurrence may change the recurrence in unintended ways: "
 
@@ -12063,15 +12182,19 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
 msgid "weekly_interval_1"
 msgstr "Repeat every:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
 msgid "weekly_interval_2"
 msgstr "week(s)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
 msgid "weekly_weekdays"
 msgstr "Repeat on:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
 msgid "weekly_weekdays_human"
 msgstr "on: "
 
@@ -12085,39 +12208,51 @@ msgstr ""
 msgid "working_copy_info"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
 msgid "yearly_day_of_month_1"
 msgstr "Every"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
 msgid "yearly_day_of_month_1_human"
 msgstr "on"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
 msgid "yearly_day_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
 msgid "yearly_day_of_month_3"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
 msgid "yearly_interval_1"
 msgstr "Repeat every:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
 msgid "yearly_interval_2"
 msgstr "year(s)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
 msgid "yearly_repeat_on"
 msgstr "Repeat on:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
 msgid "yearly_weekday_of_month_1"
 msgstr "The"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
 msgid "yearly_weekday_of_month_1_human"
 msgstr "on the"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
 msgid "yearly_weekday_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
 msgid "yearly_weekday_of_month_3"
 msgstr "of"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
 msgid "yearly_weekday_of_month_4"
 msgstr " "
 

--- a/plone/app/locales/locales/en_AU/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/en_AU/LC_MESSAGES/plone.po
@@ -3499,6 +3499,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6268,9 +6272,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6281,6 +6293,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6305,6 +6325,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6441,6 +6465,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6608,6 +6640,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6635,6 +6675,10 @@ msgstr ""
 #. Default: "Delete current image"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
 msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
@@ -7186,6 +7230,14 @@ msgstr ""
 msgid "description_you_can_log_on_now"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7212,6 +7264,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7281,6 +7337,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7299,6 +7363,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8550,8 +8629,31 @@ msgstr ""
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10784,6 +10886,10 @@ msgstr ""
 msgid "login_portlet_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -10869,6 +10975,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -10894,6 +11048,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -10912,6 +11070,40 @@ msgstr ""
 #. Default: "No comments."
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
 msgstr ""
 
 #. Default: "Keep existing file"
@@ -10938,6 +11130,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -10946,6 +11158,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -10965,6 +11181,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -10991,6 +11215,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11014,6 +11242,34 @@ msgstr ""
 msgid "published"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11024,6 +11280,18 @@ msgstr ""
 #: CMFPlone/skins/plone_content/folder_summary_view.pt:105
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
 msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
@@ -11043,6 +11311,10 @@ msgstr ""
 #. Default: "Please log out or exit your browser when you're done."
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
 msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
@@ -11074,6 +11346,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11199,6 +11475,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11447,6 +11747,10 @@ msgstr ""
 #. Default: "Yesterday"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
 msgstr ""
 
 #. Default: "Actions for the current content item"
@@ -11809,6 +12113,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -11874,6 +12182,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -11882,6 +12206,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/eo/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/eo/LC_MESSAGES/plone.po
@@ -3575,6 +3575,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6431,9 +6435,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr "Ekzistas ĉi tie malnovstilaj kestetoj. Klaku butonon por konverti ilin al novstilaj kestetoj."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6444,6 +6456,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6468,6 +6488,10 @@ msgstr "Ĉu vi vere volas forpreni tiun dosierujon kaj ĝian enhavon?"
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6604,6 +6628,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6771,6 +6803,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6799,6 +6839,10 @@ msgstr "Forigi la nunan dosieron"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Forigi la nunan bildon."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7351,6 +7395,14 @@ msgstr "Vi membriĝis."
 msgid "description_you_can_log_on_now"
 msgstr "Alklaku la butonon por tuj saluti."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7377,6 +7429,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7446,6 +7502,14 @@ msgstr "${name} necesas, bonvolu korekti."
 msgid "error_vocabulary"
 msgstr "La valoro ${val} ne eblas en vortaro de elemento ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7464,6 +7528,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8727,8 +8806,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Se ĉiuj de la sekvaj kondiĉoj estas plenumitaj:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10975,6 +11077,10 @@ msgstr "Ĉar aŭtentikigado per kuketoj estas maŝaltita, perkuketa saluto ne eb
 msgid "login_portlet_disabled"
 msgstr "Perkuketa aŭtentikigado malebligita. Saluto ne alirebla."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11060,6 +11166,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11085,6 +11239,10 @@ msgstr "Vi devas enskribi pasvorton aŭ elekti sendi retpoŝtmesaĝon."
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11104,6 +11262,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Neniu komento"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11129,6 +11321,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "aŭ alŝutu dosieron (la ekzistanta enhavo estos forigita)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11137,6 +11349,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11156,6 +11372,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11182,6 +11406,10 @@ msgstr "Ne bloki"
 msgid "portlets_value_use_parent"
 msgstr "Uzu la patran agordon"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11205,6 +11433,34 @@ msgstr "publikigu"
 msgid "published"
 msgstr "publikigita"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11216,6 +11472,18 @@ msgstr ""
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Legu pli..."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11235,6 +11503,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Ne forgesu adiaŭi"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11265,6 +11537,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11390,6 +11666,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11640,6 +11940,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Hieraŭ"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12003,6 +12307,10 @@ msgstr "Versia politiko"
 msgid "types_controlpanel_warn_remap"
 msgstr "Ŝanĝi la laborfluon de erotipo daŭras iomete. La retejo povas malrapidiĝi signife dum la enhavo aktualiĝas laŭ la nova agordo."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12068,6 +12376,22 @@ msgstr "Lingve neūtrala (reteja aprioro)"
 msgid "warning_contentrules_disabled"
 msgstr "Reguloj estas ĉie malŝaltitaj. Difinataj reguloj ne havas efikon, ĝis ili estas denove ŝaltitaj. Uzu ${controlpanel_link} por ŝalti ilin denove."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12077,6 +12401,54 @@ msgstr "Politiko..."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Tiu ero estas redaktata de ${creator} en ${working_copy} kreita je ${created}."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/es/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/es/LC_MESSAGES/plone.po
@@ -3578,6 +3578,10 @@ msgstr "No hay contenido a migrar."
 msgid "No email address is registered for member: ${member_id}"
 msgstr "No se ha registrado una dirección de correo para el miembro: ${member_id}"
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr "Archivo no especificado"
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "No se han encontrado imágenes en esta colección."
@@ -6434,10 +6438,18 @@ msgstr "Prefijo de URL absoluto"
 msgid "action_convert_legacy_portlets"
 msgstr "Se han definido aquí portlets heredados. Haga clic en el botón para convertirlos al nuevo estilo de portlets."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
 msgstr "Comentar"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
+msgstr ""
 
 #. Default: "Add new fieldset…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:13
@@ -6447,6 +6459,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6472,6 +6492,10 @@ msgstr "¿Está seguro de que quiere eliminar esta carpeta y todos sus contenido
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
 msgstr "alfabéticamente"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
+msgstr ""
 
 #. Default: "<any>"
 #: Archetypes/ArchetypeTool.py:848
@@ -6608,6 +6632,14 @@ msgstr "Borrar"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
 msgstr "Aprobar"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
+msgstr ""
 
 #. Default: "Cancel"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:101
@@ -6774,6 +6806,14 @@ msgstr "Tema actual"
 msgid "current_theme_description"
 msgstr "El nombre del tema actual, es decir, el aplicado más recientemente."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr "fecha (primero los más nuevos)"
@@ -6802,6 +6842,10 @@ msgstr "Eliminar archivo actual"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Eliminar imagen actual"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7353,6 +7397,14 @@ msgstr "Ha sido registrado como miembro."
 msgid "description_you_can_log_on_now"
 msgstr "Pulse el botón para entrar inmediatamente."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7379,6 +7431,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7448,6 +7504,14 @@ msgstr "${name} requerido, por favor corríjalo."
 msgid "error_vocabulary"
 msgstr "Los valores ${val} no están permitidos en el vocabulario del elemento ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7467,6 +7531,21 @@ msgstr ""
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
 msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr "Mantener archivo existente"
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr "Eliminar archivo existente"
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
+msgstr "Reemplazar con un nuevo archivo"
 
 #: CMFPlone/browser/templates/search.pt:283
 #: plone.app.querystring/plone/app/querystring/results.pt:71
@@ -8720,9 +8799,32 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Si todas las siguientes condiciones se cumplen:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr "Mantener imagen existente"
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr "Eliminar imagen existente"
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr "Reemplazar con una nueva imagen"
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
 msgstr "en caracteres"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
+msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
 #: plone.app.layout/plone/app/layout/dashboard/dashboard.py:32
@@ -10961,6 +11063,10 @@ msgstr "Debido a que la autenticación basada en cookie esté deshabilitada, el 
 msgid "login_portlet_disabled"
 msgstr "Autenticación mediante cookies deshabilitada. El portlet de inicio de sesión no está disponible."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11062,6 +11168,54 @@ msgstr "migrar los tipos de contenido por defecto a Dexterity."
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr "la sección de migración en la documentación de plone.app.contenttypes"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11087,6 +11241,10 @@ msgstr "Debe establecer una contraseña o elegir que le sea enviado un correo."
 msgid "msg_text_too_long"
 msgstr "El texto es demasiado largo. (Máximo ${max} caracteres.)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11106,6 +11264,40 @@ msgstr "No"
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "No hay comentarios."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr "Ningún archivo"
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr "Ninguna imagen"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11131,6 +11323,26 @@ msgstr "o"
 msgid "or_upload_a_file"
 msgstr "o suba un archivo (el contenido existente será reemplazado)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11140,6 +11352,10 @@ msgstr "Expresiones de parámetro"
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
 msgstr "Puede definir aquí los parámetros que serán pasados al tema compilado. En su archivo de reglas, puede hacer referencia a un parámetro mediante $name. Los parámetros se definen utilizando expresiones TALES, que deben evaluarse como cadena, número, booleano o None. Las variables disponibles son `context`, `request`, `portal`, `portal_state`, y `context_state`."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
+msgstr ""
 
 #. Default: "pending"
 #: workflow state defined in plone_workflow - title Pending
@@ -11158,6 +11374,14 @@ msgstr "plone.app.collection"
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11184,6 +11408,10 @@ msgstr "No bloquear"
 msgid "portlets_value_use_parent"
 msgstr "Utilizar configuración de elemento superior"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11207,6 +11435,34 @@ msgstr "publicar"
 msgid "published"
 msgstr "publicado"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11218,6 +11474,18 @@ msgstr "Leer de la red"
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Leer Más"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11237,6 +11505,10 @@ msgstr "relevancia"
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "No olvide cerrar su sesión o salir de su navegador cuando haya terminado."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11268,6 +11540,10 @@ msgstr "Archivo de reglas"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
 msgstr "Ruta del archivo de reglas"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
+msgstr ""
 
 #. Default: "Select Prefix"
 #: plone.app.registry/plone/app/registry/browser/records.pt:62
@@ -11393,6 +11669,30 @@ msgstr "Etiquetas a agregar"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
 msgstr "Etiquetas a quitar"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
+msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
 msgid "test wc workflow"
@@ -11641,6 +11941,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Ayer"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12002,6 +12306,10 @@ msgstr "Política de versionado:"
 msgid "types_controlpanel_warn_remap"
 msgstr "Cambiar el flujo de trabajo de un tipo puede tardar un rato, y ralentizar el sitio significativamente mientras que el contenido está siendo actualizado a la nueva configuración."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12067,6 +12375,22 @@ msgstr "Neutral respecto al idioma (por defecto para un sitio)"
 msgid "warning_contentrules_disabled"
 msgstr "Las reglas de contenido han sido deshabilitadas globalmente. No se ejecutarán las reglas asignadas hasta que sean rehabilitadas. Utilice el ${controlpanel_link} para habilitarlas de nuevo."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12076,6 +12400,54 @@ msgstr "Política..."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Este elemento está siendo editado por ${creator} en ${working_copy} creado el ${created}."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/et/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/et/LC_MESSAGES/plone.po
@@ -3587,6 +3587,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6460,9 +6464,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6473,6 +6485,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6498,6 +6518,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6641,6 +6665,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6808,6 +6840,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6836,6 +6876,10 @@ msgstr "Kustuta see fail"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Kustuta see pilt"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7402,6 +7446,14 @@ msgstr "Oled registreeritud portaali kasutajaks. "
 msgid "description_you_can_log_on_now"
 msgstr "Klõpsa siin, kui soovid kohe sisse logida."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7428,6 +7480,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7498,6 +7554,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7516,6 +7580,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8831,8 +8910,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11140,6 +11242,10 @@ msgstr "Kuna autentimine küpsiste kasutamisega on välja lülitatud, siis küps
 msgid "login_portlet_disabled"
 msgstr "Küpsistepõhine autentimine  on välja lülitatud. Sisselogimisplokk pole süsteemis kättesaadav. "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11225,6 +11331,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11250,6 +11404,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11269,6 +11427,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Kommentaare pole."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11294,6 +11486,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "või lae üles uus fail (olemasolev sisu asendatakse uuega)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11302,6 +11514,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11321,6 +11537,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11345,6 +11569,10 @@ msgstr ""
 #. Default: "Use parent settings"
 #: plone.app.portlets/plone/app/portlets/browser/templates/edit-manager-contextual.pt:78
 msgid "portlets_value_use_parent"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
 msgstr ""
 
 # MM
@@ -11373,6 +11601,34 @@ msgstr "avalda"
 msgid "published"
 msgstr "avaldatud"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11385,6 +11641,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "Loe edasi"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11405,6 +11673,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Palun logi välja ja sule  brauseri aken, kui oled  töö lõpetanud."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11436,6 +11708,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11566,6 +11842,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11824,6 +12124,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Eile"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12189,6 +12493,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12255,6 +12563,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12263,6 +12587,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/eu/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/eu/LC_MESSAGES/plone.po
@@ -3578,6 +3578,10 @@ msgstr "Ez dago migratzeko edukirik"
 msgid "No email address is registered for member: ${member_id}"
 msgstr "${member_id} erabiltzaileak ez du eposta helbiderik"
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "Bilduma honetan ez da irudirik aurkitu."
@@ -6433,6 +6437,7 @@ msgstr "URL absolutuen aurrizkia"
 msgid "action_convert_legacy_portlets"
 msgstr "Hemen definitutako portlet zaharrak daude. Egin klik portlet berri bihurtzeko."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
 msgid "add"
 msgstr "Gehitu"
 
@@ -6441,6 +6446,7 @@ msgstr "Gehitu"
 msgid "add_comment_button"
 msgstr "Eman erantzuna"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
 msgid "add_date"
 msgstr "Data gehitu"
 
@@ -6454,9 +6460,11 @@ msgstr "Eremu-multzo berria gehitu..."
 msgid "add_new_field_hellip"
 msgstr "Eremu berria gehitu..."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
 msgid "add_rules"
 msgstr "Erregelak gehitu"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
 msgid "additional_date"
 msgstr "Data gehigarria"
 
@@ -6484,6 +6492,7 @@ msgstr "Karpeta hau eta bere eduki guztia ezabatzea nahi duzu?"
 msgid "alphabetically"
 msgstr "alfabetikoki"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
 msgid "already_added"
 msgstr "Jada gehituta"
 
@@ -6623,9 +6632,11 @@ msgstr "Ezabatu"
 msgid "bulkactions_publish"
 msgstr "Onartu"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
 msgid "bysetpos"
 msgstr "BYSETPOS ezin da erabili"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
 msgid "cancel"
 msgstr "Utzi"
 
@@ -6794,9 +6805,11 @@ msgstr "Egungo itxura"
 msgid "current_theme_description"
 msgstr "Egungo itxuraren izena, azkenengo aplikatu dena."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
 msgid "daily_interval_1"
 msgstr "Errepikapena:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
 msgid "daily_interval_2"
 msgstr "egunean behin"
 
@@ -6829,6 +6842,7 @@ msgstr "Uneko fitxategia ezabatu"
 msgid "delete_image"
 msgstr "Uneko irudia ezabatu"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
 msgid "delete_rules"
 msgstr "Erregelak ezabatu"
 
@@ -7380,9 +7394,11 @@ msgstr "Ondo eman duzu izena."
 msgid "description_you_can_log_on_now"
 msgstr "Klik egizu botoian berehala saioa hasteko."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
 msgid "display_activate"
 msgstr "Hauetan errepikatzen da:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
 msgid "display_unactivate"
 msgstr "Errepikapenik ez"
 
@@ -7414,6 +7430,7 @@ msgstr "Erantzuna editatu"
 msgid "edit_comment_form_title"
 msgstr "Erantzuna editatu"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
 msgid "edit_rules"
 msgstr "Erregelak editatu"
 
@@ -7484,9 +7501,11 @@ msgstr "${name} beharrezkoa da, zuzendu mesedez."
 msgid "error_vocabulary"
 msgstr "${val} balioa ez dago ${label} elementuaren hiztegian onartuta"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
 msgid "except"
 msgstr "ezik"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
 msgid "exclude"
 msgstr "Kendu"
 
@@ -7509,6 +7528,21 @@ msgstr "Hiztegiko '${value1}' balioak arazo bat dauka '${value2}'rekin"
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
 msgstr "Ezin dituzu hiztegiaren izena eta hiztegiaren balioak ezarri. Ezabatu balioak edo ez ezarri baliorik hemen"
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
+msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
 #: plone.app.querystring/plone/app/querystring/results.pt:71
@@ -8762,13 +8796,30 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Ondoko baldintza guztiak betetzen badira:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
 msgstr "karakteretan"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
 msgid "include"
 msgstr "Sartu"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
 msgid "including"
 msgstr ", eta ere"
 
@@ -11008,6 +11059,7 @@ msgstr "Cookie autentifikazioa desgaitua dagoen bitartean, cookie-etan oinarritu
 msgid "login_portlet_disabled"
 msgstr "Cookien bitarteko autentikazioa desgaitua. Saio hasierako portleta ez dago erabilgarri"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
 msgid "long_date_format"
 msgstr "yyyy-mmmm-dd, dddd"
 
@@ -11110,36 +11162,51 @@ msgstr "Defektuzko elementu-motak Dexterityra migratu."
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr "migrazioari dagokion atala plone.app.contenttypes-en dokumentazioan"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
 msgid "monthly_day_of_month_1"
 msgstr "Hilabeteko"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
 msgid "monthly_day_of_month_1_human"
 msgstr "Hilabeteko"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
 msgid "monthly_day_of_month_2"
 msgstr ". egunean"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
 msgid "monthly_day_of_month_3"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
 msgid "monthly_interval_1"
 msgstr "Errepikapena:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
 msgid "monthly_interval_2"
 msgstr "hilabetean behin"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
 msgid "monthly_repeat_on"
 msgstr "Errepikapena:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
 msgid "monthly_weekday_of_month_1"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
 msgid "monthly_weekday_of_month_1_human"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
 msgid "monthly_weekday_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
 msgid "monthly_weekday_of_month_3"
 msgstr " "
 
@@ -11168,6 +11235,7 @@ msgstr "Pasahitza idatzi edo e-postaz bidaltzea aukeratu behar duzu."
 msgid "msg_text_too_long"
 msgstr "Testua luzeegia da (gehienez ${max} karaktere)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
 msgid "multiple_day_of_month"
 msgstr "Tresna honetan ezin dira hilabeteroko edo urteroko errepikapenak erabili"
 
@@ -11191,21 +11259,37 @@ msgstr "Ez"
 msgid "no_comments"
 msgstr "Ez dago iruzkinik."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
 msgid "no_end_after_n_occurrences"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
 msgid "no_end_date"
 msgstr "Errorea: bukaera data ez duzu sartu, sartu data zuzen bat"
 
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
 msgid "no_repeat_every"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
 msgid "no_repeat_on"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
 msgid "no_rule"
 msgstr "Erregelarik-ez"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
 msgid "no_template_match"
 msgstr " "
 
@@ -11233,18 +11317,23 @@ msgstr "edo"
 msgid "or_upload_a_file"
 msgstr "edo fitxategi bat igo (dagoen edukia ordeztua izango da)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
 msgid "order_indexes_first"
 msgstr "lehenengo"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
 msgid "order_indexes_fourth"
 msgstr "laugarren"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
 msgid "order_indexes_last"
 msgstr "azkena"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
 msgid "order_indexes_second"
 msgstr "bigarren"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
 msgid "order_indexes_third"
 msgstr "hirugarren"
 
@@ -11258,6 +11347,7 @@ msgstr "Parametroen espresioak"
 msgid "parameter_expressions_description"
 msgstr "Konpilatutako itxurari pasatuko zaizkion parametroak definitu ditzakezu. Erregelen fitxategian parametro hauei $izena eran egin diezakezu erreferentzia. Parametroak TALES espresioak erabiliz definitzen dira eta euren emaitza testu-kate bat, zenbaki bat, balio boolear bat edo None izan behar da. Espresioan erabili ditzakezun defektuzko aldagaiak hauek dira: context, request, portal, portal_state eta context_state."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
 msgid "past_end_date"
 msgstr "Errorea: bukaera-data ezin da hasiera-data baino lehenagokoa izan"
 
@@ -11279,6 +11369,14 @@ msgstr "plone.app.collection"
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
 msgstr "plone.app.iterate: testak"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
+msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
 msgid "plone.protect configuration"
@@ -11304,6 +11402,7 @@ msgstr "Ez blokeatu"
 msgid "portlets_value_use_parent"
 msgstr "Gurasoaren ezarpenak erabili"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
 msgid "preview"
 msgstr "Aurreikusi"
 
@@ -11330,24 +11429,31 @@ msgstr "argitaratu"
 msgid "published"
 msgstr "argitaratua"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
 msgid "range"
 msgstr "Tartea"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
 msgid "range_by_end_date"
 msgstr "Eskuzko bukaera-data"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
 msgid "range_by_end_date_human"
 msgstr "Eskuzko bukaera-data"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
 msgid "range_by_occurrences_1"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
 msgid "range_by_occurrences_1_human"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
 msgid "range_by_occurrences_2"
 msgstr "hitzorduren ondoren bukatu"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
 msgid "range_no_end"
 msgstr "Inoiz"
 
@@ -11363,12 +11469,15 @@ msgstr "Saretik irakurri"
 msgid "read_more"
 msgstr "Gehiago irakurri"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
 msgid "recurrence_start"
 msgstr "Errepikapenaren hasiera"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
 msgid "recurrence_type"
 msgstr "Errepikapen mota"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
 msgid "refresh"
 msgstr "Birkargatu"
 
@@ -11391,6 +11500,7 @@ msgstr "errelebantzia"
 msgid "remember_to_log_out"
 msgstr "Mesedez, amaitzen duzunean sistematik atera edo nabigatzailea itxi."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
 msgid "remove"
 msgstr "Ezabatu"
 
@@ -11425,6 +11535,7 @@ msgstr "Erregela-fitxategia"
 msgid "rules_file_path"
 msgstr "Erregela-fitxategirako fitxategi-bidea"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
 msgid "save"
 msgstr "Gorde"
 
@@ -11556,21 +11667,27 @@ msgstr "Gehitu beharreko etiketak"
 msgid "tags_to_remove"
 msgstr "Kendu beharreko etiketak"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
 msgid "template_daily"
 msgstr "Egunero (txantiloia)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
 msgid "template_mondayfriday"
 msgstr "Astelehenetik ostiralera (txantiloia)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
 msgid "template_monthly"
 msgstr "Hilero (txantiloia)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
 msgid "template_weekdays"
 msgstr "Astegunetan (txantiloia)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
 msgid "template_weekly"
 msgstr "Astero (txantiloia)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
 msgid "template_yearly"
 msgstr "Urtero (txantiloia)"
 
@@ -11823,6 +11940,7 @@ msgstr ":"
 msgid "time_yesterday"
 msgstr "Atzo"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
 msgid "title"
 msgstr "Izenburua"
 
@@ -12186,6 +12304,7 @@ msgstr "Bertsio kudeaketaren politika:"
 msgid "types_controlpanel_warn_remap"
 msgstr "Elementu mota baten lan-fluxua aldatzeak denbora bat hartu eta webgunea geldoarazi dezake eragiketak dirauen artean."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
 msgid "unsupported_features"
 msgstr " "
 
@@ -12254,15 +12373,19 @@ msgstr "Hizkuntzarekiko neutrala (webguneko defektuzkoa)"
 msgid "warning_contentrules_disabled"
 msgstr "Erregelak atari guztiak desaktibattua daude. Esleitutako erregelak ez dira exekutatuko berriz aktibatu arte. Erabili ${controlpanel_link} berriz aktibatzeko."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
 msgid "weekly_interval_1"
 msgstr "Errepikapena:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
 msgid "weekly_interval_2"
 msgstr "astean behin"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
 msgid "weekly_weekdays"
 msgstr "Astegunak"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
 msgid "weekly_weekdays_human"
 msgstr "Astegunak"
 
@@ -12276,39 +12399,51 @@ msgstr "Politika..."
 msgid "working_copy_info"
 msgstr "${creator} elementu hau editatzen ari da ${created}en sortutako ${working_copy}n"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
 msgid "yearly_day_of_month_1"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
 msgid "yearly_day_of_month_1_human"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
 msgid "yearly_day_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
 msgid "yearly_day_of_month_3"
 msgstr "guztietan"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
 msgid "yearly_interval_1"
 msgstr "Errepikapena:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
 msgid "yearly_interval_2"
 msgstr "urtean behin"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
 msgid "yearly_repeat_on"
 msgstr "Errepikapena:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
 msgid "yearly_weekday_of_month_1"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
 msgid "yearly_weekday_of_month_1_human"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
 msgid "yearly_weekday_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
 msgid "yearly_weekday_of_month_3"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
 msgid "yearly_weekday_of_month_4"
 msgstr " "
 

--- a/plone/app/locales/locales/fa/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/fa/LC_MESSAGES/plone.po
@@ -3577,6 +3577,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6436,9 +6440,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6449,6 +6461,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6474,6 +6494,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6614,6 +6638,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6781,6 +6813,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6809,6 +6849,10 @@ msgstr "حذف پرونده فعلی"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "حذف تصویر فعلی"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7364,6 +7408,14 @@ msgstr "شما به عنوان یک عضو، ثبت‌نام شدید."
 msgid "description_you_can_log_on_now"
 msgstr "این دکمه را برای ورود سریع فشار دهید."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7390,6 +7442,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7459,6 +7515,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7477,6 +7541,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8756,8 +8835,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11022,6 +11124,10 @@ msgstr "در هنگام غیرفعال بودن هویت‌سنجی مبتنی �
 msgid "login_portlet_disabled"
 msgstr "هویت‌سنجی مبتنی بر کوکی غیرفعال گشته است. جعبه ورود در دسترس نمی‌باشد."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11107,6 +11213,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11132,6 +11286,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11151,6 +11309,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "نظری داده نشده"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11176,6 +11368,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "یا پرونده‌ای را بارگذاری کنید (جایگزین محتوای موجود خواهد شد)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11184,6 +11396,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11203,6 +11419,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11229,6 +11453,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11252,6 +11480,34 @@ msgstr "منتشر کردن"
 msgid "published"
 msgstr "منتشر شده"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11264,6 +11520,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "ادامه"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11283,6 +11551,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "لطفا پس از پایان کار خود، logout کنید و یا مرورگر خود را ببندید."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11313,6 +11585,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11443,6 +11719,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11701,6 +12001,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "دیروز"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12065,6 +12369,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12130,6 +12438,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 #, fuzzy
@@ -12139,6 +12463,54 @@ msgstr "خط‌مشی"
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/fi/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/fi/LC_MESSAGES/plone.po
@@ -3576,6 +3576,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr "Ei tiedostoa"
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "Tästä kokoelmasta ei löytynyt kuvia."
@@ -6424,6 +6428,7 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr "Täällä on vanhan tavan mukaisia sovelmia. Paina nappia muuntaaksesi ne ajanmukaisiksi sovelmiksi."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
 msgid "add"
 msgstr "Lisää"
 
@@ -6432,6 +6437,7 @@ msgstr "Lisää"
 msgid "add_comment_button"
 msgstr "Lisää"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
 msgid "add_date"
 msgstr "Lisää poikkeus"
 
@@ -6445,9 +6451,11 @@ msgstr ""
 msgid "add_new_field_hellip"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
 msgid "add_rules"
 msgstr "Lisää"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
 msgid "additional_date"
 msgstr "Lisäpäivä"
 
@@ -6475,6 +6483,7 @@ msgstr "Haluatko todella poistaa tämän kansion ja kaiken sen sisällön?"
 msgid "alphabetically"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
 msgid "already_added"
 msgstr "Tämä päivä on jo lisätty"
 
@@ -6614,9 +6623,11 @@ msgstr "Poista valitut"
 msgid "bulkactions_publish"
 msgstr "Hyväksy valitut"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
 msgid "bysetpos"
 msgstr "BYSETPOS ei ole tuettu"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
 msgid "cancel"
 msgstr "Peru"
 
@@ -6785,9 +6796,11 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
 msgid "daily_interval_1"
 msgstr "joka:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
 msgid "daily_interval_2"
 msgstr "päivä"
 
@@ -6820,6 +6833,7 @@ msgstr "Poista tämä tiedosto"
 msgid "delete_image"
 msgstr "Poista tämä kuva"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
 msgid "delete_rules"
 msgstr "(X)"
 
@@ -7374,9 +7388,11 @@ msgstr "Sinut on rekisteröity."
 msgid "description_you_can_log_on_now"
 msgstr "Kirjaudu sisään napsauttamalla alla olevaa painiketta."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
 msgid "display_activate"
 msgstr "Toistuu joka "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
 msgid "display_unactivate"
 msgstr "Ei toistu"
 
@@ -7408,6 +7424,7 @@ msgstr ""
 msgid "edit_comment_form_title"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
 msgid "edit_rules"
 msgstr "Muokkaa"
 
@@ -7478,9 +7495,11 @@ msgstr "${name} on pakollinen tieto."
 msgid "error_vocabulary"
 msgstr "Arvo ${val} ei ole sallittu elementille ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
 msgid "except"
 msgstr ", paitsi"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
 msgid "exclude"
 msgstr "Jätä pois"
 
@@ -7503,6 +7522,21 @@ msgstr ""
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
 msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr "Säilytä nykyinen tiedosto"
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr "Poista nykyinen kuva"
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
+msgstr "Korvaa toisella tiedostolla"
 
 #: CMFPlone/browser/templates/search.pt:283
 #: plone.app.querystring/plone/app/querystring/results.pt:71
@@ -8765,13 +8799,30 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Jos kaikki seuraavat ehdot täyttyvät:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr "Säilytä nykyinen kuva"
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr "Poista nykyinen kuva"
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr "Korvaa toisella kuvalla"
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
 msgid "include"
 msgstr "Ota mukaan"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
 msgid "including"
 msgstr ", lisäksi "
 
@@ -11014,6 +11065,7 @@ msgstr "Kun evästetunnistus (<em>cookie authentication</em>) on poissa käytös
 msgid "login_portlet_disabled"
 msgstr "Evästetunnistus on poistettu käytöstä. Kirjautumissovelma ei ole käytettävissä."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
 msgid "long_date_format"
 msgstr "dddd mmmm dd, yyyy"
 
@@ -11102,36 +11154,51 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
 msgid "monthly_day_of_month_1"
 msgstr "Kuukauden"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
 msgid "monthly_day_of_month_1_human"
 msgstr "on day"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
 msgid "monthly_day_of_month_2"
 msgstr "päivänä"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
 msgid "monthly_day_of_month_3"
 msgstr "kuukausi"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
 msgid "monthly_interval_1"
 msgstr "joka:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
 msgid "monthly_interval_2"
 msgstr "kuukausi"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
 msgid "monthly_repeat_on"
 msgstr "toistuen:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
 msgid "monthly_weekday_of_month_1"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
 msgid "monthly_weekday_of_month_1_human"
 msgstr "on the"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
 msgid "monthly_weekday_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
 msgid "monthly_weekday_of_month_3"
 msgstr "kuukaudessa"
 
@@ -11160,6 +11227,7 @@ msgstr "Aseta salasana tai valitse sen lähetys sähköpostilla."
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
 msgid "multiple_day_of_month"
 msgstr "Useampi kuin yksi päivä ei ole mahdollista kuukauden tai vuoden perusteella toistuvassa tapahtumassa."
 
@@ -11183,21 +11251,37 @@ msgstr ""
 msgid "no_comments"
 msgstr "Ei kommentteja."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
 msgid "no_end_after_n_occurrences"
 msgstr "Virhe: \"N:n toiston jälkeen\"-kentän arvo tulee olla välillä 1-1000."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
 msgid "no_end_date"
 msgstr "Virhe: Loppumispäivää ei ole asetettu. Ole hyvä ja aseta päivä."
 
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr "Ei tiedostoa"
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr "Ei kuvaa"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
 msgid "no_repeat_every"
 msgstr "Virhe: \"Toista joka\"-kentän arvon tulee olla välillä 1-1000."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
 msgid "no_repeat_on"
 msgstr "Virhe: \"Toistuvuus\"-kentän arvo on pakollinen."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
 msgid "no_rule"
 msgstr "RRULE-tietue on puutteellinen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
 msgid "no_template_match"
 msgstr "Toistuvuus templatea ei löytynyt"
 
@@ -11225,18 +11309,23 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "tai lähetä tiedosto (nykyinen sisältö korvataan)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
 msgid "order_indexes_first"
 msgstr "ensimmäinen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
 msgid "order_indexes_fourth"
 msgstr "neljäs"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
 msgid "order_indexes_last"
 msgstr "viimeinen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
 msgid "order_indexes_second"
 msgstr "toinen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
 msgid "order_indexes_third"
 msgstr "kolmas"
 
@@ -11250,6 +11339,7 @@ msgstr ""
 msgid "parameter_expressions_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
 msgid "past_end_date"
 msgstr "Virhe: Loppumispäivä ei voi tulla ennen alkamispäivää."
 
@@ -11270,6 +11360,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11296,6 +11394,7 @@ msgstr "Näytä aina"
 msgid "portlets_value_use_parent"
 msgstr "Käytä ylemmän tason asetuksia"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
 msgid "preview"
 msgstr "Toistumispäivät"
 
@@ -11322,24 +11421,31 @@ msgstr "julkaise"
 msgid "published"
 msgstr "julkaistu"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
 msgid "range"
 msgstr "päättyen:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
 msgid "range_by_end_date"
 msgstr "viimeistään "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
 msgid "range_by_end_date_human"
 msgstr "loppuen "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
 msgid "range_by_occurrences_1"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
 msgid "range_by_occurrences_1_human"
 msgstr "päättyen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
 msgid "range_by_occurrences_2"
 msgstr "toiston jälkeen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
 msgid "range_no_end"
 msgstr "Ei koskaan"
 
@@ -11355,12 +11461,15 @@ msgstr ""
 msgid "read_more"
 msgstr "Lue lisää..."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
 msgid "recurrence_start"
 msgstr "Toistumisjakson alku"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
 msgid "recurrence_type"
 msgstr "Toistuu:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
 msgid "refresh"
 msgstr "Päivitä"
 
@@ -11383,6 +11492,7 @@ msgstr ""
 msgid "remember_to_log_out"
 msgstr "Kun olet valmis, muista kirjautua sivustolta ulos tai sulkea selainikkunat."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
 msgid "remove"
 msgstr "Poista"
 
@@ -11417,6 +11527,7 @@ msgstr ""
 msgid "rules_file_path"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
 msgid "save"
 msgstr "Tallenna"
 
@@ -11556,21 +11667,27 @@ msgstr ""
 msgid "tags_to_remove"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
 msgid "template_daily"
 msgstr "Päivittäin"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
 msgid "template_mondayfriday"
 msgstr "Maanantaisin ja perjantaisin"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
 msgid "template_monthly"
 msgstr "Kuukausittain"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
 msgid "template_weekdays"
 msgstr "Arkipäivisin"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
 msgid "template_weekly"
 msgstr "Viikottain"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
 msgid "template_yearly"
 msgstr "Vuosittain"
 
@@ -11823,6 +11940,7 @@ msgstr "."
 msgid "time_yesterday"
 msgstr "Eilen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
 msgid "title"
 msgstr "Toistuva tapahtuma"
 
@@ -12188,6 +12306,7 @@ msgstr "Versiointi käytäntö:"
 msgid "types_controlpanel_warn_remap"
 msgstr "Sisältötyypin työnkulun vaihtaminen voi viedä hetken. Sivusto voi hidastua merkittävästi muunnostyön aikana."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
 msgid "unsupported_features"
 msgstr "Varoitus: Tapahtuma käyttää toisto-ominaisuuksia, joita ei tueta. Tapahtuman tallentaminen voi hävittää nämä tiedot."
 
@@ -12256,15 +12375,19 @@ msgstr "Kielineutraali (sivuston oletus)"
 msgid "warning_contentrules_disabled"
 msgstr "Sisältösäännöt on kytketty pois koko sivustolta. Mikään sääntö ei ole voimassa, ennen kuin säännöt kytketään päälle. Käytä ${controlpanel_link}a ottaaksesi säännöt käyttöön."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
 msgid "weekly_interval_1"
 msgstr "joka:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
 msgid "weekly_interval_2"
 msgstr "viikko"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
 msgid "weekly_weekdays"
 msgstr "päivinä:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
 msgid "weekly_weekdays_human"
 msgstr "on: "
 
@@ -12278,39 +12401,51 @@ msgstr "Käytäntö..."
 msgid "working_copy_info"
 msgstr "${creator} muokkaa tätä kohdetta ${created} luodussa työkopiossa ${working_copy}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
 msgid "yearly_day_of_month_1"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
 msgid "yearly_day_of_month_1_human"
 msgstr "on"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
 msgid "yearly_day_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
 msgid "yearly_day_of_month_3"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
 msgid "yearly_interval_1"
 msgstr "joka:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
 msgid "yearly_interval_2"
 msgstr "vuosi"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
 msgid "yearly_repeat_on"
 msgstr "toistuen:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
 msgid "yearly_weekday_of_month_1"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
 msgid "yearly_weekday_of_month_1_human"
 msgstr "on the"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
 msgid "yearly_weekday_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
 msgid "yearly_weekday_of_month_3"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
 msgid "yearly_weekday_of_month_4"
 msgstr " "
 

--- a/plone/app/locales/locales/fr/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/fr/LC_MESSAGES/plone.po
@@ -3584,6 +3584,10 @@ msgstr "Aucun contenu à migrer"
 msgid "No email address is registered for member: ${member_id}"
 msgstr "Aucune adresse email n’est enregistrée pour le membre : ${member_id}"
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr "Aucun fichier ajouté"
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "Aucune image trouvée dans la collection."
@@ -6440,6 +6444,7 @@ msgstr "Préfixe de l'URL absolue"
 msgid "action_convert_legacy_portlets"
 msgstr "Des portlets d'anciennes générations sont définis ici. Cliquez ici pour les transformer en portlets nouvelle génération."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
 msgid "add"
 msgstr "Ajouter"
 
@@ -6448,6 +6453,7 @@ msgstr "Ajouter"
 msgid "add_comment_button"
 msgstr "Commenter"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
 msgid "add_date"
 msgstr "Ajouter une date"
 
@@ -6461,9 +6467,11 @@ msgstr "Ajouter un groupe de champs…"
 msgid "add_new_field_hellip"
 msgstr "Ajouter un champ…"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
 msgid "add_rules"
 msgstr "Ajouter"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
 msgid "additional_date"
 msgstr "Dates supplémentaires"
 
@@ -6491,6 +6499,7 @@ msgstr "Voulez-vous réellement supprimer ce dossier et tout son contenu ?"
 msgid "alphabetically"
 msgstr "alphabétiquement"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
 msgid "already_added"
 msgstr "Cette date a déjà été ajoutée"
 
@@ -6630,9 +6639,11 @@ msgstr "Supprimer"
 msgid "bulkactions_publish"
 msgstr "Approuver"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
 msgid "bysetpos"
 msgstr "BYSETPOS n'est pas soutenu"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
 msgid "cancel"
 msgstr "Annuler"
 
@@ -6801,9 +6812,11 @@ msgstr "Thème actuel"
 msgid "current_theme_description"
 msgstr "Le nom du thème actuel, c'est-à-dire celui utilisé."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
 msgid "daily_interval_1"
 msgstr "Répétition :"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
 msgid "daily_interval_2"
 msgstr "Jours"
 
@@ -6836,6 +6849,7 @@ msgstr "Supprimer le fichier actuel"
 msgid "delete_image"
 msgstr "Supprimer l'image actuelle"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
 msgid "delete_rules"
 msgstr "Supprimer"
 
@@ -7389,9 +7403,11 @@ msgstr "Vous êtes maintenant inscrit(e)."
 msgid "description_you_can_log_on_now"
 msgstr "Cliquez sur ce bouton pour ouvrir une session immédiatement."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
 msgid "display_activate"
 msgstr "Se répète tous les"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
 msgid "display_unactivate"
 msgstr "Pas de répétitions"
 
@@ -7423,6 +7439,7 @@ msgstr "Éditer le commentaire"
 msgid "edit_comment_form_title"
 msgstr "Éditer le commentaire"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
 msgid "edit_rules"
 msgstr "Modifier"
 
@@ -7493,9 +7510,11 @@ msgstr "${name} est obligatoire, veuillez corriger."
 msgid "error_vocabulary"
 msgstr "Les valeurs ${val} ne sont pas permises comme vocabulaire de l'élément ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
 msgid "except"
 msgstr ", sauf que"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
 msgid "exclude"
 msgstr "Exclu"
 
@@ -7518,6 +7537,21 @@ msgstr "La valeur de vocabulaire '${value1}' est en conflit avec '${value2}'"
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
 msgstr "Vous ne pouvez pas indiquer un nom de vocabulaire ET des valeurs. Merci de vider l'un des deux champs."
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr "Garder le fichier existant"
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr "Effacer le fichier existant"
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
+msgstr "Remplacer par un nouveau fichier"
 
 #: CMFPlone/browser/templates/search.pt:283
 #: plone.app.querystring/plone/app/querystring/results.pt:71
@@ -8770,13 +8804,30 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Si toutes les conditions suivantes sont remplies :"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr "Garder l'image existante"
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr "Effacer l'image existante"
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr "Remplacer par une nouvelle image"
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
 msgstr "en caractères"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
 msgid "include"
 msgstr "Inclue"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
 msgid "including"
 msgstr ", et aussi"
 
@@ -11015,6 +11066,7 @@ msgstr "L'authentification par cookie n'est pas possible si les cookies sont dé
 msgid "login_portlet_disabled"
 msgstr "Le cookie a été désactivé. Le portlet de connexion n'est pas disponible."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
 msgid "long_date_format"
 msgstr "dddd mmmm dd, yyyy"
 
@@ -11119,36 +11171,51 @@ msgstr "Migrer les types de contenu par défaut en Dexterity."
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr "Section migration dans la documentation de plone.app.contenttypes"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
 msgid "monthly_day_of_month_1"
 msgstr "Jour"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
 msgid "monthly_day_of_month_1_human"
 msgstr "le jour"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
 msgid "monthly_day_of_month_2"
 msgstr "du mois"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
 msgid "monthly_day_of_month_3"
 msgstr "Mois"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
 msgid "monthly_interval_1"
 msgstr "Se répète tous les:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
 msgid "monthly_interval_2"
 msgstr "Mois"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
 msgid "monthly_repeat_on"
 msgstr "Se répète:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
 msgid "monthly_weekday_of_month_1"
 msgstr "Le"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
 msgid "monthly_weekday_of_month_1_human"
 msgstr "le"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
 msgid "monthly_weekday_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
 msgid "monthly_weekday_of_month_3"
 msgstr "le mois"
 
@@ -11177,6 +11244,7 @@ msgstr "Vous devez définir un mot de passe ou choisir d'envoyer un courriel."
 msgid "msg_text_too_long"
 msgstr "Le texte est trop long. (maximum ${max} caractères)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
 msgid "multiple_day_of_month"
 msgstr "Cet outil ne soutient pas de répétitions mensuelles ou annuelles"
 
@@ -11200,11 +11268,39 @@ msgstr "non"
 msgid "no_comments"
 msgstr "Aucun commentaire."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
 msgid "no_end_date"
 msgstr "Faute: La fin de la date n'a pas été saisie, veuillez saisir une date correcte."
 
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr "Aucun fichier"
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr "Aucune image"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
 msgid "no_rule"
 msgstr "Pas de dates RRULE dans RRULE"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11230,18 +11326,23 @@ msgstr "ou"
 msgid "or_upload_a_file"
 msgstr "ou transférer un fichier sur le serveur (le contenu sera remplacé)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
 msgid "order_indexes_first"
 msgstr "premier"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
 msgid "order_indexes_fourth"
 msgstr "quatrième"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
 msgid "order_indexes_last"
 msgstr "dernier"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
 msgid "order_indexes_second"
 msgstr "deuxième"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
 msgid "order_indexes_third"
 msgstr "troisième"
 
@@ -11255,6 +11356,7 @@ msgstr "Expressions de configuration"
 msgid "parameter_expressions_description"
 msgstr "Vous pouvez définir les paramètres ici, qui seront passés à la compilation du thème. Dans votre fichier de règles, vous pouvez y faire référence en utilisant $name. Les paramètres sont définis à l'aide d'expressions TALES, qui doivent être évaluées en tant que chaine de caractères, nombre, booléen ou None. Les variables disponibles sont `context`, `request`, `portal`, `portal_state`,  et `context_state`."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
 msgid "past_end_date"
 msgstr "Faute: La fin ne peut pas être avant le démarrage de la date."
 
@@ -11275,6 +11377,14 @@ msgstr "plone.app.collection"
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11301,6 +11411,7 @@ msgstr "Ne pas bloquer"
 msgid "portlets_value_use_parent"
 msgstr "Paramètres du dossier parent"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
 msgid "preview"
 msgstr "Dates choisies"
 
@@ -11327,24 +11438,31 @@ msgstr "publier"
 msgid "published"
 msgstr "publié"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
 msgid "range"
 msgstr "Fin de la répétition:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
 msgid "range_by_end_date"
 msgstr "Jusqu'à"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
 msgid "range_by_end_date_human"
 msgstr "finit le"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
 msgid "range_by_occurrences_1"
 msgstr "Finit après"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
 msgid "range_by_occurrences_1_human"
 msgstr "finit après"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
 msgid "range_by_occurrences_2"
 msgstr "évènement(s)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
 msgid "range_no_end"
 msgstr "Jamais"
 
@@ -11360,12 +11478,15 @@ msgstr "Lire le réseau"
 msgid "read_more"
 msgstr "Lire la suite…"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
 msgid "recurrence_start"
 msgstr "Début de la répétition"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
 msgid "recurrence_type"
 msgstr "Se répète:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
 msgid "refresh"
 msgstr "Actualiser"
 
@@ -11388,6 +11509,7 @@ msgstr "pertinence"
 msgid "remember_to_log_out"
 msgstr "N'oubliez pas de fermer votre session ou de quitter votre navigateur quand vous aurez terminé."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
 msgid "remove"
 msgstr "Eliminer"
 
@@ -11422,6 +11544,7 @@ msgstr "Fichier de règles"
 msgid "rules_file_path"
 msgstr "Chemin vers le fichier de règles."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
 msgid "save"
 msgstr "Enregistrer"
 
@@ -11550,21 +11673,27 @@ msgstr "Tags à ajouter"
 msgid "tags_to_remove"
 msgstr "Tags à supprimer"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
 msgid "template_daily"
 msgstr "Quotidiennement"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
 msgid "template_mondayfriday"
 msgstr "Lundi et vendredi"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
 msgid "template_monthly"
 msgstr "Mensuel"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
 msgid "template_weekdays"
 msgstr "Lundi à vendredi"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
 msgid "template_weekly"
 msgstr "Hebdomadaire"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
 msgid "template_yearly"
 msgstr "Annuelle"
 
@@ -11816,6 +11945,7 @@ msgstr ":"
 msgid "time_yesterday"
 msgstr "Hier"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
 msgid "title"
 msgstr "Répétition"
 
@@ -12179,6 +12309,10 @@ msgstr "Politique de versionnement :"
 msgid "types_controlpanel_warn_remap"
 msgstr "Affecter un nouveau processus à un type de contenu peut prendre beaucoup de temps et va ralentir significativement le site durant cette opération."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12244,15 +12378,19 @@ msgstr "Indépendant de la langue (par défaut du site)"
 msgid "warning_contentrules_disabled"
 msgstr "Les règles sont désactivées globalement. Aucune affectation de règle ne sera possible avant qu'elles ne soient réactivées. Utilisez le ${controlpanel_link} pour les activer à nouveau."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
 msgid "weekly_interval_1"
 msgstr "Se répète tous les:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
 msgid "weekly_interval_2"
 msgstr "Semaine(s)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
 msgid "weekly_weekdays"
 msgstr "Se répète tous les:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
 msgid "weekly_weekdays_human"
 msgstr "le:"
 
@@ -12266,39 +12404,51 @@ msgstr "Politique locale"
 msgid "working_copy_info"
 msgstr "Cet élément est en train d'être modifié par ${creator} dans ${working_copy} créé le ${created}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
 msgid "yearly_day_of_month_1"
 msgstr "Tous les"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
 msgid "yearly_day_of_month_1_human"
 msgstr "le"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
 msgid "yearly_day_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
 msgid "yearly_day_of_month_3"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
 msgid "yearly_interval_1"
 msgstr "Se répète tous les:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
 msgid "yearly_interval_2"
 msgstr "An(s)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
 msgid "yearly_repeat_on"
 msgstr "Se répète tous les:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
 msgid "yearly_weekday_of_month_1"
 msgstr "Le"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
 msgid "yearly_weekday_of_month_1_human"
 msgstr "le"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
 msgid "yearly_weekday_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
 msgid "yearly_weekday_of_month_3"
 msgstr "de"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
 msgid "yearly_weekday_of_month_4"
 msgstr " "
 

--- a/plone/app/locales/locales/fu/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/fu/LC_MESSAGES/plone.po
@@ -3580,6 +3580,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6453,9 +6457,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6466,6 +6478,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6491,6 +6511,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6636,6 +6660,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6803,6 +6835,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6831,6 +6871,10 @@ msgstr "Elimine il schedari corint"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Elimine la figure corinte"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7403,6 +7447,14 @@ msgstr "Tu sês stât metût in note te liste dai colaboradôrs."
 msgid "description_you_can_log_on_now"
 msgstr "Frache il boton par jentrâ daurman tal sît."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7429,6 +7481,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7498,6 +7554,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7516,6 +7580,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8824,8 +8903,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11102,6 +11204,10 @@ msgstr "Cuant che la autentificazion cui cookies e je disabilitade, no si rive a
 msgid "login_portlet_disabled"
 msgstr "L'autenticazion cui cookies e risulte disabilitade. Il ricuadri pal login nol è disponibil."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11188,6 +11294,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11213,6 +11367,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11232,6 +11390,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Nissun coment."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11257,6 +11449,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "o ben cjame un schedari (che al sostituirà il contignût atuâl)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11265,6 +11477,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11284,6 +11500,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11310,6 +11534,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11333,6 +11561,34 @@ msgstr "publiche"
 msgid "published"
 msgstr "publicât"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11345,6 +11601,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "Lei il rest"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11364,6 +11632,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Cuant che tu âs finît, visiti di distacâti o di lâ fûr dal browser."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11394,6 +11666,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11535,6 +11811,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11793,6 +12093,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Di îr"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12157,6 +12461,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12222,6 +12530,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 #, fuzzy
@@ -12231,6 +12555,54 @@ msgstr "Politiche di control"
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/gl/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/gl/LC_MESSAGES/plone.po
@@ -3574,6 +3574,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6430,9 +6434,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr "Definíronse aquí portlets herdados. Faga clic no botón para convertelos ao novo estilo de portlets."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6443,6 +6455,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6467,6 +6487,10 @@ msgstr "Está seguro de que quere eliminar este cartafol e todos os seus contido
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6604,6 +6628,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6771,6 +6803,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6799,6 +6839,10 @@ msgstr "Eliminar ficheiro actual"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Eliminar imaxe actual"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7359,6 +7403,14 @@ msgstr "Foi rexistrado como membro."
 msgid "description_you_can_log_on_now"
 msgstr "Prema o botón para entrar inmediatamente."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7385,6 +7437,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7454,6 +7510,14 @@ msgstr "${name} requirido, por favor, corrízao."
 msgid "error_vocabulary"
 msgstr "Os valores ${val} non están permitidos no vocabulario do elemento ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7472,6 +7536,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8745,8 +8824,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Se todas as seguintes condicións se cumpren:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11002,6 +11104,10 @@ msgstr "Mentres a autenticación baseada en cookie estea deshabilitada, o inicio
 msgid "login_portlet_disabled"
 msgstr "Autenticación mediante cookies deshabilitada. O portlet de inicio de sesión non está dispoñible."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11087,6 +11193,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11112,6 +11266,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11131,6 +11289,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Non hai comentarios."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11156,6 +11348,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "ou suba un ficheiro (o contido existente será substituído)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11164,6 +11376,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11183,6 +11399,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11209,6 +11433,10 @@ msgstr "Non bloquear"
 msgid "portlets_value_use_parent"
 msgstr "Utilizar configuración de elemento superior"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11232,6 +11460,34 @@ msgstr "publicar"
 msgid "published"
 msgstr "publicado"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11244,6 +11500,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "Ler máis…"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11263,6 +11531,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Non esqueza pechar a súa sesión ou saír do seu navegador cando remate."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11293,6 +11565,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11422,6 +11698,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11673,6 +11973,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Onte"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12038,6 +12342,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr "Cambiar o fluxo de traballo dun tipo pode tardar un momento e retardar o sitio significativamente mentres que o contido está a ser actualizado á configuración nova."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12103,6 +12411,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr "As regras de contido foron deshabilitadas globalmente. Non se executarán as regras asignadas ata que sexan rehabilitadas. Utilice o ${controlpanel_link} para habilitalas outra vez."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 #, fuzzy
@@ -12113,6 +12437,54 @@ msgstr "Política"
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Este elemento está a ser editado por ${creator} en ${working_copy} creado o ${created}."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/he/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/he/LC_MESSAGES/plone.po
@@ -3576,6 +3576,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6432,9 +6436,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr "כאן פורטלטים הבסיס מוגדרים.  לחץ על הכפתור על מנת להסבם לסטייל הפורטלטים החדש "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6445,6 +6457,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6469,6 +6489,10 @@ msgstr "האם באמת ברצונך למחוק את ספריה זו ואת כל
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6607,6 +6631,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6775,6 +6807,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6803,6 +6843,10 @@ msgstr "מחק קובץ נוכחי"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "מחק תמונה נוכחית"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7363,6 +7407,14 @@ msgstr "נרשמת כמשתמש"
 msgid "description_you_can_log_on_now"
 msgstr "לחץ על הכפתור על מנת להתחבר מייד"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7389,6 +7441,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7459,6 +7515,14 @@ msgstr "${name} נדרש בבקשה תקן."
 msgid "error_vocabulary"
 msgstr "ערך ${val}  לא מורשה לאוצר מילים של אלמנט ${label}"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7477,6 +7541,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8758,8 +8837,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "במידה וכל התנאים הבאים מתקיימים:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11026,6 +11128,10 @@ msgstr "טופס כניסה לא זמין"
 msgid "login_portlet_disabled"
 msgstr "אישור אוטנטיקציה עוגיות נשלל.  פורטלט התחברות לא זמין."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11111,6 +11217,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11136,6 +11290,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11155,6 +11313,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "אין הערות"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11180,6 +11372,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "או תעלה קובץ (התוכן הקיים יוחלף)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11188,6 +11400,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11207,6 +11423,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11233,6 +11457,10 @@ msgstr "אל תחסום"
 msgid "portlets_value_use_parent"
 msgstr "השתמש בהגדרות הורים"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11256,6 +11484,34 @@ msgstr "פרסם"
 msgid "published"
 msgstr "פורסם"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11268,6 +11524,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "קרא  עוד..."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11287,6 +11555,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "זכור להתנתק"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11317,6 +11589,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11446,6 +11722,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11698,6 +11998,10 @@ msgstr "מפריד זמן"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "אתמול"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12065,6 +12369,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr "שינוי תהליך העבודה של הסוג יכול לקחת זמן, ויכול להאט את פלון בצורה משמעותיתי במשך זמן זה"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12130,6 +12438,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr "חוקי תוכן אינם מאופשרים בצורה גלובלית.  כאשר לא מגדירים הרשאות עד שהם מאופשרים.  השתמש ב ${controlpanel_link} לאפשר אותם שוב"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 #, fuzzy
@@ -12140,6 +12464,54 @@ msgstr "מדיניות"
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "עותק עובד"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/hi/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/hi/LC_MESSAGES/plone.po
@@ -3574,6 +3574,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6430,9 +6434,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6443,6 +6455,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6467,6 +6487,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6605,6 +6629,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6772,6 +6804,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6799,6 +6839,10 @@ msgstr ""
 #. Default: "Delete current image"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
 msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
@@ -7353,6 +7397,14 @@ msgstr ""
 msgid "description_you_can_log_on_now"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7379,6 +7431,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7448,6 +7504,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7466,6 +7530,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8726,8 +8805,31 @@ msgstr "एचटीएमएल"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10979,6 +11081,10 @@ msgstr "प्रमाणीकृत कुकी निष्क्रिय 
 msgid "login_portlet_disabled"
 msgstr "प्रमाणीकृत कुकी निष्क्रिय। लॉगइन पोर्टलैट उपलब्ध नहीं"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11064,6 +11170,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11089,6 +11243,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11108,6 +11266,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "कोई टिप्पणी नहीं"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11133,6 +11325,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11141,6 +11353,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11160,6 +11376,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11186,6 +11410,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11209,6 +11437,34 @@ msgstr "प्रकाशित करना"
 msgid "published"
 msgstr "प्रकाशित"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11221,6 +11477,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "और पढ़ें"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11240,6 +11508,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "काम पूरा होने पर अपने ब्राउज़र से लॉग आउट करें या एग्ज़िट करें"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11270,6 +11542,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11396,6 +11672,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11649,6 +11949,10 @@ msgstr "समय विभाजक"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "कल"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12011,6 +12315,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12076,6 +12384,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12084,6 +12408,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/hr/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/hr/LC_MESSAGES/plone.po
@@ -3576,6 +3576,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6432,9 +6436,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6445,6 +6457,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6469,6 +6489,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6606,6 +6630,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6773,6 +6805,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6800,6 +6840,10 @@ msgstr ""
 #. Default: "Delete current image"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
 msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
@@ -7353,6 +7397,14 @@ msgstr "Registrirani kao korisnik."
 msgid "description_you_can_log_on_now"
 msgstr "Za trenutnu prijavu kliknite gumb."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7379,6 +7431,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7448,6 +7504,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7466,6 +7530,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8738,8 +8817,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10991,6 +11093,10 @@ msgstr "Cookie bazirana prijava nije moguća dok je cookie autentikacija isklju�
 msgid "login_portlet_disabled"
 msgstr "Cookie autentikacija je isključena. Portlet za prijavu nije dostupan."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11076,6 +11182,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11101,6 +11255,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11120,6 +11278,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Nema komentara."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11145,6 +11337,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11153,6 +11365,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11172,6 +11388,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11198,6 +11422,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11221,6 +11449,34 @@ msgstr "objavi"
 msgid "published"
 msgstr "objavljeno"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11233,6 +11489,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "više..."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11252,6 +11520,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Kada završite odjavite se ili izađete iz preglednika."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11282,6 +11554,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11408,6 +11684,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11659,6 +11959,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Jučer"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12021,6 +12325,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12086,6 +12394,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12094,6 +12418,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/hu/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/hu/LC_MESSAGES/plone.po
@@ -3583,6 +3583,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6440,9 +6444,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr "Régebbi típusú portletek szerepelnek itt. Kattintson a gombra ahhoz, hogy új stílusú portletekké alakítsuk át őket."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6453,6 +6465,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6479,6 +6499,10 @@ msgstr "Biztos, hogy törölni akarja ezt a mappát a benne lévő tartalommal e
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
 msgstr "ABC sorrendben"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
+msgstr ""
 
 #. Default: "<any>"
 #: Archetypes/ArchetypeTool.py:848
@@ -6615,6 +6639,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6782,6 +6814,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr "időrend szerint (az első a legújabb)"
@@ -6810,6 +6850,10 @@ msgstr "Aktuális fájl törlése"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Aktuális kép törlése"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7365,6 +7409,14 @@ msgstr "Felhasználóként regisztráltuk oldalunkon."
 msgid "description_you_can_log_on_now"
 msgstr "Kattintson az alábbi gombra az azonnali bejelentkezéshez."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7391,6 +7443,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7461,6 +7517,14 @@ msgstr "${name} megadása kötelező, kérjük töltse ki a mezőt."
 msgid "error_vocabulary"
 msgstr "${val} érték nem megengedett az ${label} szótáránál."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7479,6 +7543,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8759,8 +8838,31 @@ msgstr "html"
 msgid "if_all_conditions_met"
 msgstr "Ha minden itt felsorolt követelmény teljesült:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11019,6 +11121,10 @@ msgstr "A sütin (cookie) alapuló bejelentkezés nem működik, mivel a sütik 
 msgid "login_portlet_disabled"
 msgstr "A sütin (cookie) alapuló azonosítás letiltva. A belépésre szolgáló oldalsó doboz letiltva."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11104,6 +11210,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11129,6 +11283,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 #, fuzzy
@@ -11149,6 +11307,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Nincs megjegyzés."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11174,6 +11366,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "vagy töltsön föl egy fájlt (a már létező fájlt felülírja)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11182,6 +11394,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11201,6 +11417,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11227,6 +11451,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11250,6 +11478,34 @@ msgstr "publikál"
 msgid "published"
 msgstr "publikálva"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11262,6 +11518,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "Tovább…"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11281,6 +11549,10 @@ msgstr "fontosság"
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Kérem, jelentkezzen ki vagy zárja be a böngészőjét, miután befejezte a műveletet."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11311,6 +11583,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11438,6 +11714,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11689,6 +11989,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Tegnap"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12054,6 +12358,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr "Egy tartalomtípus munkamenetének frissítése időt vesz igénybe, és jelentősen lelassíthatja az oldalt, míg a tartalom az új beállításoknak megfelelően frissítésre nem kerül."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12119,6 +12427,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr "Tartalomszabályok globálisan letiltva. A hozzárendelt szabályok nem kerülnek végrehajtásra, mindaddig, amíg újra engedélyezésre kerülnek. Engedélyezze őket újból a ${controlpanel_link} segítségével."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 #, fuzzy
@@ -12129,6 +12453,54 @@ msgstr "Munkafolyamat szabályozása"
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Ezt az elemet jelenleg ${creator} szerkeszti: ${working_copy}, létrehozva: ${created}."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/hy/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/hy/LC_MESSAGES/plone.po
@@ -3574,6 +3574,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6430,9 +6434,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6443,6 +6455,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6467,6 +6487,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6604,6 +6628,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6771,6 +6803,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6798,6 +6838,10 @@ msgstr ""
 #. Default: "Delete current image"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
 msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
@@ -7352,6 +7396,14 @@ msgstr "Ձեր անդամակցությունը գրանցված է: "
 msgid "description_you_can_log_on_now"
 msgstr "Սեղմեք կոճակը համակարգի մեջ անմիջապես մտնելու համար: "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7378,6 +7430,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7447,6 +7503,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7465,6 +7529,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8737,8 +8816,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10990,6 +11092,10 @@ msgstr "Կուկիների վրա հիմնված մուտքը հասանելի �
 msgid "login_portlet_disabled"
 msgstr "Կուկիների աուտենտիկացիան անջատված է:  Մուտքի գործիքը հասանելի չէ:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11075,6 +11181,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11100,6 +11254,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11119,6 +11277,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Նշում չկա:"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11144,6 +11336,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11152,6 +11364,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11171,6 +11387,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11197,6 +11421,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11220,6 +11448,34 @@ msgstr "հրապարակել"
 msgid "published"
 msgstr "հրապարակված "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11232,6 +11488,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "Շարունակություն "
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11251,6 +11519,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Չմոռանաք փակել բրաուզերը աշխատանքի վերջում: "
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11281,6 +11553,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11407,6 +11683,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11658,6 +11958,10 @@ msgstr ": "
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Երեկ "
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12020,6 +12324,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12085,6 +12393,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12093,6 +12417,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/id/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/id/LC_MESSAGES/plone.po
@@ -3574,6 +3574,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6430,9 +6434,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr "Mengubah portlet turunan"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6443,6 +6455,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6467,6 +6487,10 @@ msgstr "Yakin akan menghapus pelipat ini?"
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6603,6 +6627,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6770,6 +6802,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6798,6 +6838,10 @@ msgstr "Hapus berkas"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Hapus gambar"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7350,6 +7394,14 @@ msgstr "Anda telah terdaftar."
 msgid "description_you_can_log_on_now"
 msgstr "Klik pada tombol ini untuk langsung login"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7376,6 +7428,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7445,6 +7501,14 @@ msgstr "${name}\" harus di isikan, silakan dibenahi"
 msgid "error_vocabulary"
 msgstr "${val} tidak diperkenankan untuk elemen ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7463,6 +7527,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8725,8 +8804,31 @@ msgstr ""
 msgid "if_all_conditions_met"
 msgstr "Bila semua prasyarat terpenuhi"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10965,6 +11067,10 @@ msgstr "Karena autentikasi dengan cookie tidak diaktifkan, maka login berbasis c
 msgid "login_portlet_disabled"
 msgstr "Authentikasi dengan cookie tidak aktif. Portlet login tidak tersedia."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11050,6 +11156,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11075,6 +11229,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11094,6 +11252,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Belum ada komentar"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11119,6 +11311,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "atau unggah berkas baru (berkas yang ada akan ditimpa)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11127,6 +11339,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11146,6 +11362,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11172,6 +11396,10 @@ msgstr "Jangan diblok"
 msgid "portlets_value_use_parent"
 msgstr "Gunakan pengaturan dari induknya"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11195,6 +11423,34 @@ msgstr "publis"
 msgid "published"
 msgstr "dipublikasikan"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11206,6 +11462,18 @@ msgstr ""
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Baca Selengkapnya"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11225,6 +11493,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Silahkan keluar atau tutup Browser Anda jika selesai."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11255,6 +11527,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11380,6 +11656,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11630,6 +11930,10 @@ msgstr "Pemisah waktu"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Kemarin"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -11993,6 +12297,10 @@ msgstr "Kebijakan pem-versi-an:"
 msgid "types_controlpanel_warn_remap"
 msgstr "Mengubah alurkerja suatu tipe akan butuh waktu, dan mungkin akan memperlambat kinerja situs saat kontennya diperbaharui sesuai dengan pengaturan yang baru."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12058,6 +12366,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12067,6 +12391,54 @@ msgstr "Aturan konten telah dinon-aktifkan secara global. Tidak akan ada aturan 
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Item ini telah diedit oleh ${creator} dalam ${working_copy} yang dibuat pada ${created}"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/it/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/it/LC_MESSAGES/plone.po
@@ -3583,6 +3583,10 @@ msgstr "Nessun contenuto da migrare."
 msgid "No email address is registered for member: ${member_id}"
 msgstr "Nessun indirizzo Email registrato per l'utente: ${member_id}"
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr "Nessun file fornito"
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "Nessuna immagine trovata in questa collezione"
@@ -6441,10 +6445,18 @@ msgstr "Prefisso dell'URL assoluto"
 msgid "action_convert_legacy_portlets"
 msgstr "Ci sono portlet obsoleti definiti qui. Clicca sul pulsante per convertirli al nuovo stile."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
 msgstr "Commenta"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
+msgstr ""
 
 #. Default: "Add new fieldset…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:13
@@ -6454,6 +6466,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6479,6 +6499,10 @@ msgstr "Vuoi veramente eliminare questa cartella e tutto quello che contiene?"
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
 msgstr "alfabeticamente"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
+msgstr ""
 
 #. Default: "<any>"
 #: Archetypes/ArchetypeTool.py:848
@@ -6615,6 +6639,14 @@ msgstr "Elimina"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
 msgstr "Approva"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
+msgstr ""
 
 #. Default: "Cancel"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:101
@@ -6781,6 +6813,14 @@ msgstr "Tema corrente"
 msgid "current_theme_description"
 msgstr "Il nome del tema corrente, es. quello applicato per ultimo"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr "Data (prima i più recenti)"
@@ -6809,6 +6849,10 @@ msgstr "Elimina il file corrente"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Elimina l'immagine corrente"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7364,6 +7408,14 @@ msgstr "Sei stato registrato nel sito."
 msgid "description_you_can_log_on_now"
 msgstr "Clicca sul pulsante per accedere al sito immediatamente."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7391,6 +7443,10 @@ msgstr "Modifica commento"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
 msgstr "Modifica commento"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
+msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
 #: plone.app.openid/plone/app/openid/skins/ploneopenid/login_form.cpt:156
@@ -7459,6 +7515,14 @@ msgstr "${name} è un campo obbligatorio, inserisci l'informazione richiesta."
 msgid "error_vocabulary"
 msgstr "Il valore ${val} non è consentito dal dizionario dell'elemento ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7478,6 +7542,21 @@ msgstr ""
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
 msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr "Mantieni il file corrente"
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr "Rimuovi il file corrente"
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
+msgstr "Sostituisci con il nuovo file"
 
 #: CMFPlone/browser/templates/search.pt:283
 #: plone.app.querystring/plone/app/querystring/results.pt:71
@@ -8734,9 +8813,32 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Se tutte le seguenti condizioni sono soddisfatte:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr "Mantieni l'immagine corrente"
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr "Rimuovi l'immagine corrente"
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr "Sostituisci con la nuova immagine"
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
 msgstr "in caratteri"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
+msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
 #: plone.app.layout/plone/app/layout/dashboard/dashboard.py:32
@@ -10976,6 +11078,10 @@ msgstr "Dal momento che l'autenticazione con i cookie è disabilitata, non è po
 msgid "login_portlet_disabled"
 msgstr "L'autenticazione con i cookie risulta disabilitata. Il portlet per il login non è disponibile."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11077,6 +11183,54 @@ msgstr "Migra i contenuti di default a dexterity"
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr "sezione sulla migrazione nella documentazione di plone.app.contenttypes"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11102,6 +11256,10 @@ msgstr "Devi impostare una password o scegliere un'email"
 msgid "msg_text_too_long"
 msgstr "Il testo è troppo lungo: può essere al massimo ${max} caratteri. "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11121,6 +11279,40 @@ msgstr "No"
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Nessun commento."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr "Nessun file"
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr "Nessuna immagine"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11146,6 +11338,26 @@ msgstr "o"
 msgid "or_upload_a_file"
 msgstr "oppure carica un file (che rimpiazzerà l'attuale contenuto)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11155,6 +11367,10 @@ msgstr "Altri parametri (expressions)"
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
 msgstr "Puoi definire dei parametri aggiuntivi da passare al tema. All'interno del file delle regole ti puoi riferire ad uno qualsiasi di questi parametri con $name. I parametri sono definiti utilizzando espressioni TALES che possono ritornare una stringa, un numero, un booleano o None. Sono disponibili le seguenti variabili: `context`, `request`, `portal`, `portal_state`,  and `context_state`."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
+msgstr ""
 
 #. Default: "pending"
 #: workflow state defined in plone_workflow - title Pending
@@ -11173,6 +11389,14 @@ msgstr "plone.app.collection"
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11199,6 +11423,10 @@ msgstr "Non bloccare"
 msgid "portlets_value_use_parent"
 msgstr "Usa le impostazioni ereditate"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11222,6 +11450,34 @@ msgstr "pubblica"
 msgid "published"
 msgstr "pubblicato"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11233,6 +11489,18 @@ msgstr "Leggi dalla rete"
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Leggi il resto"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11252,6 +11520,10 @@ msgstr "rilevanza"
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Quando hai finito, ricordati di disconnetterti o di uscire dal browser."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11283,6 +11555,10 @@ msgstr "File delle regole"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
 msgstr "Path del file con le regole del tema"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
+msgstr ""
 
 #. Default: "Select Prefix"
 #: plone.app.registry/plone/app/registry/browser/records.pt:62
@@ -11421,6 +11697,30 @@ msgstr "Etichette da aggiungere"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
 msgstr "Etichette da rimuovere"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
+msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
 msgid "test wc workflow"
@@ -11673,6 +11973,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Da ieri"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12034,6 +12338,10 @@ msgstr "Politica di versionamento:"
 msgid "types_controlpanel_warn_remap"
 msgstr "La modifica del workflow di un tipo di contenuto può richiedere un po' di tempo. Durante questa operazione il sito potrebbe risultare rallentato in maniera significativa."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12099,6 +12407,22 @@ msgstr "Lingua non definita (vale l'impostazione predefinita del sito)"
 msgid "warning_contentrules_disabled"
 msgstr "Le regole di contenuto sono disabilitate globalmente. Nessuna regola assegnata verrà eseguita finché non saranno riabilitate. Usa il ${controlpanel_link} per abilitarle di nuovo."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12108,6 +12432,54 @@ msgstr "Politica..."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Questo elemento è in modifica da parte di ${creator} in ${working_copy} dal ${created}."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/ja/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/ja/LC_MESSAGES/plone.po
@@ -3591,6 +3591,10 @@ msgstr "移行するコンテンツなし"
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "このコレクションに画像は見つかりません。"
@@ -6447,10 +6451,18 @@ msgstr "URLプリフィックス(絶対指定)"
 msgid "action_convert_legacy_portlets"
 msgstr "ここでレガシーポートレットが定義されています。新スタイルポートレットに変換するにはボタンを押してください。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
 msgstr "コメント"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
+msgstr ""
 
 #. Default: "Add new fieldset…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:13
@@ -6460,6 +6472,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6485,6 +6505,10 @@ msgstr "このフォルダとその中のコンテンツを本当に削除しま
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
 msgstr "アルファベット順"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
+msgstr ""
 
 #. Default: "<any>"
 #: Archetypes/ArchetypeTool.py:848
@@ -6621,6 +6645,14 @@ msgstr "削除する"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
 msgstr "承認する"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
+msgstr ""
 
 #. Default: "Cancel"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:101
@@ -6787,6 +6819,14 @@ msgstr "現在のテーマ"
 msgid "current_theme_description"
 msgstr "現在のテーマの名前。言い換えれば、最も最近適用されたテーマの名前。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr "日付（新しいもの順）"
@@ -6815,6 +6855,10 @@ msgstr "現在のファイルを削除"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "現在の画像を削除"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7370,6 +7414,14 @@ msgstr "登録されました。"
 msgid "description_you_can_log_on_now"
 msgstr "すぐにログインするにはボタンをクリックしてください。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7398,6 +7450,10 @@ msgstr "コメントを編集"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
 msgstr "コメントを編集"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
+msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
 #: plone.app.openid/plone/app/openid/skins/ploneopenid/login_form.cpt:156
@@ -7466,6 +7522,14 @@ msgstr "${name} が必要です。正しく入れてください。"
 msgid "error_vocabulary"
 msgstr "値 ${val} は要素 ${label} の語彙として許されていません。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7484,6 +7548,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8748,8 +8827,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "追加条件の指定"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10989,6 +11091,10 @@ msgstr "クッキー認証が無効なので、クッキーベースのログイ
 msgid "login_portlet_disabled"
 msgstr "クッキー認証が無効です。ログインポートレットが使えません。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11090,6 +11196,54 @@ msgstr "デフォルトのコンテンツタイプを Dexterity に移行"
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr "plone.app.contenttypes のドキュメンテーション内の Migrationのセクション"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11115,6 +11269,10 @@ msgstr "パスワードを設定するか、あるいはメールを送るを選
 msgid "msg_text_too_long"
 msgstr "テキストが長過ぎます。(最大 ${max} 文字)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 #, fuzzy
@@ -11135,6 +11293,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "コメントなし"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11160,6 +11352,26 @@ msgstr "または"
 msgid "or_upload_a_file"
 msgstr "またはファイルをアップロード（既存コンテンツは置き換えられます）"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11169,6 +11381,10 @@ msgstr "パラメータ式"
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
 msgstr "コンパイルされたテーマに渡すパラメータを、ここで定義することができます。ルールファイルの中で、 $name を使ってパラメータを参照できます。パラメータは TALES式を使って定義され、文字列、数値、ブーリアン、None へと評価されます。利用可能な変数は `context`, `request`, `portal`, `portal_state`, `context_state` です。"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
+msgstr ""
 
 #. Default: "pending"
 #: workflow state defined in plone_workflow - title Pending
@@ -11187,6 +11403,14 @@ msgstr "plone.app.collection"
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11213,6 +11437,10 @@ msgstr "ブロックしない"
 msgid "portlets_value_use_parent"
 msgstr "上位の設定を使う"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11236,6 +11464,34 @@ msgstr "公開"
 msgid "published"
 msgstr "公開中"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11247,6 +11503,18 @@ msgstr "ネットワークから読む"
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "もっと読む"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11266,6 +11534,10 @@ msgstr "関連性"
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "利用後はログアウトするかブラウザを終了してください。"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11297,6 +11569,10 @@ msgstr "ルールファイル"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
 msgstr "ルールファイルへのファイルパス"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
+msgstr ""
 
 #. Default: "Select Prefix"
 #: plone.app.registry/plone/app/registry/browser/records.pt:62
@@ -11432,6 +11708,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11681,6 +11981,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "昨日"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12044,6 +12348,10 @@ msgstr "バージョニングポリシー"
 msgid "types_controlpanel_warn_remap"
 msgstr "タイプのワークフローを変更することは時間がかかります。さらに、コンテンツが新しいセッティングにアップデートされる間、このサイトの動作速度を著しく低下させるかもしれません。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12109,6 +12417,22 @@ msgstr "言語中立（サイトデフォルト）"
 msgid "warning_contentrules_disabled"
 msgstr "コンテンツルールがサイト全体で無効になっています。有効になるまで、適用されたルールは実行されません。コンテンツルールをもう一度有効にするには、${controlpanel_link} を使います。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12118,6 +12442,54 @@ msgstr "ポリシー..."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "このアイテムは ${created} に作成された ${working_copy} の中で ${creator} によって編集されている最中です。"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/ka/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/ka/LC_MESSAGES/plone.po
@@ -3574,6 +3574,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6423,9 +6427,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6436,6 +6448,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6461,6 +6481,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6601,6 +6625,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6768,6 +6800,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6796,6 +6836,10 @@ msgstr "მიმდინარე ფაილის წაშლა"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "მიმდინარე ნახატის წაშლა"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7347,6 +7391,14 @@ msgstr "თქვენ დარეგისტრირდით როგო�
 msgid "description_you_can_log_on_now"
 msgstr "დაუყოვნებლივ შესასვლელად დაწკაპეთ ეს ღილაკი."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7373,6 +7425,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7442,6 +7498,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7460,6 +7524,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8738,8 +8817,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11002,6 +11104,10 @@ msgstr "სანამ ბმულების საშუალებით 
 msgid "login_portlet_disabled"
 msgstr "მულების საშუალებით აუთენტიფიკაცია გამორთულია.  შესვლა დაბლოკილია."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11087,6 +11193,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11112,6 +11266,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11131,6 +11289,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "უკომენტაროდ."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11156,6 +11348,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "ან ფაილის ატვირთვა (არსებული შიგთავსი შეიცვლება)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11164,6 +11376,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11183,6 +11399,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11209,6 +11433,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11232,6 +11460,34 @@ msgstr "გამოქვეყნება"
 msgid "published"
 msgstr "გამოქვეყნდა"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11244,6 +11500,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "დამატებით"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11263,6 +11531,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "სამუშაოს დამთავრების შემდეგ არ დაგავიწყდეთ სისტემიდან გამოსვლა ან ბრაუხერის დახურვა."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11293,6 +11565,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11421,6 +11697,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11674,6 +11974,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "გუშინ"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12038,6 +12342,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12103,6 +12411,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12111,6 +12435,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/kn/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/kn/LC_MESSAGES/plone.po
@@ -3576,6 +3576,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6426,9 +6430,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6439,6 +6451,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6464,6 +6484,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6606,6 +6630,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6773,6 +6805,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6801,6 +6841,10 @@ msgstr "ಸದ್ಯದ ಕಡತವನ್ನು ಅಳಿಸು"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "ಸದ್ಯದ ಚಿತ್ರವನ್ನು ಅಳಿಸು"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7363,6 +7407,14 @@ msgstr "You have been registered as a member."
 msgid "description_you_can_log_on_now"
 msgstr "Click the button to log in immediately."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7389,6 +7441,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7459,6 +7515,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7477,6 +7541,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8782,8 +8861,31 @@ msgstr "ಎಚ್‌ಟಿಎಮ್ಎಲ್"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11090,6 +11192,10 @@ msgstr "ಕುಕೀ ದೃಢೀಕರಣ ಸಕ್ರಿಯವಾಗಿಲ್�
 msgid "login_portlet_disabled"
 msgstr "While cookie authentication is disabled, cookie-based login is not available."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11175,6 +11281,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11200,6 +11354,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11219,6 +11377,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "ಯಾವುದೇ ಟಿಪ್ಪಣಿಯಿಲ್ಲ "
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11244,6 +11436,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "ಅಥವಾ ಕಡತ ಸೇರಿಸಿ (ಇರುವ ಕಡತದ ಬದಲಾಗಿ) "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11252,6 +11464,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11271,6 +11487,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11297,6 +11521,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11320,6 +11548,34 @@ msgstr "ಪ್ರಕಟಿಸು"
 msgid "published"
 msgstr "ಪ್ರಕಟಿತಗೊಂಡಿದೆ"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11332,6 +11588,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "ಹೆಚ್ಚಿಗೆ ಓದು"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11351,6 +11619,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "ಕೆಲಸ ಮುಗಿದಾಗ ಪ್ರವೇಶ ತೊರೆಯಿರಿ ಅಥವಾ ಬ್ರೌಸರನ್ನು ಮುಚ್ಚಿ."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11381,6 +11653,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11511,6 +11787,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11768,6 +12068,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Yesterday"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12134,6 +12438,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12199,6 +12507,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 #, fuzzy
@@ -12208,6 +12532,54 @@ msgstr "ಸ್ಥಳೀಯ ಕಾರ್ಯಹರಿವು ನೀತಿಯನ್�
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/ko/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/ko/LC_MESSAGES/plone.po
@@ -3576,6 +3576,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6432,9 +6436,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6445,6 +6457,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6470,6 +6490,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6607,6 +6631,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6774,6 +6806,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6803,6 +6843,10 @@ msgstr "현재 파일 삭제"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "현재 이미지 삭제"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7361,6 +7405,14 @@ msgstr "오서오세요. 회원이 되셨습니다."
 msgid "description_you_can_log_on_now"
 msgstr "지금 바로 로그인하시려면 이 버튼을 클릭하세요."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7387,6 +7439,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7456,6 +7512,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7474,6 +7538,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8750,8 +8829,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11016,6 +11118,10 @@ msgstr ""
 msgid "login_portlet_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11101,6 +11207,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11126,6 +11280,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11145,6 +11303,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "코멘트 없음."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11170,6 +11362,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "혹은 파일 업로드하기 (기존에 있던 컨텐트는 교체됩니다)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11178,6 +11390,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11197,6 +11413,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11223,6 +11447,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11246,6 +11474,34 @@ msgstr "일반공개"
 msgid "published"
 msgstr "일반공개"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11258,6 +11514,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "전문읽기"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11277,6 +11545,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "더 이상 사용하지 않으려면 로그아웃 하시거나 브라우저를 종료해 주세요."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11307,6 +11579,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11434,6 +11710,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11689,6 +11989,10 @@ msgstr "어제"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "어제"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12052,6 +12356,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12117,6 +12425,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 #, fuzzy
@@ -12126,6 +12450,54 @@ msgstr "정책"
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/lt/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/lt/LC_MESSAGES/plone.po
@@ -3583,6 +3583,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6444,9 +6448,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr "Čia yra apibrėžtų palikimo langelių. Spragletkite mygtuką, kad paversti juos naujoviškus langelius."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6457,6 +6469,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6481,6 +6501,10 @@ msgstr "Ar iš tikrųjų norite pašalinti šį katalogą kartu su jo turiniu?"
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6618,6 +6642,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6785,6 +6817,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6813,6 +6853,10 @@ msgstr "Ištrinti šį failą"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Ištrinti šį paveikslėlį"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7375,6 +7419,14 @@ msgstr "Jūs esate įregistruotas narys"
 msgid "description_you_can_log_on_now"
 msgstr "Paspauskite mygtuką, kad galėtumėte prisijungti"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7401,6 +7453,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7471,6 +7527,14 @@ msgstr "${name} yra būtina, pataisykite."
 msgid "error_vocabulary"
 msgstr "Reikšmė ${val} yra neleistina elemento ${label} žodyne."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7489,6 +7553,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8762,8 +8841,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Jei visos šios sąlygos patenkintos."
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11020,6 +11122,10 @@ msgstr "Kol atjungtas 'cookie' autorizavimas, 'cookie' pagrįstas prisijungimas 
 msgid "login_portlet_disabled"
 msgstr "'Cookie' pagrįstas prisijungimas atjungtas. Prisijungimo 'portlet' negalimas."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11105,6 +11211,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11130,6 +11284,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11149,6 +11307,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Nėra komentarų."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11174,6 +11366,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "arba įkelkite failą (esamas turinys bus pakeistas)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11182,6 +11394,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11201,6 +11417,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11227,6 +11451,10 @@ msgstr "Visada rodyti"
 msgid "portlets_value_use_parent"
 msgstr "Naudoti tėvines nuostatas"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11250,6 +11478,34 @@ msgstr "publikuoti"
 msgid "published"
 msgstr "publikuotas"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11262,6 +11518,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "Skaityti daugiau"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11281,6 +11549,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Prašome atsijungti arba uždaryti naršyklę, kada baigsite darbą."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11311,6 +11583,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11440,6 +11716,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11691,6 +11991,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "vakar"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12056,6 +12360,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr "Tipo darbo eigos keitimas gali šiek tiek užtrukti ir ganėtinai sulėtinti tinklalapį, kol turinys bus atnaujintas naujoms nuostatoms."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12121,6 +12429,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr "Turinio taisyklės yra atjungtos. Jokios priskirtos taisyklės neveiks kol nebus įgalintos. Naudokite ${controlpanel_link} joms vėl įgalinti."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 #, fuzzy
@@ -12130,6 +12454,54 @@ msgstr "Elgsena"
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/lv/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/lv/LC_MESSAGES/plone.po
@@ -3573,6 +3573,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6425,9 +6429,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr "Šeit ir definēti pārmantotie (<i>legacy</i>) portleti. Klikšķiniet pogu, lai pārveidotu tos uz jaunā stila portletiem."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6438,6 +6450,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6462,6 +6482,10 @@ msgstr "Vai tu tiešām vēlies dzēst šo mapi un visu tās saturu?"
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6599,6 +6623,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6766,6 +6798,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6794,6 +6834,10 @@ msgstr "Dzēst pašreizējo failu"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Dzēst pašreizējo attēlu"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7347,6 +7391,14 @@ msgstr "Jūs esat ticis reģistrēts."
 msgid "description_you_can_log_on_now"
 msgstr "Klikšķiniet pogu, lai nekavējoties pieslēgtos."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7373,6 +7425,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7443,6 +7499,14 @@ msgstr "${name} ir obligāts, lūdzu, izlabojiet."
 msgid "error_vocabulary"
 msgstr "Vērtība ${val} nav atļauta elementa ${label} vārdnīcai."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7461,6 +7525,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8727,8 +8806,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Ja visi no sekojošajiem apstākļiem ir apmierināti:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10993,6 +11095,10 @@ msgstr "Kamēr cepumiņu autentifikācija ir izslēgta, uz cepumiņiem balstīt�
 msgid "login_portlet_disabled"
 msgstr "Cepumiņu autentifikācija ir izslēgta. Pieslēgšanās portlets nav pieejams."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11078,6 +11184,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11103,6 +11257,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11122,6 +11280,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Bez komentāriem."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11147,6 +11339,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "vai augšupielādēt failu (esošais saturs tiks aizvietots)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11155,6 +11367,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11174,6 +11390,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11201,6 +11425,10 @@ msgstr "Vienmēr rādīt"
 msgid "portlets_value_use_parent"
 msgstr "Izmantot vecāku iestatījumus"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11224,6 +11452,34 @@ msgstr "publicēt"
 msgid "published"
 msgstr "publicēts"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11236,6 +11492,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "Lasīt vairāk…"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11255,6 +11523,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Lūdzu, atslēdzieties vai izejiet no sava pārlūka, kad esat beiguši."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11285,6 +11557,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11427,6 +11703,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11676,6 +11976,10 @@ msgstr ""
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Vakar"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12038,6 +12342,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12103,6 +12411,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12111,6 +12435,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/mi/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/mi/LC_MESSAGES/plone.po
@@ -3574,6 +3574,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6423,9 +6427,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6436,6 +6448,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6460,6 +6480,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6596,6 +6620,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6763,6 +6795,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6790,6 +6830,10 @@ msgstr ""
 #. Default: "Delete current image"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
 msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
@@ -7340,6 +7384,14 @@ msgstr ""
 msgid "description_you_can_log_on_now"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7366,6 +7418,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7435,6 +7491,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7453,6 +7517,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8704,8 +8783,31 @@ msgstr ""
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10940,6 +11042,10 @@ msgstr ""
 msgid "login_portlet_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11025,6 +11131,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11050,6 +11204,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11068,6 +11226,40 @@ msgstr ""
 #. Default: "No comments."
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
 msgstr ""
 
 #. Default: "Keep existing file"
@@ -11094,6 +11286,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11102,6 +11314,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11121,6 +11337,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11147,6 +11371,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11170,6 +11398,34 @@ msgstr ""
 msgid "published"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11180,6 +11436,18 @@ msgstr ""
 #: CMFPlone/skins/plone_content/folder_summary_view.pt:105
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
 msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
@@ -11199,6 +11467,10 @@ msgstr ""
 #. Default: "Please log out or exit your browser when you're done."
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
 msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
@@ -11230,6 +11502,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11355,6 +11631,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11603,6 +11903,10 @@ msgstr ""
 #. Default: "Yesterday"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
 msgstr ""
 
 #. Default: "Actions for the current content item"
@@ -11965,6 +12269,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12030,6 +12338,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12038,6 +12362,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/mk_MK/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/mk_MK/LC_MESSAGES/plone.po
@@ -3578,6 +3578,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6429,9 +6433,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6442,6 +6454,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6466,6 +6486,10 @@ msgstr "Дали навистина сакате да ја избришите о
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6606,6 +6630,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6773,6 +6805,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6801,6 +6841,10 @@ msgstr "Избриши оваа датотека"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Избриши оваа слика"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7358,6 +7402,14 @@ msgstr "зачленети сте."
 msgid "description_you_can_log_on_now"
 msgstr "сега можете да се вклучите на страницата."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7384,6 +7436,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7454,6 +7510,14 @@ msgstr "Неопходно е: ${name}.  Ве молиме да го попра�
 msgid "error_vocabulary"
 msgstr "Вредност ${val} не е дозволена во речникот на елементи ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7472,6 +7536,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8749,8 +8828,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11009,6 +11111,10 @@ msgstr "не е достапно."
 msgid "login_portlet_disabled"
 msgstr "портлети исклучени."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11094,6 +11200,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11119,6 +11273,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11138,6 +11296,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Нема коментар."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11163,6 +11355,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "ставите нова датотека"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11171,6 +11383,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11190,6 +11406,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11216,6 +11440,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11239,6 +11467,34 @@ msgstr "објава"
 msgid "published"
 msgstr "објавено"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11251,6 +11507,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "Прочитајте повеќе..."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11270,6 +11538,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Ве молиме одјавете се или искучете разгледач кога ќе завршите."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11300,6 +11572,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11427,6 +11703,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11680,6 +11980,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "вчера"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12042,6 +12346,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12107,6 +12415,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 #, fuzzy
@@ -12116,6 +12440,54 @@ msgstr "работен тек на страницата"
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/my/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/my/LC_MESSAGES/plone.po
@@ -3576,6 +3576,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6432,9 +6436,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6445,6 +6457,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6470,6 +6490,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6610,6 +6634,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6777,6 +6809,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6805,6 +6845,10 @@ msgstr "လက္ရႀိဖိုင္ကို ဖဵက္ရန္"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "လက္ရႀိပံုကို ဖဵက္ရန္"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7360,6 +7404,14 @@ msgstr "သင့္ဟာ အဖၾဲႚဝင္တေယာက္အဴဖ�
 msgid "description_you_can_log_on_now"
 msgstr "အလ႖င္စလို ကၾန္ရက္အဆက္အသၾယ္အတၾင္း ဝင္ခဵင္ရင္ ဒီခလုပ္ကို ႎႀိပ္ပၝ"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7386,6 +7438,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7455,6 +7511,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7473,6 +7537,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8753,8 +8832,31 @@ msgstr ""
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11018,6 +11120,10 @@ msgstr "Cookie ဟုတ္မႀန္ေဳကာင္း ထင္ရႀာ�
 msgid "login_portlet_disabled"
 msgstr "Cookie ဟုတ္မႀန္ေဳကာင္း ထင္ရႀားေစဴခင္းအား မလုပ္ေဆာင္ႎုိင္ေအာင္ ဴဖစ္ထားတယ္။ ကၾန္ရက္သိုႚ ဝင္ေရာက္မႁ portlet အား မရႎိုင္ပၝ။ "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11103,6 +11209,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11128,6 +11282,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11147,6 +11305,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "ဘာမႀတ္ခဵက္မႀ မ႟ႀိပၝ"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11172,6 +11364,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "သိုႚမဟုတ္ ဖိုင္ လၿင့္တင္ဴခင္း (ရႀိႎႀင့္႓ပီးသည့္ အေဳကာင္းအရာေနရာတၾင္ အစားဝင္လိမ့္မည္)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11180,6 +11392,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11199,6 +11415,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11225,6 +11449,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11248,6 +11476,34 @@ msgstr "ထုတ္လၿင့္ရန္"
 msgid "published"
 msgstr "ထုတ္လၿင့္ခဲ့တယ္"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11260,6 +11516,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "အေသးစိတ္ကို ဖတ္႟ႁရန္"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11279,6 +11547,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "သင္ အလုပ္ေတၾ႓ပီးပၝက ကၾန္ရက္အတၾင္းမႀ ထၾက္ပၝ ဒၝမဟုတ္ ကၾန္ရက္ဳကည့္ကိရိယာကို ပိတ္လိုက္ပၝ"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11309,6 +11581,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11437,6 +11713,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11690,6 +11990,10 @@ msgstr ""
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "မေနႚက"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12052,6 +12356,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12117,6 +12425,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 #, fuzzy
@@ -12126,6 +12450,54 @@ msgstr "မူဝၝဒ"
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/nl/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/nl/LC_MESSAGES/plone.po
@@ -3512,6 +3512,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr "Geen bestand opgegeven."
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "Geen afbeeldingen gevonden in deze verzameling."
@@ -6282,6 +6286,7 @@ msgstr "Absoluut URL voorvoegsel"
 msgid "action_convert_legacy_portlets"
 msgstr "Er zijn verouderde portlets gedefinieerd. Click op de button om ze te converteren naar nieuwe stijl portlets."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
 msgid "add"
 msgstr "Toevoegen"
 
@@ -6290,6 +6295,7 @@ msgstr "Toevoegen"
 msgid "add_comment_button"
 msgstr "Commentaar toevoegen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
 msgid "add_date"
 msgstr "Datum toevoegen"
 
@@ -6303,9 +6309,11 @@ msgstr ""
 msgid "add_new_field_hellip"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
 msgid "add_rules"
 msgstr "Toevoegen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
 msgid "additional_date"
 msgstr "Extra datum"
 
@@ -6335,6 +6343,7 @@ msgstr "Wilt u deze map en alle inhoud echt verwijderen?"
 msgid "alphabetically"
 msgstr "alfabetisch"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
 msgid "already_added"
 msgstr "Deze datum is al toegevoegd"
 
@@ -6475,9 +6484,11 @@ msgstr "Verwijderen"
 msgid "bulkactions_publish"
 msgstr "Publiceren"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
 msgid "bysetpos"
 msgstr "BYSETPOS wordt niet ondersteund"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
 msgid "cancel"
 msgstr "Afbreken"
 
@@ -6652,9 +6663,11 @@ msgstr "Huidige thema"
 msgid "current_theme_description"
 msgstr "De naam van het huidige thema, dus degene die het meest recent is toegepast."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
 msgid "daily_interval_1"
 msgstr "Herhaal alle:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
 msgid "daily_interval_2"
 msgstr "dagen"
 
@@ -6687,6 +6700,7 @@ msgstr "Huidige bestand verwijderen"
 msgid "delete_image"
 msgstr "Huidige afbeelding verwijderen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
 msgid "delete_rules"
 msgstr "Wissen"
 
@@ -7358,9 +7372,11 @@ msgstr "U bent geregistreerd."
 msgid "description_you_can_log_on_now"
 msgstr "Klik op de knop om direct in te loggen."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
 msgid "display_activate"
 msgstr "Herhaalt alle "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
 msgid "display_unactivate"
 msgstr "Wordt niet herhaald"
 
@@ -7394,6 +7410,7 @@ msgstr ""
 msgid "edit_comment_form_title"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
 msgid "edit_rules"
 msgstr "Bewerken"
 
@@ -7471,9 +7488,11 @@ msgstr "${name} is vereist, gelieve te corrigeren."
 msgid "error_vocabulary"
 msgstr "Waarden ${val} zijn niet toegestaan voor woordenlijst van element ${label}"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
 msgid "except"
 msgstr ", behalve"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
 msgid "exclude"
 msgstr "Uitsluiten"
 
@@ -7496,6 +7515,21 @@ msgstr ""
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
 msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr "Behoud huidig bestand"
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr "Verwijder huidige bestand"
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
+msgstr "Vervangen door nieuw bestand"
 
 #: CMFPlone/browser/templates/search.pt:283
 #: plone.app.querystring/plone/app/querystring/results.pt:71
@@ -8829,13 +8863,30 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Als aan alle onderstaande condities voldaan wordt:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr "Behoud huidige afbeelding"
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr "Verwijder huidige afbeelding"
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr "Vervangen door nieuwe afbeelding"
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
 msgstr "in karakters"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
 msgid "include"
 msgstr "Meenemen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
 msgid "including"
 msgstr ", en ook "
 
@@ -11082,6 +11133,7 @@ msgstr "Cookies zijn uitgeschakeld. Cookie gebaseerde login is niet mogelijk."
 msgid "login_portlet_disabled"
 msgstr "Cookie authenticatie is uitgeschakeld. De loginbox is niet beschikbaar."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
 msgid "long_date_format"
 msgstr "dddd mmmm dd, yyyy"
 
@@ -11173,36 +11225,51 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
 msgid "monthly_day_of_month_1"
 msgstr "Dag"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
 msgid "monthly_day_of_month_1_human"
 msgstr "op dag"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
 msgid "monthly_day_of_month_2"
 msgstr "van de maand"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
 msgid "monthly_day_of_month_3"
 msgstr "maand(en)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
 msgid "monthly_interval_1"
 msgstr "Herhaal alle:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
 msgid "monthly_interval_2"
 msgstr "maand(en)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
 msgid "monthly_repeat_on"
 msgstr "Herhaal op:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
 msgid "monthly_weekday_of_month_1"
 msgstr "De"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
 msgid "monthly_weekday_of_month_1_human"
 msgstr "op de"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
 msgid "monthly_weekday_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
 msgid "monthly_weekday_of_month_3"
 msgstr "van de maand"
 
@@ -11231,6 +11298,7 @@ msgstr "U dient een wachtwoord in te stellen of ervoor te kiezen een e-mail te s
 msgid "msg_text_too_long"
 msgstr "De tekst is te lang. (Maximum is ${max} tekens.)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
 msgid "multiple_day_of_month"
 msgstr "Dit widget ondersteunt geen meerdere dagen in maandelijkse of jaarlijkse herhalingen"
 
@@ -11255,21 +11323,37 @@ msgstr ""
 msgid "no_comments"
 msgstr "Geen opmerkingen."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
 msgid "no_end_after_n_occurrences"
 msgstr "Fout: Het \"Na N herhalingen\"-veld moet tussen 1 en 1000 liggen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
 msgid "no_end_date"
 msgstr "Fout: Geen einddatum ingesteld. Stel een correcte waarde in."
 
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr "Geen bestand"
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr "Geen afbeelding"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
 msgid "no_repeat_every"
 msgstr "Fout: Het \"Herhaal elke\"-veld moet tussen 1 en 1000 liggen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
 msgid "no_repeat_on"
 msgstr "Fout: \"Herhaal op\"-waarde moet geselecteerd zijn"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
 msgid "no_rule"
 msgstr "Geen RRULE in RRULE-data"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
 msgid "no_template_match"
 msgstr "Geen passende herhalings-template"
 
@@ -11298,18 +11382,23 @@ msgstr "of"
 msgid "or_upload_a_file"
 msgstr "of upload een bestand - dient platte tekst te zijn en is niet geschikt voor Word documenten. Reeds toegevoegde inhoud wordt overschreven."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
 msgid "order_indexes_first"
 msgstr "eerste"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
 msgid "order_indexes_fourth"
 msgstr "vierde"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
 msgid "order_indexes_last"
 msgstr "laatste"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
 msgid "order_indexes_second"
 msgstr "tweede"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
 msgid "order_indexes_third"
 msgstr "derde"
 
@@ -11327,6 +11416,7 @@ msgstr "Parameter uitdrukkingen"
 msgid "parameter_expressions_description"
 msgstr "U kunt hier parameters definiëren die doorgegeven zullen worden aan het gecompileerde thema. In het regels bestand kan gerefereerd worden aan de parameter met $naam. Parameters zijn gedefinieerd met TALES uitdrukkingen die moeten evalueren tot een tekst, getal, boolean of None. De beschikbare variabelen zijn `context`, `request`, `portal`, `portal_state` en `context_state`."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
 msgid "past_end_date"
 msgstr "Fout: Einddatum kan niet voor startdatum liggen"
 
@@ -11347,6 +11437,14 @@ msgstr "plone.app.collection"
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11373,6 +11471,7 @@ msgstr "Altijd tonen"
 msgid "portlets_value_use_parent"
 msgstr "Neem bovenliggende instellingen over"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
 msgid "preview"
 msgstr "Geselecteerde datums"
 
@@ -11399,24 +11498,31 @@ msgstr "publiceren"
 msgid "published"
 msgstr "gepubliceerd"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
 msgid "range"
 msgstr "Einde herhaling:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
 msgid "range_by_end_date"
 msgstr "Tot "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
 msgid "range_by_end_date_human"
 msgstr "eindigt op "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
 msgid "range_by_occurrences_1"
 msgstr "Eindigt na "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
 msgid "range_by_occurrences_1_human"
 msgstr "eindigt na"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
 msgid "range_by_occurrences_2"
 msgstr "herhaling(en)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
 msgid "range_no_end"
 msgstr "Nooit"
 
@@ -11432,12 +11538,15 @@ msgstr "Lees netwerk"
 msgid "read_more"
 msgstr "Lees verder..."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
 msgid "recurrence_start"
 msgstr "Start van de herhaling"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
 msgid "recurrence_type"
 msgstr "Herhaalt zich:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
 msgid "refresh"
 msgstr "Verversen"
 
@@ -11460,6 +11569,7 @@ msgstr "relevantie"
 msgid "remember_to_log_out"
 msgstr "Vergeet niet uit te loggen of de browser te sluiten als u klaar bent."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
 msgid "remove"
 msgstr "Verwijderen"
 
@@ -11495,6 +11605,7 @@ msgstr "Regelbestand"
 msgid "rules_file_path"
 msgstr "Bestandslocatie van het regelbestand"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
 msgid "save"
 msgstr "Opslaan"
 
@@ -11641,21 +11752,27 @@ msgstr ""
 msgid "tags_to_remove"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
 msgid "template_daily"
 msgstr "Dagelijks"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
 msgid "template_mondayfriday"
 msgstr "Maandag en vrijdag"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
 msgid "template_monthly"
 msgstr "Maandelijks"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
 msgid "template_weekdays"
 msgstr "Dag van de week"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
 msgid "template_weekly"
 msgstr "Wekelijks"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
 msgid "template_yearly"
 msgstr "Jaarlijks"
 
@@ -11917,6 +12034,7 @@ msgstr ":"
 msgid "time_yesterday"
 msgstr "Gisteren"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
 msgid "title"
 msgstr "Herhalen"
 
@@ -12287,6 +12405,7 @@ msgstr "Versiebeleid:"
 msgid "types_controlpanel_warn_remap"
 msgstr "Het aanpassen van de workflow van een content type duurt enige tijd. Als een gevolg kan de gehele site merkbaar trager worden tijdens het bijwerken naar deze nieuwe instelling."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
 msgid "unsupported_features"
 msgstr "Waarschuwing: Dit Agenda-item gebruikt herhalings-functies die dit widget niet ondersteunt. De herhaling opslaan kan onbedoeld de herhaling veranderen."
 
@@ -12358,15 +12477,19 @@ msgstr "Taal neutraal (site-standaard)"
 msgid "warning_contentrules_disabled"
 msgstr "Contentregels staan voor de hele site uit. De ingestelde regels worden niet toegepast tot dit wordt ingeschakeld. Gebruik het ${controlpanel_link} om dit in te schakelen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
 msgid "weekly_interval_1"
 msgstr "Herhaal alle:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
 msgid "weekly_interval_2"
 msgstr "we(e)k(en)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
 msgid "weekly_weekdays"
 msgstr "Herhaal op:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
 msgid "weekly_weekdays_human"
 msgstr "op: "
 
@@ -12381,39 +12504,51 @@ msgstr "Workflowbeleid"
 msgid "working_copy_info"
 msgstr "Dit item wordt bewerkt door ${creator} in ${working_copy} aangemaakt op ${created}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
 msgid "yearly_day_of_month_1"
 msgstr "Iedere"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
 msgid "yearly_day_of_month_1_human"
 msgstr "op"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
 msgid "yearly_day_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
 msgid "yearly_day_of_month_3"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
 msgid "yearly_interval_1"
 msgstr "Herhaal alle:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
 msgid "yearly_interval_2"
 msgstr "ja(a)r(en)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
 msgid "yearly_repeat_on"
 msgstr "Herhaal op:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
 msgid "yearly_weekday_of_month_1"
 msgstr "De"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
 msgid "yearly_weekday_of_month_1_human"
 msgstr "op de"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
 msgid "yearly_weekday_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
 msgid "yearly_weekday_of_month_3"
 msgstr "van"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
 msgid "yearly_weekday_of_month_4"
 msgstr " "
 

--- a/plone/app/locales/locales/nn/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/nn/LC_MESSAGES/plone.po
@@ -3575,6 +3575,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6431,9 +6435,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6444,6 +6456,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6468,6 +6488,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6605,6 +6629,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6772,6 +6804,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6799,6 +6839,10 @@ msgstr ""
 #. Default: "Delete current image"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
 msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
@@ -7352,6 +7396,14 @@ msgstr "Du er registrert som brukar."
 msgid "description_you_can_log_on_now"
 msgstr "Bruk knappen under for å logge inn umiddelbart."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7378,6 +7430,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7447,6 +7503,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7465,6 +7529,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8737,8 +8816,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10990,6 +11092,10 @@ msgstr "Sidan innlogging ved hjelp av informasjonskapslar er skrudd av kan du ik
 msgid "login_portlet_disabled"
 msgstr "Informasjonskapsel-basert innlogging er ikkje tilgjengeleg."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11075,6 +11181,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11100,6 +11254,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11119,6 +11277,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Ingen kommentarer."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11144,6 +11336,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11152,6 +11364,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11171,6 +11387,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11197,6 +11421,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11220,6 +11448,34 @@ msgstr "publisert"
 msgid "published"
 msgstr "publisert"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11232,6 +11488,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "Les meir"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11251,6 +11519,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Vennligst logg ut eller lukk nettlesaren når du er ferdig."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11281,6 +11553,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11418,6 +11694,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11669,6 +11969,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "I går"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12031,6 +12335,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12096,6 +12404,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12104,6 +12428,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/no/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/no/LC_MESSAGES/plone.po
@@ -3577,6 +3577,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6433,10 +6437,18 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr "Det er definert eldre infobokser her. Klikk på knappen for å oppgradere dem."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
 msgstr "Kommentér"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
+msgstr ""
 
 #. Default: "Add new fieldset…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:13
@@ -6446,6 +6458,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6471,6 +6491,10 @@ msgstr "Er du sikker på at du vil slette denne mappen og alt innhold?"
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
 msgstr "alfabetisk"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
+msgstr ""
 
 #. Default: "<any>"
 #: Archetypes/ArchetypeTool.py:848
@@ -6607,6 +6631,14 @@ msgstr "Slett"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
 msgstr "Godkjenn"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
+msgstr ""
 
 #. Default: "Cancel"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:101
@@ -6773,6 +6805,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr "dato (siste først)"
@@ -6801,6 +6841,10 @@ msgstr "Slett eksisterende fil"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Slett eksisterende bilde"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7353,6 +7397,14 @@ msgstr "Du er registrert som bruker."
 msgid "description_you_can_log_on_now"
 msgstr "Bruk knappen under for å logge inn umiddelbart."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7379,6 +7431,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7448,6 +7504,14 @@ msgstr "${name} er et obligatorisk felt."
 msgid "error_vocabulary"
 msgstr "Verdien ${val} er ikke blant de tillatte valgmulighetene for elementet ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7466,6 +7530,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8731,8 +8810,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Hvis alle de følgende betingelsene oppfylles:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10980,6 +11082,10 @@ msgstr "Siden innlogging ved hjelp av informasjonskapsler er skrudd av, kan du i
 msgid "login_portlet_disabled"
 msgstr "Informasjonskapsel-basert innlogging er ikke tilgjengelig. Innloggings-boksen er ikke tilgjengelig."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11065,6 +11171,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11090,6 +11244,10 @@ msgstr "Du må enten velge et passord eller velge å få tilsendt en epost."
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 #, fuzzy
@@ -11110,6 +11268,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Ingen kommentarer."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11135,6 +11327,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "eller last opp en fil (eksisterende innhold vil bli erstattet)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11143,6 +11355,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11162,6 +11378,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11188,6 +11412,10 @@ msgstr "Ikke blokkér"
 msgid "portlets_value_use_parent"
 msgstr "Bruk overordnede innstillinger"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11211,6 +11439,34 @@ msgstr "publisert"
 msgid "published"
 msgstr "publisert"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11222,6 +11478,18 @@ msgstr ""
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Les mer…"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11241,6 +11509,10 @@ msgstr "relevans"
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Vennligst logg ut eller lukk nettleseren når du er ferdig."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11271,6 +11543,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11407,6 +11683,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11658,6 +11958,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "I går"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12021,6 +12325,10 @@ msgstr "Versjoneringsregler:"
 msgid "types_controlpanel_warn_remap"
 msgstr "Det tar en stund å endre arbeidsflyten for en type, og dette kan gjøre nettstedet betydelig langsommere mens innholdet blir oppdatert til den nye innstillingen."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12086,6 +12394,22 @@ msgstr "Språknøytralt (standard)"
 msgid "warning_contentrules_disabled"
 msgstr "Innholdsregler deaktiveres globalt. Ingen tildelte regler blir utført før de aktiveres igjen. Bruk ${controlpanel_link}for å aktivere dem igjen."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12095,6 +12419,54 @@ msgstr "Policy…"
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Dette elementet blir redigert av ${creator} i ${working_copy} opprettet ${created}."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/pl/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/pl/LC_MESSAGES/plone.po
@@ -3585,6 +3585,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "Brak obrazów w tej kolekcji."
@@ -6443,9 +6447,17 @@ msgstr "Bezwzględny prefiks URL"
 msgid "action_convert_legacy_portlets"
 msgstr "Wykryto portlety starego typu. Kliknij przycisk, aby przekonwertować je do portletów nowego rodzaju."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6456,6 +6468,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6481,6 +6501,10 @@ msgstr "Czy na pewno chcesz usunąć ten folder i całą jego zawartość?"
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
 msgstr "alfabetycznie"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
+msgstr ""
 
 #. Default: "<any>"
 #: Archetypes/ArchetypeTool.py:848
@@ -6616,6 +6640,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6783,6 +6815,14 @@ msgstr "Bieżący motyw"
 msgid "current_theme_description"
 msgstr "Nazwa bieżącego motywu, np. ostatnio zastosowanego."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr "data (od najnowszych)"
@@ -6811,6 +6851,10 @@ msgstr "Usuń plik"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Usuń obraz"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7366,6 +7410,14 @@ msgstr "Zostałeś zarejestrowany jako użytkownik."
 msgid "description_you_can_log_on_now"
 msgstr "Kliknij w przycisk aby się zalogować."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7393,6 +7445,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7463,6 +7519,14 @@ msgstr "Pole ${name} jest wymagane, prosze uzupełnij je."
 msgid "error_vocabulary"
 msgstr "Wartość ${val} nie jest dozwolona dla słownika elementu ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7481,6 +7545,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8749,8 +8828,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Jeśli wszystkie poniższe warunki są spełnione:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10997,6 +11099,10 @@ msgstr "Jeśli autoryzacja ciasteczkami jest wyłączona, logowanie ciasteczkiem
 msgid "login_portlet_disabled"
 msgstr "Autoryzacja ciasteczkami jest wyłączona, Portlet logowania nie jest dostępny."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11082,6 +11188,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11107,6 +11261,10 @@ msgstr "Musisz ustalić hasło lub wybrać wysyłkę wiadomości e-mail."
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 #, fuzzy
@@ -11127,6 +11285,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Brak komentarzy."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11152,6 +11344,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "lub załaduj plik (zastąpi on istniejący plik)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11161,6 +11373,10 @@ msgstr "Wyrażenia parametrów"
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
 msgstr "Możesz zdefiniować parametry, które zostaną przekazane do skompilowanego motywu. W pliku reguł możesz odwołać się do parametru za pomocą $nazwa. Parametry są definiowane przy użyciu wyrażeń TALES, które powinny zwracać tekst, liczbę, wartość boolowską lub None. Dostępne są zmienne `context`, `request`, `portal`, `portal_state` i `context_state`."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
+msgstr ""
 
 #. Default: "pending"
 #: workflow state defined in plone_workflow - title Pending
@@ -11179,6 +11395,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11206,6 +11430,10 @@ msgstr "Nie blokuj"
 msgid "portlets_value_use_parent"
 msgstr "Jak dla nadrzędnego"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11229,6 +11457,34 @@ msgstr "opublikuj"
 msgid "published"
 msgstr "opublikowane"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11240,6 +11496,18 @@ msgstr "Odczyt przez sieć"
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Czytaj dalej..."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11259,6 +11527,10 @@ msgstr "trafność"
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Wyloguj się proszę lub zamknij okienko przeglądarki kiedy skończysz."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11290,6 +11562,10 @@ msgstr "Plik reguł"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
 msgstr "Ścieżka do pliku reguł"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
+msgstr ""
 
 #. Default: "Select Prefix"
 #: plone.app.registry/plone/app/registry/browser/records.pt:62
@@ -11414,6 +11690,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11666,6 +11966,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Wczoraj"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12030,6 +12334,10 @@ msgstr "Zasada wersjonowania:"
 msgid "types_controlpanel_warn_remap"
 msgstr "Zmiana obiegu informacji zajmie trochę czasu, uaktualnianie treści do nowych ustawień może też znacznie spowolnić witrynę."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12095,6 +12403,22 @@ msgstr "Bezjęzykowy (standardowy)"
 msgid "warning_contentrules_disabled"
 msgstr "Reguły zawartości zostały wyłączone. Żadna z nich się nie wykona jeśli nie zostaną ponownie włączone. Przejdź do ${controlpanel_link} aby je uaktywnić. "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12104,6 +12428,54 @@ msgstr "Zasada"
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Ten element jest edytowany przez ${creator} w ${working_copy} od ${created}."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/plone.pot
+++ b/plone/app/locales/locales/plone.pot
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2016-01-26 16:31+0000\n"
+"POT-Creation-Date: 2016-01-27 12:56+0000\n"
 "PO-Revision-Date: 2006-01-29 23:00+0000\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
@@ -3508,6 +3508,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6265,9 +6269,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6278,6 +6290,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6302,6 +6322,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6438,6 +6462,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6605,6 +6637,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6632,6 +6672,10 @@ msgstr ""
 #. Default: "Delete current image"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
 msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
@@ -7182,6 +7226,14 @@ msgstr ""
 msgid "description_you_can_log_on_now"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7208,6 +7260,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7277,6 +7333,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7295,6 +7359,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8546,8 +8625,31 @@ msgstr ""
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10780,6 +10882,10 @@ msgstr ""
 msgid "login_portlet_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -10865,6 +10971,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -10890,6 +11044,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -10908,6 +11066,40 @@ msgstr ""
 #. Default: "No comments."
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
 msgstr ""
 
 #. Default: "Keep existing file"
@@ -10934,6 +11126,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -10942,6 +11154,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -10961,6 +11177,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -10987,6 +11211,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11010,6 +11238,34 @@ msgstr ""
 msgid "published"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11020,6 +11276,18 @@ msgstr ""
 #: CMFPlone/skins/plone_content/folder_summary_view.pt:105
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
 msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
@@ -11039,6 +11307,10 @@ msgstr ""
 #. Default: "Please log out or exit your browser when you're done."
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
 msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
@@ -11070,6 +11342,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11195,6 +11471,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11443,6 +11743,10 @@ msgstr ""
 #. Default: "Yesterday"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
 msgstr ""
 
 #. Default: "Actions for the current content item"
@@ -11805,6 +12109,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -11870,6 +12178,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -11878,6 +12202,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/pt/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/pt/LC_MESSAGES/plone.po
@@ -3578,6 +3578,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6434,10 +6438,18 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr "Estão aqui definidos portlets herdados de versões anteriores.  Carregue no botão para os converter para portlets do novo estilo."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
 msgstr "Comentar"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
+msgstr ""
 
 #. Default: "Add new fieldset…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:13
@@ -6447,6 +6459,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6471,6 +6491,10 @@ msgstr "Deseja realmente apagar esta pasta e todo o seu conteúdo?"
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6608,6 +6632,14 @@ msgstr "Excluir"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
 msgstr "Publicar"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
+msgstr ""
 
 #. Default: "Cancel"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:101
@@ -6774,6 +6806,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6802,6 +6842,10 @@ msgstr "Apagar o ficheiro corrente"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Apagar a imagem corrente"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7380,6 +7424,14 @@ msgstr "Você foi registado."
 msgid "description_you_can_log_on_now"
 msgstr "Prima o botão para se autenticar imediatamente."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7406,6 +7458,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7475,6 +7531,14 @@ msgstr "${name} é um dado obrigatório; corrija, por favor."
 msgid "error_vocabulary"
 msgstr "Os valores ${val} não são permitidos no vocabulário do elemento ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7493,6 +7557,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8769,8 +8848,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Se todas as condições seguintes forem satisfeitas:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11024,6 +11126,10 @@ msgstr "Uma vez que a autenticação por cookies está desactivada, o acesso (co
 msgid "login_portlet_disabled"
 msgstr "A autenticação por cookies está desactivada.  Portlet de acesso autenticado não disponível."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11120,6 +11226,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11145,6 +11299,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11164,6 +11322,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Sem comentários."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11189,6 +11381,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "ou enviar um ficheiro (o conteúdo existente será substituído)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11197,6 +11409,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11216,6 +11432,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11242,6 +11466,10 @@ msgstr "Não bloquear"
 msgid "portlets_value_use_parent"
 msgstr "Preferências do pai"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11265,6 +11493,34 @@ msgstr "publicar"
 msgid "published"
 msgstr "publicado"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11276,6 +11532,18 @@ msgstr ""
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Ler Mais"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11295,6 +11563,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Por favor saia da sessão autenticada ou feche o seu navegador quando terminar."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11325,6 +11597,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11465,6 +11741,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11715,6 +12015,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Ontem"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12079,6 +12383,10 @@ msgstr "Política de controlo de versões:"
 msgid "types_controlpanel_warn_remap"
 msgstr "Alterar o workflow de um tipo pode levar algum tempo, e pode tornar o sítio significativamente mais lento enquanto o conteúdo é actualizado para a nova configuração."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12144,6 +12452,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr "As regras de conteúdo estão desactivadas globalmente. As regras atribuídas não serão executas enquanto não forem reactivadas. Utilize ${controlpanel_link} para activar novamente."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12153,6 +12477,54 @@ msgstr "Política..."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Este item está a ser editado por ${creator} em ${working_copy} criado em ${created}."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/pt_BR/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/pt_BR/LC_MESSAGES/plone.po
@@ -3585,6 +3585,10 @@ msgstr "Sem conteúdo para migrar"
 msgid "No email address is registered for member: ${member_id}"
 msgstr "Nenhum endereço de e-mail está registrado para membro: ${member_id}"
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr "Nenhum arquivo fornecido."
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "Nenhuma imagem encontrada nesta coleção."
@@ -6441,10 +6445,18 @@ msgstr "Prefixo da URL absoluta"
 msgid "action_convert_legacy_portlets"
 msgstr "Existem portlets antigos definidos aqui. Clique no botão para converte-los para o novo formato de portlets."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
 msgstr "Comentar"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
+msgstr ""
 
 #. Default: "Add new fieldset…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:13
@@ -6455,6 +6467,14 @@ msgstr "Adicionar uma nova aba de configuração"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
 msgstr "Adicionar um novo campo…"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
+msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
 #: plone.app.content/plone/app/content/browser/templates/delete_confirmation.pt:18
@@ -6479,6 +6499,10 @@ msgstr "Você realmente quer apagar esta pasta e todo o seu conteúdo?"
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
 msgstr "alfabeticamente"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
+msgstr ""
 
 #. Default: "<any>"
 #: Archetypes/ArchetypeTool.py:848
@@ -6615,6 +6639,14 @@ msgstr "Excluir"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
 msgstr "Publicar"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
+msgstr ""
 
 #. Default: "Cancel"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:101
@@ -6781,6 +6813,14 @@ msgstr "Tema atual"
 msgid "current_theme_description"
 msgstr "O nome do tema atual (o que foi aplicado mais recentemente)."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr "data (mais recente primeiro)"
@@ -6809,6 +6849,10 @@ msgstr "Excluir arquivo atual"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Excluir imagem atual"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7362,6 +7406,14 @@ msgstr "Você foi registrado."
 msgid "description_you_can_log_on_now"
 msgstr "Clique no botão para acessar agora."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7390,6 +7442,10 @@ msgstr "Editar comentário"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
 msgstr "Editar cometário"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
+msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
 #: plone.app.openid/plone/app/openid/skins/ploneopenid/login_form.cpt:156
@@ -7458,6 +7514,14 @@ msgstr "${name} é obrigatório, favor corrija."
 msgid "error_vocabulary"
 msgstr "O valor ${val} não faz parte do conjunto de valores permitidos no campo ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7477,6 +7541,21 @@ msgstr "O '${value1}' valor do vocabulário conflita com '${value2}'."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
 msgstr "Você não pode definir um nome de vocabulário E os valores do vocabulário. Por favor limpe o campo com os valores ou não defina nenhum valor aqui."
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr "Manter o arquivo atual"
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr "Remover o arquivo atual"
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
+msgstr "Substituir por um novo arquivo"
 
 #: CMFPlone/browser/templates/search.pt:283
 #: plone.app.querystring/plone/app/querystring/results.pt:71
@@ -8735,9 +8814,32 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Caso todas as seguintes condições forem satisfeitas:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr "Manter a imagem atual"
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr "Remover a imagem atual"
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr "Substituir por uma nova imagem"
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
 msgstr "em caracteres"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
+msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
 #: plone.app.layout/plone/app/layout/dashboard/dashboard.py:32
@@ -10981,6 +11083,10 @@ msgstr "Enquanto a autenticação por cookies estiver desativada, o acesso basea
 msgid "login_portlet_disabled"
 msgstr "A autenticação por cookies está desativada. Portlet de acesso não disponível."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11081,6 +11187,54 @@ msgstr "Migrar os conteúdos padrões para Dexterity."
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr "A seção de migração está na documentada em plone.app.contenttypes"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11106,6 +11260,10 @@ msgstr "Você deve definir uma senha ou optar por enviar um e-mail."
 msgid "msg_text_too_long"
 msgstr "Texto muito longo. (Máximo de ${max} caracteres.)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 #, fuzzy
@@ -11126,6 +11284,40 @@ msgstr "não"
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Sem comentários."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr "Sem arquivo"
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr "Sem imagem"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11151,6 +11343,26 @@ msgstr "ou"
 msgid "or_upload_a_file"
 msgstr "ou enviar um arquivo (o conteúdo existente será substituído)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11160,6 +11372,10 @@ msgstr "Expressões dos parâmetros"
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
 msgstr "Você pode definir os parâmetros que serão enviados para o tema compilado. Nas suas regras de conteúdo você pode referenciar um parâmetro por $name. Parametros são definidos utilizando  excpressões TALES, que deve ser avaliada como uma string, um número, booleano ou nenhum. Variáveis disponíveis são 'context', 'request', 'portal', 'portal_state', e 'context_state'. "
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
+msgstr ""
 
 #. Default: "pending"
 #: workflow state defined in plone_workflow - title Pending
@@ -11178,6 +11394,14 @@ msgstr "Coleções"
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11204,6 +11428,10 @@ msgstr "Não bloquear"
 msgid "portlets_value_use_parent"
 msgstr "Utilizar as configurações do nível superior"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11227,6 +11455,34 @@ msgstr "publicar"
 msgid "published"
 msgstr "publicado"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11238,6 +11494,18 @@ msgstr "Ler dados da rede"
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Leia mais…"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11257,6 +11525,10 @@ msgstr "relevância"
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Não esqueça de clicar em sair ou fechar seu navegador quando você acabar."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11288,6 +11560,10 @@ msgstr "Arquivo de regras"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
 msgstr "Caminho para o arquivo de regras"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
+msgstr ""
 
 #. Default: "Select Prefix"
 #: plone.app.registry/plone/app/registry/browser/records.pt:62
@@ -11426,6 +11702,30 @@ msgstr "Adicionar tags"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
 msgstr "Remover tags"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
+msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
 msgid "test wc workflow"
@@ -11675,6 +11975,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Ontem"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12037,6 +12341,10 @@ msgstr "Política de versionamento:"
 msgid "types_controlpanel_warn_remap"
 msgstr "Alterar o workflow de um tipo irá demorar um pouco, além de poder tornar significativamente lento o site enquanto o conteúdo é atualizado para a nova configuração."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12102,6 +12410,22 @@ msgstr "Idioma neutro (padrão do site)"
 msgid "warning_contentrules_disabled"
 msgstr "As regras de conteúdo estão desabilitadas globalmente. Nenhuma atribuição de regras será executada até que elas sejam reativadas. Utilize o ${controlpanel_link} para ativa-las novamente."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12111,6 +12435,54 @@ msgstr "Política local..."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Este item está sendo editado por ${creator} em ${working_copy} criado em ${created}"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/rm/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/rm/LC_MESSAGES/plone.po
@@ -3571,6 +3571,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6420,9 +6424,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6433,6 +6445,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6457,6 +6477,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6593,6 +6617,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6760,6 +6792,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6787,6 +6827,10 @@ msgstr ""
 #. Default: "Delete current image"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
 msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
@@ -7337,6 +7381,14 @@ msgstr ""
 msgid "description_you_can_log_on_now"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7363,6 +7415,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7432,6 +7488,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7450,6 +7514,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8701,8 +8780,31 @@ msgstr ""
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10937,6 +11039,10 @@ msgstr ""
 msgid "login_portlet_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11022,6 +11128,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11047,6 +11201,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11065,6 +11223,40 @@ msgstr ""
 #. Default: "No comments."
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
 msgstr ""
 
 #. Default: "Keep existing file"
@@ -11091,6 +11283,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11099,6 +11311,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11118,6 +11334,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11144,6 +11368,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11167,6 +11395,34 @@ msgstr ""
 msgid "published"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11177,6 +11433,18 @@ msgstr ""
 #: CMFPlone/skins/plone_content/folder_summary_view.pt:105
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
 msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
@@ -11196,6 +11464,10 @@ msgstr ""
 #. Default: "Please log out or exit your browser when you're done."
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
 msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
@@ -11227,6 +11499,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11352,6 +11628,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11600,6 +11900,10 @@ msgstr ""
 #. Default: "Yesterday"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
 msgstr ""
 
 #. Default: "Actions for the current content item"
@@ -11962,6 +12266,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12027,6 +12335,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12035,6 +12359,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/ro/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/ro/LC_MESSAGES/plone.po
@@ -3580,6 +3580,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "Nu a fost găsită nici o imagine în această colecție."
@@ -6437,10 +6441,18 @@ msgstr "prefixul absolut al URL-ului"
 msgid "action_convert_legacy_portlets"
 msgstr "Aici sunt definite portleturile istorice. Apasă butonul pentru a le converti în portleturi moderne."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
 msgstr "Comentariu"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
+msgstr ""
 
 #. Default: "Add new fieldset…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:13
@@ -6450,6 +6462,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6475,6 +6495,10 @@ msgstr "Eşti sigur că vrei să ştergi acest folder şi întreg conţinutul s�
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
 msgstr "alfabetic"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
+msgstr ""
 
 #. Default: "<any>"
 #: Archetypes/ArchetypeTool.py:848
@@ -6611,6 +6635,14 @@ msgstr "Sterge"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
 msgstr "Aproba"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
+msgstr ""
 
 #. Default: "Cancel"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:101
@@ -6777,6 +6809,14 @@ msgstr "Tema curentă"
 msgid "current_theme_description"
 msgstr "Numele temei curente. Ex.: cea mai recent aplicată"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr "dată (cele mai noi, mai întâi)"
@@ -6805,6 +6845,10 @@ msgstr "Şterge fişierul curent"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Şterge imaginea curentă"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7356,6 +7400,14 @@ msgstr "Ai fost înregistrat ca membru."
 msgid "description_you_can_log_on_now"
 msgstr "Apasă acest buton pentru autentificare imediată."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7383,6 +7435,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7452,6 +7508,14 @@ msgstr "error_required"
 msgid "error_vocabulary"
 msgstr "error_vocabulary"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7470,6 +7534,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8733,8 +8812,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Dacă toate condiţiile următoare sunt satisfăcute:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10973,6 +11075,10 @@ msgstr "Atâta timp cât autentificarea cu cookie este dezactivată, login-ul ba
 msgid "login_portlet_disabled"
 msgstr "Autentificarea cu cookies dezactivată. Portletul de login nu este disponibil."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11073,6 +11179,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11098,6 +11252,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 #, fuzzy
@@ -11118,6 +11276,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Nu există comentarii"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11143,6 +11335,26 @@ msgstr "sau"
 msgid "or_upload_a_file"
 msgstr "sau încarcă un fişier (conţinutul existent va fi înlocuit)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11151,6 +11363,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11170,6 +11386,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11196,6 +11420,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11219,6 +11447,34 @@ msgstr "publica"
 msgid "published"
 msgstr "publicat"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11230,6 +11486,18 @@ msgstr ""
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Citeşte mai mult..."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11249,6 +11517,10 @@ msgstr "relevanţa"
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Te rugăm să apeşi pe Ieşire sau să iţi închizi pagina web atunci cand ai terminat."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11279,6 +11551,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11404,6 +11680,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11653,6 +11953,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Ieri"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12015,6 +12319,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12080,6 +12388,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12088,6 +12412,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/ru/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/ru/LC_MESSAGES/plone.po
@@ -3581,6 +3581,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "Изображений в данной коллекции не найдено."
@@ -6437,10 +6441,18 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr "Здесь определены исходные портлеты. Нажав на кнопку, вы можете превратить их в портлеты нового вида."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
 msgstr "Комментировать"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
+msgstr ""
 
 #. Default: "Add new fieldset…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:13
@@ -6450,6 +6462,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6475,6 +6495,10 @@ msgstr "Вы действительно хотите удалить эту па�
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
 msgstr "в алфавитном порядке"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
+msgstr ""
 
 #. Default: "<any>"
 #: Archetypes/ArchetypeTool.py:848
@@ -6610,6 +6634,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6777,6 +6809,14 @@ msgstr "Текущая тема"
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6805,6 +6845,10 @@ msgstr "Удалить файл"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Удалить картинку"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7363,6 +7407,14 @@ msgstr "Вы зарегистрированы как пользователь с
 msgid "description_you_can_log_on_now"
 msgstr "Для входа в систему, нажмите сюда."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7389,6 +7441,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7458,6 +7514,14 @@ msgstr "${name} является обязательным для заполне�
 msgid "error_vocabulary"
 msgstr "Значение ${val} - не разрешенный для словаря элемент ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7476,6 +7540,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8744,8 +8823,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Если все следующие условия выполнены:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11000,6 +11102,10 @@ msgstr "Пока  идентификация при помощи куков от
 msgid "login_portlet_disabled"
 msgstr "Идентификация при помощи cookies отключена. Блок входа недоступен."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11085,6 +11191,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11110,6 +11264,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11129,6 +11287,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Без коментариев."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11154,6 +11346,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "или загрузить новый файл (заменит текущее содержимое)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11162,6 +11374,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11181,6 +11397,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11207,6 +11431,10 @@ msgstr "Не блокировать"
 msgid "portlets_value_use_parent"
 msgstr "Использовать установки родительского объекта"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11230,6 +11458,34 @@ msgstr "Публиковать"
 msgid "published"
 msgstr "Опубликованный"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11241,6 +11497,18 @@ msgstr ""
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Далее"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11260,6 +11528,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "В конце работы не забудьте выйти из системы или закрыть браузер."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11290,6 +11562,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11420,6 +11696,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11671,6 +11971,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Вчера"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12036,6 +12340,10 @@ msgstr "Порядок работы с версиями джокументов:"
 msgid "types_controlpanel_warn_remap"
 msgstr "Смена типа рабочего процесса публикации может занять довольно продолжительное время и снизить скорость работы сайта, пока не будут обновлены все состояния документов."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12101,6 +12409,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr "Использование правил для содержимого отключено. Назначенные правила не будут выполняться, если их не активировать для всего сайта. Перейдите ${controlpanel_link}, чтобы их включить снова."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12110,6 +12434,54 @@ msgstr "Политика рабочего процесса публикации"
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Этот элемент редактируется автором - ${creator} по ${working_copy}, созданной ${created}."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/sk/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/sk/LC_MESSAGES/plone.po
@@ -3574,6 +3574,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "Neboli nájdené žiadne obrázky."
@@ -6423,9 +6427,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr "Sú tu definované portlety v starom štýle. Po kliknutí na tlačitko budú skonvertované do nového štýlu."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6436,6 +6448,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6460,6 +6480,10 @@ msgstr "Skutočne chcete odstrániť tento adresár a celý jeho obsah?"
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6596,6 +6620,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6763,6 +6795,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6791,6 +6831,10 @@ msgstr "Vymazať aktuálny súbor"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Vymazať aktuálny obrázok"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7342,6 +7386,14 @@ msgstr "Registrácia prebehla úspešne."
 msgid "description_you_can_log_on_now"
 msgstr "Stlačte tlačítko na prihlásenie."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7368,6 +7420,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7437,6 +7493,14 @@ msgstr "Uveďte: ${name} - je to požadovaný údaj."
 msgid "error_vocabulary"
 msgstr "Hodnoty ${val} nie sú povolené pre slovník elementu ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7455,6 +7519,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8714,8 +8793,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Ak sú splnené všetky uvedené podmienky:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10955,6 +11057,10 @@ msgstr "Autentifikácia pomocou cookies (kúkíkmi) je vypnutá - cookie login j
 msgid "login_portlet_disabled"
 msgstr "Autentifikácia pomocou cookies (kúkíkmi) je vypnutá - login portlet je nedostupný."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11040,6 +11146,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11065,6 +11219,10 @@ msgstr "Musíte nastaviť heslo alebo zvoliť možnosť pre zaslanie emailu."
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 #, fuzzy
@@ -11085,6 +11243,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Bez komentárov."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11110,6 +11302,26 @@ msgstr "alebo"
 msgid "or_upload_a_file"
 msgstr "alebo vložte (upload) súbor (existujúci obsah bude nahradený novým)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11118,6 +11330,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11137,6 +11353,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11163,6 +11387,10 @@ msgstr "Neblokovať"
 msgid "portlets_value_use_parent"
 msgstr "Použiť nadradené nastavenia"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11186,6 +11414,34 @@ msgstr "publikovať"
 msgid "published"
 msgstr "publikované"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11197,6 +11453,18 @@ msgstr ""
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Viac..."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11216,6 +11484,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Odhláste sa alebo zavrite browser, keď skončíte."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11246,6 +11518,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11383,6 +11659,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11633,6 +11933,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Včera"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -11996,6 +12300,10 @@ msgstr "Spôsob správy verzií:"
 msgid "types_controlpanel_warn_remap"
 msgstr "Zmena pracovného postupu pre nejaký typ môže určitú dobu trvať a významne spomaliť Plone v danom časovom intervale."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12061,6 +12369,22 @@ msgstr "Nezávislé na jazyku (východzie pro portál)"
 msgid "warning_contentrules_disabled"
 msgstr "Pravidlá pre obsah sú globálne deaktivované. Nevykonajú sa žiadne z priradených pravidiel. Použite ${controlpanel_link} na ich opätovnú aktiváciu."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12070,6 +12394,54 @@ msgstr "Lokálne pravidlá"
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Táto položka bola editovaná používateľom ${creator} v ${working_copy}. Dátum vytvorenia ${created}."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/sl/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/sl/LC_MESSAGES/plone.po
@@ -3578,6 +3578,10 @@ msgstr "Ni vsebine, ki bi jo selili"
 msgid "No email address is registered for member: ${member_id}"
 msgstr "Manjka naslov elektronske pošte za člana: ${member_id}"
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "V tej zbirki ni bilo najdenih slik."
@@ -6428,9 +6432,17 @@ msgstr "Absolutni prefiks URL"
 msgid "action_convert_legacy_portlets"
 msgstr "Tu so definirani ročno napisani portleti. Klikni na gumb, da jih pretvorim v nove portlete."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6441,6 +6453,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6466,6 +6486,10 @@ msgstr "Ali res želite zbrisati to mapo in njeno vsebino?"
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
 msgstr "abecednem redu"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
+msgstr ""
 
 #. Default: "<any>"
 #: Archetypes/ArchetypeTool.py:848
@@ -6601,6 +6625,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6768,6 +6800,14 @@ msgstr "Trenutna tema"
 msgid "current_theme_description"
 msgstr "Ime trenutne teme - tudi zadnje uporabljene teme."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr "datumu (najprej najnovejši)"
@@ -6796,6 +6836,10 @@ msgstr "Briši to datoteko"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Briši to sliko"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7351,6 +7395,14 @@ msgstr "Bili ste včlanjeni."
 msgid "description_you_can_log_on_now"
 msgstr "Kliknite gumb za takojšnjo prijavo."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7378,6 +7430,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7447,6 +7503,14 @@ msgstr "${name} manjka, prosim dopolnite."
 msgid "error_vocabulary"
 msgstr "Vrednosti ${val} niso dovoljene v besednjaku elementa ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7465,6 +7529,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8731,9 +8810,32 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Če so zadovoljeni vsi naslednji pogoji:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
 msgstr "v znakih"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
+msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
 #: plone.app.layout/plone/app/layout/dashboard/dashboard.py:32
@@ -10984,6 +11086,10 @@ msgstr "Ker je prepoznavanje prek piškotkov onemogočeno, ni možna prijava pre
 msgid "login_portlet_disabled"
 msgstr "Prijava prek piškotkov je onemogočena. Ni portleta za prijavo."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11069,6 +11175,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11094,6 +11248,10 @@ msgstr "Morate nastaviti geslo ali poslati elekronsko sporočilo."
 msgid "msg_text_too_long"
 msgstr "Besedilo je predolgo. (Največ ${max} znakov.)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 #, fuzzy
@@ -11114,6 +11272,40 @@ msgstr "Ne"
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Brez komentarjev."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11139,6 +11331,26 @@ msgstr "ali"
 msgid "or_upload_a_file"
 msgstr "ali naloži datoteko in zamenjaj trenutno vsebino"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11148,6 +11360,10 @@ msgstr "Izrazi parametrov"
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
 msgstr "Tu lahko določite parametre, ki jih prenesete v prevedeno temo. V datoteki pravil se lahko sklicujete na parameter z <code>$name</code>. Parametre določimo s TALESovimi izrazi, ki se izračunajo kot niz, število, boolovo vrednost ali None. Spremenljivke, ki so na voljo, so <code>context</code>, <code>request</code>, <code>portal</code>, <code>portal_state</code>, in <code>context_state</code>."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
+msgstr ""
 
 #. Default: "pending"
 #: workflow state defined in plone_workflow - title Pending
@@ -11166,6 +11382,14 @@ msgstr "plone.app.collection"
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11192,6 +11416,10 @@ msgstr "Vedno prikaži"
 msgid "portlets_value_use_parent"
 msgstr "Uporabi nastavitve nadrejene mape"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11215,6 +11443,34 @@ msgstr "objavi"
 msgid "published"
 msgstr "objavljeno"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11226,6 +11482,18 @@ msgstr "Beri omrežje"
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Preberi več"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11245,6 +11513,10 @@ msgstr "pomembnosti"
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Prosim, odjavite se ali zaprite brskalnik, ko boste končali z delom."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11276,6 +11548,10 @@ msgstr "Datoteka pravil"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
 msgstr "Pot do datoteke pravil"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
+msgstr ""
 
 #. Default: "Select Prefix"
 #: plone.app.registry/plone/app/registry/browser/records.pt:62
@@ -11401,6 +11677,30 @@ msgstr "Značke za dodajanje"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
 msgstr "Značke za odstranjevanje"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
+msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
 msgid "test wc workflow"
@@ -11650,6 +11950,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Včeraj"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12013,6 +12317,10 @@ msgstr "Upravljanje z inačicami"
 msgid "types_controlpanel_warn_remap"
 msgstr "Spreminjanje delovnega toka zvrsti vsebine nekaj časa traja in lahko upočasni delovanje spletišča medtem ko prilagaja vsebino novim nastavitvam."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12078,6 +12386,22 @@ msgstr "Jezikovno nevtralno (privzeto za spletišče)"
 msgid "warning_contentrules_disabled"
 msgstr "Vsebinska pravila so globalno onemogočena. Nobeno pravilo se ne bo aktiviralo, dokler niso spet omogočena. Uporabite ${controlpanel_link} za ponovno aktiviranje."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12087,6 +12411,54 @@ msgstr "Politika..."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "To vsebino ureja ${creator} v ${working_copy} izdelani dne ${created}."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/sm/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/sm/LC_MESSAGES/plone.po
@@ -3574,6 +3574,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6423,9 +6427,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6436,6 +6448,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6460,6 +6480,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6596,6 +6620,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6763,6 +6795,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6790,6 +6830,10 @@ msgstr ""
 #. Default: "Delete current image"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
 msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
@@ -7340,6 +7384,14 @@ msgstr ""
 msgid "description_you_can_log_on_now"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7366,6 +7418,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7435,6 +7491,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7453,6 +7517,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8704,8 +8783,31 @@ msgstr ""
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10941,6 +11043,10 @@ msgstr ""
 msgid "login_portlet_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11026,6 +11132,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11051,6 +11205,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11069,6 +11227,40 @@ msgstr ""
 #. Default: "No comments."
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
 msgstr ""
 
 #. Default: "Keep existing file"
@@ -11095,6 +11287,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11103,6 +11315,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11122,6 +11338,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11148,6 +11372,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11171,6 +11399,34 @@ msgstr ""
 msgid "published"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11181,6 +11437,18 @@ msgstr ""
 #: CMFPlone/skins/plone_content/folder_summary_view.pt:105
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
 msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
@@ -11200,6 +11468,10 @@ msgstr ""
 #. Default: "Please log out or exit your browser when you're done."
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
 msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
@@ -11231,6 +11503,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11356,6 +11632,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11604,6 +11904,10 @@ msgstr ""
 #. Default: "Yesterday"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
 msgstr ""
 
 #. Default: "Actions for the current content item"
@@ -11966,6 +12270,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12031,6 +12339,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12039,6 +12363,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/sq/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/sq/LC_MESSAGES/plone.po
@@ -3574,6 +3574,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6431,9 +6435,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6444,6 +6456,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6468,6 +6488,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6605,6 +6629,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6772,6 +6804,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6799,6 +6839,10 @@ msgstr ""
 #. Default: "Delete current image"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
 msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
@@ -7350,6 +7394,14 @@ msgstr ""
 msgid "description_you_can_log_on_now"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7376,6 +7428,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7445,6 +7501,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7463,6 +7527,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8714,8 +8793,31 @@ msgstr ""
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10954,6 +11056,10 @@ msgstr ""
 msgid "login_portlet_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11039,6 +11145,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11064,6 +11218,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11082,6 +11240,40 @@ msgstr ""
 #. Default: "No comments."
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
 msgstr ""
 
 #. Default: "Keep existing file"
@@ -11108,6 +11300,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11116,6 +11328,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11135,6 +11351,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11161,6 +11385,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11184,6 +11412,34 @@ msgstr ""
 msgid "published"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11194,6 +11450,18 @@ msgstr ""
 #: CMFPlone/skins/plone_content/folder_summary_view.pt:105
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
 msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
@@ -11213,6 +11481,10 @@ msgstr ""
 #. Default: "Please log out or exit your browser when you're done."
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
 msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
@@ -11244,6 +11516,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11369,6 +11645,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11617,6 +11917,10 @@ msgstr ""
 #. Default: "Yesterday"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
 msgstr ""
 
 #. Default: "Actions for the current content item"
@@ -11980,6 +12284,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12045,6 +12353,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12053,6 +12377,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/sr/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/sr/LC_MESSAGES/plone.po
@@ -3589,6 +3589,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6440,9 +6444,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6453,6 +6465,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6477,6 +6497,10 @@ msgstr "Да ли заиста желите да уклоните овај ди�
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6617,6 +6641,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6784,6 +6816,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6812,6 +6852,10 @@ msgstr "Обриши ову датотеку"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Обриши ову слику"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7369,6 +7413,14 @@ msgstr "Учлањени сте."
 msgid "description_you_can_log_on_now"
 msgstr "Притисните дугме да се одмах пријавите."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7395,6 +7447,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7465,6 +7521,14 @@ msgstr "Неопходан састојак је: ${name}.  Молимо да и
 msgid "error_vocabulary"
 msgstr "Вредност ${val} није дозвољена у речнику елемента ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7483,6 +7547,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8760,8 +8839,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11020,6 +11122,10 @@ msgstr "Док је провера колачића искључена, приј
 msgid "login_portlet_disabled"
 msgstr "Пријава путем колачића је искључена. Портлет за пријаву није доступан."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11105,6 +11211,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11130,6 +11284,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11149,6 +11307,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Нема коментара."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11174,6 +11366,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "или пошаљите датотеку (постојећи садржај ће бити замењен)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11182,6 +11394,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11201,6 +11417,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11227,6 +11451,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11250,6 +11478,34 @@ msgstr "објава"
 msgid "published"
 msgstr "објављено"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11262,6 +11518,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "Прочитајте више..."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11281,6 +11549,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Молимо одјавите се или искључите разгледач када завршите."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11311,6 +11583,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11438,6 +11714,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11691,6 +11991,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Јуче"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12053,6 +12357,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12118,6 +12426,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 #, fuzzy
@@ -12127,6 +12451,54 @@ msgstr "Полиса"
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/sr_Latn/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/sr_Latn/LC_MESSAGES/plone.po
@@ -3589,6 +3589,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6440,9 +6444,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6453,6 +6465,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6477,6 +6497,10 @@ msgstr "Da li zaista želite da uklonite ovaj direktorijum i sav sadržaj u njem
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6617,6 +6641,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6784,6 +6816,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6812,6 +6852,10 @@ msgstr "Obriši ovu datoteku"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Obriši ovu sliku"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7369,6 +7413,14 @@ msgstr "Učlanjeni ste."
 msgid "description_you_can_log_on_now"
 msgstr "Pritisnite dugme da se odmah prijavite."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7395,6 +7447,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7465,6 +7521,14 @@ msgstr "Neophodan sastojak je: ${name}.  Molimo da ispravite ovo."
 msgid "error_vocabulary"
 msgstr "Vrednost ${val} nije dozvoljena u rečniku elementa ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7483,6 +7547,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8760,8 +8839,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11020,6 +11122,10 @@ msgstr "Dok je provera kolačića isključena, prijava pomoću kolačića nije d
 msgid "login_portlet_disabled"
 msgstr "Prijava putem kolačića je isključena. Portlet za prijavu nije dostupan."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11105,6 +11211,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11130,6 +11284,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11149,6 +11307,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Nema komentara."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11174,6 +11366,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "ili pošaljite datoteku (postojeći sadržaj će biti zamenjen)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11182,6 +11394,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11201,6 +11417,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11227,6 +11451,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11250,6 +11478,34 @@ msgstr "objava"
 msgid "published"
 msgstr "objavljeno"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11262,6 +11518,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "Pročitajte više..."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11281,6 +11549,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Molimo odjavite se ili isključite razgledač kada završite."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11311,6 +11583,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11438,6 +11714,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11691,6 +11991,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Juče"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12053,6 +12357,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12118,6 +12426,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 #, fuzzy
@@ -12127,6 +12451,54 @@ msgstr "Polisa"
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/sv/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/sv/LC_MESSAGES/plone.po
@@ -3596,6 +3596,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "Inga bilder hittade i den här samlingen."
@@ -6471,6 +6475,7 @@ msgstr "Prefix (absolut sökväg)"
 msgid "action_convert_legacy_portlets"
 msgstr "Det finns portlets av gamla typen här. Klicka på knappen för att konvertera dem till portlets av nya typen."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
 msgid "add"
 msgstr "Lägg till"
 
@@ -6479,6 +6484,7 @@ msgstr "Lägg till"
 msgid "add_comment_button"
 msgstr "Kommentera"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
 msgid "add_date"
 msgstr "Lägg till"
 
@@ -6492,9 +6498,11 @@ msgstr ""
 msgid "add_new_field_hellip"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
 msgid "add_rules"
 msgstr "Lägg till"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
 msgid "additional_date"
 msgstr "Tillagt datum"
 
@@ -6522,6 +6530,7 @@ msgstr "Vill du verkligen radera denna mapp och allt dess innehåll?"
 msgid "alphabetically"
 msgstr "i bokstavsordning"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
 msgid "already_added"
 msgstr "Detta datum är redan tillagt."
 
@@ -6661,9 +6670,11 @@ msgstr "Radera"
 msgid "bulkactions_publish"
 msgstr "Godkänn"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
 msgid "bysetpos"
 msgstr "BYSETPOS stöds ej"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
 msgid "cancel"
 msgstr "Avbryt"
 
@@ -6833,9 +6844,11 @@ msgstr "Nuvarande tema"
 msgid "current_theme_description"
 msgstr "Titel för nuvarande tema, d.v.s. det som applicerades senast."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
 msgid "daily_interval_1"
 msgstr "Varje"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
 msgid "daily_interval_2"
 msgstr "dag(ar)"
 
@@ -6868,6 +6881,7 @@ msgstr "Radera nuvarande fil"
 msgid "delete_image"
 msgstr "Radera nuvarande bild"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
 msgid "delete_rules"
 msgstr "(X)"
 
@@ -7436,9 +7450,11 @@ msgstr "Du har nu registrerats som användare på denna Plone-webbplats."
 msgid "description_you_can_log_on_now"
 msgstr "Klicka på knappen nedan för att logga in."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
 msgid "display_activate"
 msgstr "Återkommer var"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
 msgid "display_unactivate"
 msgstr "Återkommer inte"
 
@@ -7472,6 +7488,7 @@ msgstr ""
 msgid "edit_comment_form_title"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
 msgid "edit_rules"
 msgstr "Ändra"
 
@@ -7543,9 +7560,11 @@ msgstr "${name} krävs, vänligen korrigera."
 msgid "error_vocabulary"
 msgstr "Värdena ${val} är ej tillåtna i vokabulären för element ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
 msgid "except"
 msgstr ", förutom den"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
 msgid "exclude"
 msgstr "Exkludera"
 
@@ -7567,6 +7586,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8846,13 +8880,30 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Om samtliga följande villkor uppfylls…"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
 msgid "include"
 msgstr "Inkludera"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
 msgid "including"
 msgstr ", samt den"
 
@@ -11110,6 +11161,7 @@ msgstr "Eftersom autentisering med \"cookies\" är avstängd, är inloggning bas
 msgid "login_portlet_disabled"
 msgstr "Autentisering med \"cookies\" är avstängd. Inloggningsfunktionen inte tillgänglig."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
 msgid "long_date_format"
 msgstr "dddd dd mmmm, yyyy"
 
@@ -11215,36 +11267,51 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
 msgid "monthly_day_of_month_1"
 msgstr "Den"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
 msgid "monthly_day_of_month_1_human"
 msgstr "den"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
 msgid "monthly_day_of_month_2"
 msgstr "dagen i månaden"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
 msgid "monthly_day_of_month_3"
 msgstr "månad"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
 msgid "monthly_interval_1"
 msgstr "Återkom varje:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
 msgid "monthly_interval_2"
 msgstr "månad(er)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
 msgid "monthly_repeat_on"
 msgstr "Återkom på:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
 msgid "monthly_weekday_of_month_1"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
 msgid "monthly_weekday_of_month_1_human"
 msgstr "på"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
 msgid "monthly_weekday_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
 msgid "monthly_weekday_of_month_3"
 msgstr "i månaden"
 
@@ -11274,6 +11341,7 @@ msgstr "Du måste antingen välja ett lösenord eller "
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
 msgid "multiple_day_of_month"
 msgstr "Återkomster med flera dagar stöds inte i månatliga eller årliga återkomster"
 
@@ -11298,21 +11366,37 @@ msgstr ""
 msgid "no_comments"
 msgstr "Ingen kommentar."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
 msgid "no_end_after_n_occurrences"
 msgstr "Fel: \"Efter N Återkomster\"-fältet måste vara mellan 1 och 1000"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
 msgid "no_end_date"
 msgstr "Fel: Slutdatum är inte satt"
 
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
 msgid "no_repeat_every"
 msgstr "Fel: \"Återkom var\"-fältet måste vara mellan 1 och 1000"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
 msgid "no_repeat_on"
 msgstr "Fel: Du måste välja typ av återkomst (under \"Återkom på:\")"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
 msgid "no_rule"
 msgstr "Ingen RRULE funnen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
 msgid "no_template_match"
 msgstr "Hittar ingen återkomstmall som passar"
 
@@ -11340,18 +11424,23 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "eller ladda up en fil (nuvarande innehåll kommer att ersättas)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
 msgid "order_indexes_first"
 msgstr "första"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
 msgid "order_indexes_fourth"
 msgstr "fjärde"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
 msgid "order_indexes_last"
 msgstr "sista"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
 msgid "order_indexes_second"
 msgstr "andra"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
 msgid "order_indexes_third"
 msgstr "tredje"
 
@@ -11366,6 +11455,7 @@ msgstr "Parameteruttryck"
 msgid "parameter_expressions_description"
 msgstr "Parametrar till det kompilerade temat."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
 msgid "past_end_date"
 msgstr "Fel: Slutdatum kan inte vara före startdatum"
 
@@ -11386,6 +11476,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11412,6 +11510,7 @@ msgstr "Blockera ej"
 msgid "portlets_value_use_parent"
 msgstr "Som överordnad mapp"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
 msgid "preview"
 msgstr "Valda datum"
 
@@ -11438,24 +11537,31 @@ msgstr "publicera"
 msgid "published"
 msgstr "publicerat"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
 msgid "range"
 msgstr "Återkomsten stoppar:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
 msgid "range_by_end_date"
 msgstr "Till och med"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
 msgid "range_by_end_date_human"
 msgstr "till och med"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
 msgid "range_by_occurrences_1"
 msgstr "Stoppar efter"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
 msgid "range_by_occurrences_1_human"
 msgstr "stoppar efter"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
 msgid "range_by_occurrences_2"
 msgstr "återkomster"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
 msgid "range_no_end"
 msgstr "Aldrig"
 
@@ -11471,12 +11577,15 @@ msgstr "Läs filer från nätet"
 msgid "read_more"
 msgstr "Läs mer"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
 msgid "recurrence_start"
 msgstr "Första gången"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
 msgid "recurrence_type"
 msgstr "Återkommer:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
 msgid "refresh"
 msgstr "Ladda om"
 
@@ -11499,6 +11608,7 @@ msgstr "relevans"
 msgid "remember_to_log_out"
 msgstr "Glöm inte att logga ut eller att stänga din webbläsare när du är klar."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
 msgid "remove"
 msgstr "Ta bort"
 
@@ -11533,6 +11643,7 @@ msgstr "Regelfil"
 msgid "rules_file_path"
 msgstr "Sökväg till regelfilen"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
 msgid "save"
 msgstr "Spara"
 
@@ -11678,21 +11789,27 @@ msgstr ""
 msgid "tags_to_remove"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
 msgid "template_daily"
 msgstr "Varje dag"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
 msgid "template_mondayfriday"
 msgstr "Måndag och fredag"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
 msgid "template_monthly"
 msgstr "Varje månad"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
 msgid "template_weekdays"
 msgstr "Veckodag"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
 msgid "template_weekly"
 msgstr "Varje vecka"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
 msgid "template_yearly"
 msgstr "Varje år"
 
@@ -11945,6 +12062,7 @@ msgstr "."
 msgid "time_yesterday"
 msgstr "i går"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
 msgid "title"
 msgstr "Återkomster"
 
@@ -12317,6 +12435,7 @@ msgstr "Policy för versionshantering:"
 msgid "types_controlpanel_warn_remap"
 msgstr "Att ändra arbetsflöde för en innehållstyp tar ett tag. Under tiden som alla innehållsposter uppdateras, kan webbplatsen bli märkbart långsam."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
 msgid "unsupported_features"
 msgstr "Varning: Denna händelse använder funktionalitet som denna dialog inte stödjer. Om du sparar kan detta ändra när händelsen återkommer: "
 
@@ -12385,15 +12504,19 @@ msgstr "Språkneutralt (webbplatsens standardvärde)"
 msgid "warning_contentrules_disabled"
 msgstr "Innehållsregler är avslagna globalt. Inga kopplade regler kommer att appliceras förrän de slås på. Använd ${controlpanel_link} för att slå på dem igen."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
 msgid "weekly_interval_1"
 msgstr "Återkom varje"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
 msgid "weekly_interval_2"
 msgstr "vecka/veckor"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
 msgid "weekly_weekdays"
 msgstr "Återkom på:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
 msgid "weekly_weekdays_human"
 msgstr "på:"
 
@@ -12407,39 +12530,51 @@ msgstr "Lokal policy..."
 msgid "working_copy_info"
 msgstr "Denna post redigeras av ${creator} i ${working_copy} skapad ${created}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
 msgid "yearly_day_of_month_1"
 msgstr "Varje"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
 msgid "yearly_day_of_month_1_human"
 msgstr "på"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
 msgid "yearly_day_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
 msgid "yearly_day_of_month_3"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
 msgid "yearly_interval_1"
 msgstr "Återkom varje:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
 msgid "yearly_interval_2"
 msgstr "år"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
 msgid "yearly_repeat_on"
 msgstr "Återkom på:"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
 msgid "yearly_weekday_of_month_1"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
 msgid "yearly_weekday_of_month_1_human"
 msgstr "på"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
 msgid "yearly_weekday_of_month_2"
 msgstr " "
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
 msgid "yearly_weekday_of_month_3"
 msgstr "i"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
 msgid "yearly_weekday_of_month_4"
 msgstr " "
 

--- a/plone/app/locales/locales/ta/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/ta/LC_MESSAGES/plone.po
@@ -3575,6 +3575,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6432,9 +6436,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6445,6 +6457,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6469,6 +6489,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6607,6 +6631,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6774,6 +6806,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6801,6 +6841,10 @@ msgstr ""
 #. Default: "Delete current image"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
 msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
@@ -7357,6 +7401,14 @@ msgstr "ஒரு உறுப்பினராக நீங்கள் பத
 msgid "description_you_can_log_on_now"
 msgstr "உடனடியாக உள்ளே நுழைய, பட்டனை க்ளிக் செய்யவும்."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7383,6 +7435,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7452,6 +7508,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7470,6 +7534,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8743,8 +8822,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10996,6 +11098,10 @@ msgstr "குக்கி நம்பகத்தன்மை செயலி�
 msgid "login_portlet_disabled"
 msgstr "குக்கி நம்பகத்தன்மை செயலிழந்தது. உள்நுழைவு போர்ட்லெட் கிடைக்கவில்லை"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11081,6 +11187,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11106,6 +11260,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11125,6 +11283,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "கருத்து எதுவுமில்லை"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11150,6 +11342,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11158,6 +11370,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11177,6 +11393,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11203,6 +11427,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11226,6 +11454,34 @@ msgstr "பிரசுரித்தல்"
 msgid "published"
 msgstr "பிரசுரிக்கப்பட்டது"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11238,6 +11494,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "அதிகம் படிக்கவும்"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11257,6 +11525,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "நீங்கள் வேலையை முடித்ததும், தயவுசெய்து வெளியேறவும் அல்லது உங்கள் ப்ரௌஸரைவிட்டு அகலவும்."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11287,6 +11559,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11413,6 +11689,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11666,6 +11966,10 @@ msgstr "::"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "நேற்று"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12028,6 +12332,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12093,6 +12401,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12101,6 +12425,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/te/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/te/LC_MESSAGES/plone.po
@@ -3575,6 +3575,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6434,9 +6438,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6447,6 +6459,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6471,6 +6491,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6609,6 +6633,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6776,6 +6808,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6803,6 +6843,10 @@ msgstr ""
 #. Default: "Delete current image"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
 msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
@@ -7359,6 +7403,14 @@ msgstr "మీరు సభ్యునిగా నమెాదయ్యార�
 msgid "description_you_can_log_on_now"
 msgstr "లాగ్్ఇన్్ కోసం బటన్్ను వెంటనే నొక్కండి"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7385,6 +7437,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7454,6 +7510,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7472,6 +7536,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8746,8 +8825,31 @@ msgstr "హెచ్్టిఎంఎల్్"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10999,6 +11101,10 @@ msgstr "కుకీ అథెంటికేషన్్ డిజేబుల�
 msgid "login_portlet_disabled"
 msgstr "కుకీ ఆథెంటికేషన్్ డిసేబుల్్ అయింది. లాగ్్ ఇన్్ పోర్టలేట్్ లభించడంలేదు."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11084,6 +11190,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11109,6 +11263,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11128,6 +11286,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "కామెంట్లు లేవు"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11153,6 +11345,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11161,6 +11373,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11180,6 +11396,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11206,6 +11430,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11229,6 +11457,34 @@ msgstr "పబ్లిష్్"
 msgid "published"
 msgstr "పబ్లిష్డ్్"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11241,6 +11497,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "రీడ్ మెార్్"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11260,6 +11528,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "దయచేసి లాగ్్ అవుట్్ కండి లేదా మీ పని ముగిసిన తరువాత మీ బ్రౌజర్్ ఎక్సిట్్ చేయండి."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11290,6 +11562,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11416,6 +11692,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11669,6 +11969,10 @@ msgstr "టైమ్్ సపరేటర్్"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "నిన్న"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12031,6 +12335,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12096,6 +12404,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12104,6 +12428,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/th/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/th/LC_MESSAGES/plone.po
@@ -3570,6 +3570,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6416,9 +6420,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6429,6 +6441,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6453,6 +6473,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6589,6 +6613,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6756,6 +6788,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6783,6 +6823,10 @@ msgstr ""
 #. Default: "Delete current image"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
 msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
@@ -7334,6 +7378,14 @@ msgstr ""
 msgid "description_you_can_log_on_now"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7360,6 +7412,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7429,6 +7485,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7447,6 +7511,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8701,8 +8780,31 @@ msgstr ""
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10940,6 +11042,10 @@ msgstr ""
 msgid "login_portlet_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11025,6 +11131,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11050,6 +11204,10 @@ msgstr "คุณต้องตั้งรหัสผ่านหรือเ
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11069,6 +11227,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "ไม่มีความคิดเห็น"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11094,6 +11286,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11102,6 +11314,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11121,6 +11337,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11147,6 +11371,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11170,6 +11398,34 @@ msgstr ""
 msgid "published"
 msgstr "เผยแพร่แล้ว"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11181,6 +11437,18 @@ msgstr ""
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "อ่านเพิ่มเติม"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11200,6 +11468,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "กรุณาล็อกเอ้าท์หรือออกจากบราวเซอร์ของคุณเมื่อใช้งานเสร็จแล้ว"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11230,6 +11502,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11355,6 +11631,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11604,6 +11904,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "เมื่อวานนี้"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -11966,6 +12270,10 @@ msgstr "นโยบายการปรับเปลี่ยนเวอร
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12031,6 +12339,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12040,6 +12364,54 @@ msgstr "นโยบาย"
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "รายการนี้กำลังถูกแก้ไขโดย ${creator} ใน ${working_copy} ที่ถูกสร้างบน ${created}"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/to/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/to/LC_MESSAGES/plone.po
@@ -3574,6 +3574,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6423,9 +6427,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6436,6 +6448,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6460,6 +6480,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6596,6 +6620,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6763,6 +6795,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6790,6 +6830,10 @@ msgstr ""
 #. Default: "Delete current image"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
 msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
@@ -7340,6 +7384,14 @@ msgstr ""
 msgid "description_you_can_log_on_now"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7366,6 +7418,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7435,6 +7491,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7453,6 +7517,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8704,8 +8783,31 @@ msgstr ""
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10941,6 +11043,10 @@ msgstr ""
 msgid "login_portlet_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11026,6 +11132,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11051,6 +11205,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11069,6 +11227,40 @@ msgstr ""
 #. Default: "No comments."
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
 msgstr ""
 
 #. Default: "Keep existing file"
@@ -11095,6 +11287,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11103,6 +11315,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11122,6 +11338,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11148,6 +11372,10 @@ msgstr ""
 msgid "portlets_value_use_parent"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11171,6 +11399,34 @@ msgstr ""
 msgid "published"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11181,6 +11437,18 @@ msgstr ""
 #: CMFPlone/skins/plone_content/folder_summary_view.pt:105
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
 msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
@@ -11200,6 +11468,10 @@ msgstr ""
 #. Default: "Please log out or exit your browser when you're done."
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
 msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
@@ -11231,6 +11503,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11356,6 +11632,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11604,6 +11904,10 @@ msgstr ""
 #. Default: "Yesterday"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
 msgstr ""
 
 #. Default: "Actions for the current content item"
@@ -11966,6 +12270,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12031,6 +12339,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12039,6 +12363,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/tr/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/tr/LC_MESSAGES/plone.po
@@ -3574,6 +3574,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "Bu derlemede hiç resim bulunamadı."
@@ -6430,9 +6434,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr "Burada eskiden kalmış portlet tanımları var. Bu portletleri yeni stil portletlere dönüştürmek için düğmeye tıklayın."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6443,6 +6455,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6467,6 +6487,10 @@ msgstr "Bu klasörü ve içindeki herşeyi silmeyi gerçekten istiyor musunuz?"
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6603,6 +6627,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6770,6 +6802,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6798,6 +6838,10 @@ msgstr "Şu anki dosya silinsin"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Şu anki resim silinsin"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7350,6 +7394,14 @@ msgstr "Kayıt oldunuz."
 msgid "description_you_can_log_on_now"
 msgstr "Siteye hemen girmek için düğmeye tıklayın."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7376,6 +7428,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7445,6 +7501,14 @@ msgstr "${name} boş bırakılamaz, lütfen düzeltin."
 msgid "error_vocabulary"
 msgstr "${val} değerlerine ${label} elemanının sözlüğünde izin verilmemiş."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7463,6 +7527,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8726,8 +8805,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Şu koşulların hepsi sağlanıyorsa:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10974,6 +11076,10 @@ msgstr "Çerez asıllamasına izin verilmemiş olduğu için siteye çerez arac�
 msgid "login_portlet_disabled"
 msgstr "Çerez asıllamasına izin verilmemiş. Siteye giriş portleti kullanılamaz."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11059,6 +11165,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11084,6 +11238,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11103,6 +11261,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Yorum yok."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11128,6 +11320,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "ya da bir dosya yükleyin (şu anki içeriğin yerine geçer)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11136,6 +11348,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11155,6 +11371,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11181,6 +11405,10 @@ msgstr "Engelleme"
 msgid "portlets_value_use_parent"
 msgstr "Üst öğenin ayarları kullanılsın"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11204,6 +11432,34 @@ msgstr "yayımla"
 msgid "published"
 msgstr "yayımlanmış"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11215,6 +11471,18 @@ msgstr ""
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Gerisini oku"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11234,6 +11502,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "İşiniz bittiğinde siteden çıkmayı ya da tarayıcınızı kapatmayı unutmayın."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11264,6 +11536,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11389,6 +11665,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11639,6 +11939,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Dün"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12002,6 +12306,10 @@ msgstr "Sürümlendirme politikası:"
 msgid "types_controlpanel_warn_remap"
 msgstr "Bir tipin işakışını değiştirmek biraz zaman alacaktır; içerik yeni ayarlara göre güncellenirken site hissedilir derecede yavaşlayabilir."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12067,6 +12375,22 @@ msgstr "Dilden bağımsız (site varsayılanı)"
 msgid "warning_contentrules_disabled"
 msgstr "Sitede içerik kurallarına izin kaldırılmış. Yeniden izin verilene kadar atanmış hiçbir kural yürütülmeyecektir. Yeniden izin vermek istiyorsanız ${controlpanel_link} sayfasına gidin."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12076,6 +12400,54 @@ msgstr "Politika..."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Bu öğeyi ${creator} kullanıcısı ${created} tarihinde yarattığı ${working_copy} üzerinde düzenliyor."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/uk/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/uk/LC_MESSAGES/plone.po
@@ -3579,6 +3579,10 @@ msgstr "Немає вмісту для міграції."
 msgid "No email address is registered for member: ${member_id}"
 msgstr "Електронна пошта для члена ${member_id} не зареєстрована"
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "В цій колекції не знайдено жодного зображення."
@@ -6435,10 +6439,18 @@ msgstr "Абсолютний префікс URL"
 msgid "action_convert_legacy_portlets"
 msgstr "Тут призначено портлети з вищих рівнів. Натисніть тут, щоб перетворити їх на нові портлети."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
 msgstr "Коментар"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
+msgstr ""
 
 #. Default: "Add new fieldset…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:13
@@ -6448,6 +6460,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6473,6 +6493,10 @@ msgstr "Ви дійсно хочете видалити дану теку та �
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
 msgstr "в алфавітному порядку"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
+msgstr ""
 
 #. Default: "<any>"
 #: Archetypes/ArchetypeTool.py:848
@@ -6609,6 +6633,14 @@ msgstr "Знищити"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
 msgstr "Опублікувати"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
+msgstr ""
 
 #. Default: "Cancel"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:101
@@ -6775,6 +6807,14 @@ msgstr "Поточна тема"
 msgid "current_theme_description"
 msgstr "Назва поточної теми, тобто тієї, яка використовується останнім часом."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr "даті (нові зверху)"
@@ -6803,6 +6843,10 @@ msgstr "Знищити поточний файл"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Знищити поточне зображення"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7354,6 +7398,14 @@ msgstr "Вас зареєстровано як члена спільноти."
 msgid "description_you_can_log_on_now"
 msgstr "Натисніть цю кнопку щоб одразу ввійти."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7380,6 +7432,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7449,6 +7505,14 @@ msgstr "${name} є обов'язковим для заповнення, будь
 msgid "error_vocabulary"
 msgstr "Значення ${val} не дозволено використовувати для словника елемента ${label}"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7467,6 +7531,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8722,9 +8801,32 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Якщо виконуються усі наступні умови:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
 msgstr "в символах"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
+msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
 #: plone.app.layout/plone/app/layout/dashboard/dashboard.py:32
@@ -10960,6 +11062,10 @@ msgstr "Поки автентифікація коржиками заборон�
 msgid "login_portlet_disabled"
 msgstr "Аутентифікацію коржиками вимкнено. Портлет входу в систему є недоступний."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11061,6 +11167,54 @@ msgstr "мігрувати типи вмісту за замовчуванням
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr "розділ про міграцію у документації plone.app.contenttypes"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11086,6 +11240,10 @@ msgstr "Ви повинні встановити пароль або вибра�
 msgid "msg_text_too_long"
 msgstr "Текст занадто довгий. (Не більше ${max} символів.)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11105,6 +11263,40 @@ msgstr "Ні"
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Без коментарів."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11130,6 +11322,26 @@ msgstr "або"
 msgid "or_upload_a_file"
 msgstr "або завантажте файл (існуючий буде замінено)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11139,6 +11351,10 @@ msgstr "Значення виразів"
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
 msgstr "Ви можете визначити тут параметри, які будуть передані компільованій темі. У файлі правил, ви можете звернутися до параметру $ім'я. Параметри задаються за допомогою виразу TALES, який повинен повернути стрічкове, числове, логічне значення чи None. Доступні змінні: `context`, `request`, `portal`, `portal_state`, та `context_state`."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
+msgstr ""
 
 #. Default: "pending"
 #: workflow state defined in plone_workflow - title Pending
@@ -11157,6 +11373,14 @@ msgstr "plone.app.collection"
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11183,6 +11407,10 @@ msgstr "Не блокувати"
 msgid "portlets_value_use_parent"
 msgstr "Використовувти батьківські параметри"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11206,6 +11434,34 @@ msgstr "опублікувати"
 msgid "published"
 msgstr "опублікований"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11217,6 +11473,18 @@ msgstr "Читати з мережі"
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Більше..."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11236,6 +11504,10 @@ msgstr "відповідністю"
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Вийдіть або закрийте переглядач, коли завершите роботу."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11267,6 +11539,10 @@ msgstr "Файл правил"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
 msgstr "Шлях до файлу правил"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
+msgstr ""
 
 #. Default: "Select Prefix"
 #: plone.app.registry/plone/app/registry/browser/records.pt:62
@@ -11392,6 +11668,30 @@ msgstr "Теги для додавання"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
 msgstr "Теги для видалення"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
+msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
 msgid "test wc workflow"
@@ -11640,6 +11940,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Вчора"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12001,6 +12305,10 @@ msgstr "Політика створення версій:"
 msgid "types_controlpanel_warn_remap"
 msgstr "Зміна робочого процесу може тривати деякий час і уповільнити роботу сайту через те, що відбувається налаштуання вмісту до нових параметрів."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12066,6 +12374,22 @@ msgstr "Нейтральна мова (стандартна для сайту)"
 msgid "warning_contentrules_disabled"
 msgstr "Правила вмісту вимкнено для цілого сайту. Жодне правило не буде виконуватися допоки їх не буде ввімкнено знову. Для того, щоб увімкнути правила перейдіть на${controlpanel_link}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12075,6 +12399,54 @@ msgstr "Політика..."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Цей елемент редагує ${creator} у ${working_copy}, створеній ${created}."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/vi/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/vi/LC_MESSAGES/plone.po
@@ -3573,6 +3573,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6422,9 +6426,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr "Hiện vẫn còn các portlet kiểu cũ. Bấm nút để chuyển các portlet kiểu cũ sang kiểu mới."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6435,6 +6447,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6459,6 +6479,10 @@ msgstr "Bạn có thực sự muốn xóa thư mục này và toàn bộ nội d
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6595,6 +6619,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6762,6 +6794,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6790,6 +6830,10 @@ msgstr "Xóa tập tin hiện hành"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "Xóa hình ảnh hiện hành"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7346,6 +7390,14 @@ msgstr "Bạn đã đăng ký thành công."
 msgid "description_you_can_log_on_now"
 msgstr "Hãy bấm nút để đăng nhập ngay."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7372,6 +7424,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7441,6 +7497,14 @@ msgstr "Bạn phải nhập ${name}."
 msgid "error_vocabulary"
 msgstr "Các giá trị ${val} không được phép sử dụng cho mục từ của ${label}."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7459,6 +7523,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8726,8 +8805,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "Nếu thỏa mãn tất cả các điều kiện sau đây:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10977,6 +11079,10 @@ msgstr "Đăng nhập dựa trên cookies không có tác dụng vì chức năn
 msgid "login_portlet_disabled"
 msgstr "Chức năng xác thực thông qua cookies đã bị vô hiệu hóa. Không thể sử dụng được biểu mẫu đăng nhập."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11062,6 +11168,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11087,6 +11241,10 @@ msgstr "Bạn phải thiết lập mật khẩu hoặc chọn gửi qua thư đi
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11106,6 +11264,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "Không có."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11131,6 +11323,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "hoặc tải lên một tập tin (nội dung hiện tại sẽ được thay thế)"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11139,6 +11351,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 #. Default: "pending"
@@ -11158,6 +11374,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11184,6 +11408,10 @@ msgstr "Đừng ngăn chặn"
 msgid "portlets_value_use_parent"
 msgstr "Sử dụng thiết lập của cấp cao hơn"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11207,6 +11435,34 @@ msgstr "phát hành"
 msgid "published"
 msgstr "đã phát hành"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11218,6 +11474,18 @@ msgstr ""
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "Xem thêm"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11237,6 +11505,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "Để đảm bảo an toàn, hãy đăng xuất hoặc đóng cửa sổ trình duyệt sau khi kết thúc công việc."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11267,6 +11539,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11392,6 +11668,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11642,6 +11942,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "Ngày hôm qua"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12006,6 +12310,10 @@ msgstr "Nguyên tắc tạo phiên bản:"
 msgid "types_controlpanel_warn_remap"
 msgstr "Thay đổi dòng công việc sẽ mất một chút thời gian và có thể làm hệ thống chậm đi đáng kể trong lúc nội dung được cập nhật theo thiết lập mới."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12071,6 +12379,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr "Quy luật nội dung đã bị vô hiệu hóa trên toàn bộ hệ thống. Các quy luật đã ấn định sẽ không hoạt động cho đến khi chúng được mở trở lại. Bạn có thể truy cập ${controlpanel_link} để kích hoạt chúng trở lại."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12080,6 +12404,54 @@ msgstr "Nguyên tắc..."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "Nội dung này đang được biên tập bởi ${creator} trong ${working_copy} được tạo ngày ${created}."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/zh_CN/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/zh_CN/LC_MESSAGES/plone.po
@@ -3578,6 +3578,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr "没有提供文件。"
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "在此集合中没有找到图片。"
@@ -6434,10 +6438,18 @@ msgstr "绝对 URL 前缀"
 msgid "action_convert_legacy_portlets"
 msgstr "这些是遗留定义的面板。点击按钮转换到新的样式面板。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
 msgstr "发表评论"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
+msgstr ""
 
 #. Default: "Add new fieldset…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:13
@@ -6448,6 +6460,14 @@ msgstr "添加新字段集…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
 msgstr "添加新字段…"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
+msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
 #: plone.app.content/plone/app/content/browser/templates/delete_confirmation.pt:18
@@ -6472,6 +6492,10 @@ msgstr "您确定想要删掉这个文件夹和其下的内容吗？"
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
 msgstr "按字母表顺"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
+msgstr ""
 
 #. Default: "<any>"
 #: Archetypes/ArchetypeTool.py:848
@@ -6608,6 +6632,14 @@ msgstr "删除"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
 msgstr "批准"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
+msgstr ""
 
 #. Default: "Cancel"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:101
@@ -6774,6 +6806,14 @@ msgstr "当前主题"
 msgid "current_theme_description"
 msgstr "当前主题的名称，即最近应用那个。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr "日期 （最新在前）"
@@ -6802,6 +6842,10 @@ msgstr "删除当前文件"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "删除当前图片"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7352,6 +7396,14 @@ msgstr "您已经注册为网站成员了。"
 msgid "description_you_can_log_on_now"
 msgstr "点击按钮，可立即登录。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7379,6 +7431,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7448,6 +7504,14 @@ msgstr "${name} 是必须的，请更正。"
 msgid "error_vocabulary"
 msgstr "值 ${val} 不被 ${label} 允许。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7467,6 +7531,21 @@ msgstr ""
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
 msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr "保持现有文件"
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr "删除现有的文件"
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
+msgstr "替换为新文件"
 
 #: CMFPlone/browser/templates/search.pt:283
 #: plone.app.querystring/plone/app/querystring/results.pt:71
@@ -8725,8 +8804,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "如果满足以下所有条件："
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr "保持现有图片"
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr "删除现有的图片"
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr "替换为新图片"
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -10969,6 +11071,10 @@ msgstr "当 cookie 认证机制被禁用时，您无法使用基于 cookie 的�
 msgid "login_portlet_disabled"
 msgstr "cookie 认证被禁用。不能使用登录面板。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11073,6 +11179,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11098,6 +11252,10 @@ msgstr "您必须设置一个密码或者选择发送一封 Email 。"
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11117,6 +11275,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "没有评论。"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr "没有文件"
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr "没有图片"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11142,6 +11334,26 @@ msgstr "或者"
 msgid "or_upload_a_file"
 msgstr "或者上传一个文件（现有内容将被替换）"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11151,6 +11363,10 @@ msgstr "参数表达式"
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
 msgstr "您可以在这里定义参数，它将被传递到已编译的主题中。在您的规则文件中，您可以通过 <code>$name</code> 来引用参数。参数使用 TALES 表达式定义，它将被评估为字符串、数字、布尔值，或 None。可用的变量有 <code>context</code>, <code>request</code>, <code>portal</code>, <code>portal_state</code>, 和 <code>context_state</code>。每行定义一个变量，格式为： <code>name = expression</code>。"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
+msgstr ""
 
 #. Default: "pending"
 #: workflow state defined in plone_workflow - title Pending
@@ -11169,6 +11385,14 @@ msgstr "plone.app.collection"
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11195,6 +11419,10 @@ msgstr "显示"
 msgid "portlets_value_use_parent"
 msgstr "使用上一级设定"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11218,6 +11446,34 @@ msgstr "发布"
 msgid "published"
 msgstr "已发布"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11229,6 +11485,18 @@ msgstr "从网络读取"
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "查看更多..."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11248,6 +11516,10 @@ msgstr "相关度"
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "完成后，请记得退出或者关闭您的浏览器。"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11279,6 +11551,10 @@ msgstr "规则文件"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
 msgstr "规则文件的文件路径"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
+msgstr ""
 
 #. Default: "Select Prefix"
 #: plone.app.registry/plone/app/registry/browser/records.pt:62
@@ -11416,6 +11692,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11665,6 +11965,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "昨天"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12026,6 +12330,10 @@ msgstr "版本策略"
 msgid "types_controlpanel_warn_remap"
 msgstr "改变类型的工作流可能很需要一段时间，这段时间内 Plone 可能显著变慢。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12091,6 +12399,22 @@ msgstr "自动选择语言（站点默认）"
 msgid "warning_contentrules_disabled"
 msgstr "内容规则已全局禁用。已分配规则将不会执行，直到被重新启用。使用 ${controlpanel_link} 进行启用。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12100,6 +12424,54 @@ msgstr "策略..."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "这个条目 已被 ${creator} 在 ${working_copy} 编辑，创建于 ${created}。"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32

--- a/plone/app/locales/locales/zh_HK/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/zh_HK/LC_MESSAGES/plone.po
@@ -3619,6 +3619,10 @@ msgstr ""
 msgid "No email address is registered for member: ${member_id}"
 msgstr ""
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr ""
@@ -6531,9 +6535,17 @@ msgstr ""
 msgid "action_convert_legacy_portlets"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
 msgstr ""
 
 #. Default: "Add new fieldset…"
@@ -6544,6 +6556,14 @@ msgstr ""
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -6569,6 +6589,10 @@ msgstr ""
 
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
 msgstr ""
 
 #. Default: "<any>"
@@ -6709,6 +6733,14 @@ msgstr ""
 #. Default: "Approve"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
 msgstr ""
 
 #. Default: "Cancel"
@@ -6876,6 +6908,14 @@ msgstr ""
 msgid "current_theme_description"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr ""
@@ -6904,6 +6944,10 @@ msgstr "刪除當前檔案"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "刪除當前圖像"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7455,6 +7499,14 @@ msgstr "您已經是本站註冊成員."
 msgid "description_you_can_log_on_now"
 msgstr "按下按鈕即可立即登入."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7481,6 +7533,10 @@ msgstr ""
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
 msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
@@ -7550,6 +7606,14 @@ msgstr ""
 msgid "error_vocabulary"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7568,6 +7632,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8866,8 +8945,31 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr ""
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
 msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
@@ -11168,6 +11270,10 @@ msgstr "當cookie認證被關閉, cookie登錄將無效."
 msgid "login_portlet_disabled"
 msgstr "Cookie授權被關閉. 登入功能端無效."
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11253,6 +11359,54 @@ msgstr ""
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11278,6 +11432,10 @@ msgstr ""
 msgid "msg_text_too_long"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11297,6 +11455,40 @@ msgstr ""
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "沒有意見."
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11322,6 +11514,26 @@ msgstr ""
 msgid "or_upload_a_file"
 msgstr "或上傳檔案（現有內容將被覆蓋）"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11330,6 +11542,10 @@ msgstr ""
 #. Default: "You can define parameters here, which will be passed to the compiled theme. In your rules file, you can refer to a parameter by $name. Parameters are defined using TALES expressions, which should evaluate to a string, a number, a boolean or None. Available variables are `context`, `request`, `portal`, `portal_state`,  and `context_state`."
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
 msgstr ""
 
 # workflow state defined in plone_workflow, title:
@@ -11350,6 +11566,14 @@ msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11374,6 +11598,10 @@ msgstr ""
 #. Default: "Use parent settings"
 #: plone.app.portlets/plone/app/portlets/browser/templates/edit-manager-contextual.pt:78
 msgid "portlets_value_use_parent"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
 msgstr ""
 
 # workflow state defined in plone_workflow, title:
@@ -11406,6 +11634,34 @@ msgstr "發佈"
 msgid "published"
 msgstr "已發佈"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11418,6 +11674,18 @@ msgstr ""
 #, fuzzy
 msgid "read_more"
 msgstr "閱讀更多"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11439,6 +11707,10 @@ msgstr ""
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "請記得登出"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11472,6 +11744,10 @@ msgstr ""
 #. Default: "File path to the rules file"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
 msgstr ""
 
 #. Default: "Select Prefix"
@@ -11605,6 +11881,30 @@ msgstr ""
 #. Default: "Tags to remove"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
 msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
@@ -11858,6 +12158,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "昨天"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12222,6 +12526,10 @@ msgstr ""
 msgid "types_controlpanel_warn_remap"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12289,6 +12597,22 @@ msgstr ""
 msgid "warning_contentrules_disabled"
 msgstr ""
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12297,6 +12621,54 @@ msgstr ""
 #. Default: "This item is being edited by ${creator} in ${working_copy} created on ${created}."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
 msgstr ""
 
 #. Default: "Yes"

--- a/plone/app/locales/locales/zh_TW/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/zh_TW/LC_MESSAGES/plone.po
@@ -3576,6 +3576,10 @@ msgstr "沒有內容需要昇級。"
 msgid "No email address is registered for member: ${member_id}"
 msgstr "這位成員沒有登記電郵地址: ${member_id}"
 
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:8
+msgid "No file provided."
+msgstr ""
+
 #: plone.app.collection/plone/app/collection/browser/templates/thumbnail_view.pt:72
 msgid "No images found in this collection."
 msgstr "搜尋結果裡沒有圖檔。"
@@ -6432,10 +6436,18 @@ msgstr "路徑前置值"
 msgid "action_convert_legacy_portlets"
 msgstr "舊式資訊方框在這裡設定。點選按鈕，轉換成新式資訊方框。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
+msgid "add"
+msgstr ""
+
 #. Default: "Comment"
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:128
 msgid "add_comment_button"
 msgstr "留言"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:17
+msgid "add_date"
+msgstr ""
 
 #. Default: "Add new fieldset…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:13
@@ -6446,6 +6458,14 @@ msgstr "新增欄位集…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
 msgstr "新增欄位…"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
+msgid "add_rules"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:60
+msgid "additional_date"
+msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
 #: plone.app.content/plone/app/content/browser/templates/delete_confirmation.pt:18
@@ -6470,6 +6490,10 @@ msgstr "確定要刪除這目錄以及它包含的所有項目?"
 #: CMFPlone/browser/search.py:147
 msgid "alphabetically"
 msgstr "依字母順序"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:129
+msgid "already_added"
+msgstr ""
 
 #. Default: "<any>"
 #: Archetypes/ArchetypeTool.py:848
@@ -6606,6 +6630,14 @@ msgstr "刪除"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:65
 msgid "bulkactions_publish"
 msgstr "審核"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:122
+msgid "bysetpos"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:57
+msgid "cancel"
+msgstr ""
 
 #. Default: "Cancel"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:101
@@ -6772,6 +6804,14 @@ msgstr "目前的佈景主題"
 msgid "current_theme_description"
 msgstr "目前佈景主題的名稱，也就是最近更新的設定值。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
+msgid "daily_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:20
+msgid "daily_interval_2"
+msgstr ""
+
 #: CMFPlone/browser/search.py:144
 msgid "date (newest first)"
 msgstr "日期 (新的優先)"
@@ -6800,6 +6840,10 @@ msgstr "刪除目前檔案"
 #: Archetypes/skins/archetypes/widgets/image.pt:85
 msgid "delete_image"
 msgstr "刪除目前圖檔"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:12
+msgid "delete_rules"
+msgstr ""
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:611
@@ -7349,6 +7393,14 @@ msgstr "你已經完成帳號註冊。"
 msgid "description_you_can_log_on_now"
 msgstr "點選按鈕可以立即登入系統。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:9
+msgid "display_activate"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:8
+msgid "display_unactivate"
+msgstr ""
+
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:162
 msgid "doctype"
@@ -7376,6 +7428,10 @@ msgstr "編輯留言"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:58
 msgid "edit_comment_form_title"
 msgstr "編輯"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
+msgid "edit_rules"
+msgstr ""
 
 #. Default: "Cookies are not enabled. You must ${enable_cookies} before you can log in."
 #: plone.app.openid/plone/app/openid/skins/ploneopenid/login_form.cpt:156
@@ -7444,6 +7500,14 @@ msgstr "${name} 是必填欄位，請更正。"
 msgid "error_vocabulary"
 msgstr "資料值 ${val} 不能用於元件 ${label} 的字彙集裡。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
+msgid "except"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
+msgid "exclude"
+msgstr ""
+
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:28
 msgid "exclude_from_nav"
@@ -7462,6 +7526,21 @@ msgstr ""
 #. Default: "You can't set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:205
 msgid "field_edit_error_values_and_name"
+msgstr ""
+
+#. Default: "Keep existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:57
+msgid "file_keep"
+msgstr ""
+
+#. Default: "Remove existing file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:70
+msgid "file_remove"
+msgstr ""
+
+#. Default: "Replace with new file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_input.pt:82
+msgid "file_replace"
 msgstr ""
 
 #: CMFPlone/browser/templates/search.pt:283
@@ -8716,9 +8795,32 @@ msgstr "HTML"
 msgid "if_all_conditions_met"
 msgstr "如果下列條件全部符合:"
 
+#. Default: "Keep existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:61
+msgid "image_keep"
+msgstr ""
+
+#. Default: "Remove existing image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:74
+msgid "image_remove"
+msgstr ""
+
+#. Default: "Replace with new image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_input.pt:86
+msgid "image_replace"
+msgstr ""
+
 #: plone.app.textfield/plone/app/textfield/interfaces.py:33
 msgid "in characters"
 msgstr "以字元數計算"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:61
+msgid "include"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
+msgid "including"
+msgstr ""
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
 #: plone.app.layout/plone/app/layout/dashboard/dashboard.py:32
@@ -10953,6 +11055,10 @@ msgstr "由於已停用 cookie 認證，無法使用 cookie 來進行登入。"
 msgid "login_portlet_disabled"
 msgstr "Cookie 認證被關閉，無法使用登入資訊方框。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:117
+msgid "long_date_format"
+msgstr ""
+
 #. Default: "A comment on '${title}' has been posted here: ${link}\n\n---\n${text}\n---\n"
 #: plone.app.discussion/plone/app/discussion/comment.py:47
 msgid "mail_notification_message"
@@ -11054,6 +11160,54 @@ msgstr "昇級預設型別成為 Dexterity。"
 msgid "migration-section in the documentation of plone.app.contenttypes"
 msgstr "plone.app.contenttypes 的文件說明"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:27
+msgid "monthly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:28
+msgid "monthly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:29
+msgid "monthly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:30
+msgid "monthly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:31
+msgid "monthly_day_of_month_4"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:25
+msgid "monthly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:26
+msgid "monthly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:36
+msgid "monthly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:32
+msgid "monthly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:33
+msgid "monthly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:34
+msgid "monthly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:35
+msgid "monthly_weekday_of_month_3"
+msgstr ""
+
 #. Default: "More…"
 #: plone.portlet.collection/plone/portlet/collection/collection.pt:57
 msgid "more_url"
@@ -11079,6 +11233,10 @@ msgstr "必須設定密碼或是選擇寄送通知信件。"
 msgid "msg_text_too_long"
 msgstr "文字過長 (最多 ${max} 字元)。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:121
+msgid "multiple_day_of_month"
+msgstr ""
+
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:66
 msgid "narrow_search_options"
@@ -11098,6 +11256,40 @@ msgstr "出現"
 #: plone.app.layout/plone/app/layout/viewlets/review_history.pt:59
 msgid "no_comments"
 msgstr "沒有附註。"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:128
+msgid "no_end_after_n_occurrences"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:125
+msgid "no_end_date"
+msgstr ""
+
+#. Default: "No file"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/file_display.pt:39
+msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: plone.formwidget.namedfile/plone/formwidget/namedfile/image_display.pt:31
+msgid "no_image"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:124
+msgid "no_repeat_every"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:126
+msgid "no_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:123
+msgid "no_rule"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:120
+msgid "no_template_match"
+msgstr ""
 
 #. Default: "Keep existing file"
 #: Archetypes/skins/archetypes/widgets/file.pt:68
@@ -11123,6 +11315,26 @@ msgstr "或"
 msgid "or_upload_a_file"
 msgstr "或上傳一個檔案（現有內容將被覆蓋）"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:65
+msgid "order_indexes_first"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:68
+msgid "order_indexes_fourth"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:69
+msgid "order_indexes_last"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:66
+msgid "order_indexes_second"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:67
+msgid "order_indexes_third"
+msgstr ""
+
 #. Default: "Parameter expressions"
 #: plone/app/theming/interfaces.py:145
 msgid "parameter_expressions"
@@ -11132,6 +11344,10 @@ msgstr "參數表示式"
 #: plone/app/theming/interfaces.py:146
 msgid "parameter_expressions_description"
 msgstr "用來指定佈景主題的編譯參數，在規則檔裡可以用 <code>$name</code> 來存取參數，參數是使用 TALES 表示式來定義，運算結果可以是字串、數字、布林值、或 None。可供使用的變數包括 <code>context</code>、<code>request</code>、<code>portal</code>、<code>portal_state</code>、<code>context_state</code> 等。請逐行定義每個變數，格式範例 <code>name = expression</code>。"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
+msgid "past_end_date"
+msgstr ""
 
 #. Default: "pending"
 #: workflow state defined in plone_workflow - title Pending
@@ -11150,6 +11366,14 @@ msgstr "plone.app.collection"
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:32
 msgid "plone.app.iterate: Test fixture"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/configure.zcml:20
+msgid "plone.formwidget.recurrence resource registration."
 msgstr ""
 
 #: plone.protect/plone/protect/configure.zcml:31
@@ -11176,6 +11400,10 @@ msgstr "沿用"
 msgid "portlets_value_use_parent"
 msgstr "沿用上層設定值"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:16
+msgid "preview"
+msgstr ""
+
 #. Default: "private"
 #: workflow state defined in folder_workflow - title Private
 #: workflow state defined in plone_workflow - title Private
@@ -11199,6 +11427,34 @@ msgstr "發佈"
 msgid "published"
 msgstr "已公開"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:49
+msgid "range"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:54
+msgid "range_by_end_date"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:55
+msgid "range_by_end_date_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:51
+msgid "range_by_occurrences_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:52
+msgid "range_by_occurrences_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:53
+msgid "range_by_occurrences_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:50
+msgid "range_no_end"
+msgstr ""
+
 #. Default: "Read network"
 #: plone/app/theming/interfaces.py:119
 msgid "readNetwork"
@@ -11210,6 +11466,18 @@ msgstr "讀取網路設定值"
 #: plone.app.collection/plone/app/collection/browser/templates/summary_view.pt:52
 msgid "read_more"
 msgstr "閱讀全文"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:59
+msgid "recurrence_start"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:18
+msgid "recurrence_type"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:14
+msgid "refresh"
+msgstr ""
 
 #. Default: "Cookie authentication has been disabled."
 #: CMFPlone/skins/plone_login/registered.pt:13
@@ -11229,6 +11497,10 @@ msgstr "相關程度"
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:166
 msgid "remember_to_log_out"
 msgstr "完成工作後，請記得登出或關閉瀏覽器。"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:63
+msgid "remove"
+msgstr ""
 
 #. Default: "The following users have been sent an e-mail with link to reset their password: ${user_ids}"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.py:194
@@ -11260,6 +11532,10 @@ msgstr "規則檔"
 #: plone/app/theming/interfaces.py:101
 msgid "rules_file_path"
 msgstr "規則檔的路徑"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:58
+msgid "save"
+msgstr ""
 
 #. Default: "Select Prefix"
 #: plone.app.registry/plone/app/registry/browser/records.pt:62
@@ -11392,6 +11668,30 @@ msgstr "想要新增的關鍵詞"
 #: plone.app.content/plone/app/content/browser/contents/templates/tags.pt:2
 msgid "tags_to_remove"
 msgstr "想要移除的關鍵詞"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:131
+msgid "template_daily"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:132
+msgid "template_mondayfriday"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:135
+msgid "template_monthly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:133
+msgid "template_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:134
+msgid "template_weekly"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:136
+msgid "template_yearly"
+msgstr ""
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
 msgid "test wc workflow"
@@ -11640,6 +11940,10 @@ msgstr ":"
 #: CMFPlone/browser/templates/search.pt:121
 msgid "time_yesterday"
 msgstr "昨天"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:15
+msgid "title"
+msgstr ""
 
 #. Default: "Actions for the current content item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:47
@@ -12001,6 +12305,10 @@ msgstr "版本管理方式："
 msgid "types_controlpanel_warn_remap"
 msgstr "變更內容型別的工作流程，必須花費時間進行更新，在更新的過程，也可能會使系統明顯變慢。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
+msgid "unsupported_features"
+msgstr ""
+
 #. Default: "Replace with new file:"
 #: Archetypes/skins/archetypes/widgets/file.pt:99
 msgid "upload_file"
@@ -12066,6 +12374,22 @@ msgstr "語文中性 (預設值)"
 msgid "warning_contentrules_disabled"
 msgstr "內容規則已全面停用。要重新啟用之後，指派的內容規則才會執行。請到 ${controlpanel_link} 來重新啟用它們。"
 
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:21
+msgid "weekly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:22
+msgid "weekly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:23
+msgid "weekly_weekdays"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:24
+msgid "weekly_weekdays_human"
+msgstr ""
+
 #. Default: "Policy..."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:794
 msgid "workflow_policy"
@@ -12075,6 +12399,54 @@ msgstr "規則..."
 #: plone.app.iterate/plone/app/iterate/browser/info_baseline.pt:20
 msgid "working_copy_info"
 msgstr "這個項目由 ${creator} 編輯中，工作備份 ${working_copy} 建立於 ${created}。"
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:39
+msgid "yearly_day_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:40
+msgid "yearly_day_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:41
+msgid "yearly_day_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:42
+msgid "yearly_day_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:37
+msgid "yearly_interval_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:38
+msgid "yearly_interval_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:48
+msgid "yearly_repeat_on"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:43
+msgid "yearly_weekday_of_month_1"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:44
+msgid "yearly_weekday_of_month_1_human"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:45
+msgid "yearly_weekday_of_month_2"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:46
+msgid "yearly_weekday_of_month_3"
+msgstr ""
+
+#: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:47
+msgid "yearly_weekday_of_month_4"
+msgstr ""
 
 #. Default: "Yes"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:32


### PR DESCRIPTION
As a side effect the messages of p.formwidget.recurrence got recreated
again. But this time the references to the place where translation
is located in the source is created.