### PR TITLE
Ort -> Pfad, Daten -> Datum

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 5.0.11 (unreleased)
 -------------------
 
+- German: Change the querystring criteria group from "Daten" to "Datum".
+  It's right, that "Daten" is the plural of "Datum".
+  But the naming is misleading and means the same like the english "data".
+  [thet]
+
 - German: Change "Ort" to "Path" for translations indicating the hierarchical location of some content.
   Fixes: #117
   [thet]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 5.0.11 (unreleased)
 -------------------
 
+- German: Change "Ort" to "Path" for translations indicating the hierarchical location of some content.
+  Fixes: #117
+  [thet]
+
 - Minor German updates.
   [thet]
 

--- a/plone/app/locales/locales/de/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/plone.po
@@ -1521,7 +1521,7 @@ msgstr ""
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 msgid "Dates"
-msgstr "Daten"
+msgstr "Datum"
 
 #: Archetypes/browser/templates/calendar_macros.pt:108
 msgid "Day"

--- a/plone/app/locales/locales/de/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/plone.po
@@ -3029,12 +3029,12 @@ msgstr ""
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 #: plone.app.querystring/plone/app/querystring/profiles/upgrades/to_5/registry.xml
 msgid "Location"
-msgstr "Ort"
+msgstr "Pfad"
 
 #. Default: "Location in site"
 #: criterion description of criterion ATPathCriterion
 msgid "Location in site"
-msgstr "Ort in der Website"
+msgstr "Pfad in der Website"
 
 #: ATContentTypes/criteria/relativepath.py
 #: criterion description of criterion ATRelativePathCriterionSchema
@@ -3049,7 +3049,7 @@ msgstr ""
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 #: plone.app.querystring/plone/app/querystring/profiles/upgrades/to_5/registry.xml
 msgid "Location in the site structure"
-msgstr "Ort in der Seitenstruktur"
+msgstr "Pfad in der Seitenstruktur"
 
 #: plone.app.lockingbehavior/plone/app/lockingbehavior/configure.zcml:17
 msgid "Locking"


### PR DESCRIPTION
- German: Change "Ort" to "Path" for translations indicating the hierarchical location of some content.
Fixes: #117

- German: Change the querystring criteria group from "Daten" to "Datum".
It's right, that "Daten" is the plural of "Datum".
But the naming is misleading and means the same like the english "data".