### PR TITLE
Minor German updates.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 5.0.11 (unreleased)
 -------------------
 
+- Minor German updates.
+  [thet]
+
 - Updated Tranditional Chinese translations.
   [l34marr]
 

--- a/plone/app/locales/locales/de/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/plone.po
@@ -8282,7 +8282,7 @@ msgstr ""
 #: Archetypes/ExtensibleMetadata.py:93
 #: plone.app.dexterity/plone/app/dexterity/behaviors/metadata.py:73
 msgid "help_description"
-msgstr "Die Zusammenfassung wird angezeigt in Auflistungen und Suchresultaten."
+msgstr "Die Zusammenfassung wird in Auflistungen und Suchresultaten angezeigt."
 
 #. Default: "Some discussion related settings are not located in the Discussion Control Panel.\nTo enable comments for a specific content type, go to the Types Control Panel of this type and choose \"Allow comments\".\nTo enable the moderation workflow for comments, go to the Types Control Panel, choose \"Comment\" and set workflow to \"Comment Review Workflow\"."
 #: plone.app.discussion/plone/app/discussion/browser/controlpanel.py:28


### PR DESCRIPTION
... actually update without the plural-s.

There is another thing with ``help_description``:

"Used in item listings and search results." isn't quite right. It's acually used there AND in detail views of their contents.
IMO, that should be changed to - but then in all languages.

