### PR TITLE
fix german translation

### DIFF
--- a/plone/app/locales/locales/de/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/widgets.po
@@ -537,7 +537,7 @@ msgstr "Designvorschau"
 
 #: ./patterns/livesearch/pattern.js
 msgid "Previous"
-msgstr "Nächste"
+msgstr "Zurück"
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Query"


### PR DESCRIPTION
instead of prev it sayed next.. so the livesearch would show next next instead of prev next