### PR TITLE
German(de), fix resource --> Ressource

### DIFF
--- a/plone/app/locales/locales/de/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/plone.po
@@ -3059,7 +3059,7 @@ msgstr ""
 
 #: CMFPlone/interfaces/resources.py:78
 msgid "Loaded resources"
-msgstr "Geladene Resourcen"
+msgstr "Geladene Ressourcen"
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:506
 msgid "Local Roles"
@@ -4455,23 +4455,23 @@ msgstr "Pflichtfeld"
 #: CMFPlone/controlpanel/browser/resourceregistry.pt:20
 #: CMFPlone/profiles/default/controlpanel.xml
 msgid "Resource Registries"
-msgstr "Resourcen Registrierung"
+msgstr "Ressourcen Registrierung"
 
 #: CMFPlone/controlpanel/browser/tinymce.py:26
 msgid "Resource Types"
-msgstr "Resourcentypen"
+msgstr "Ressourcentypen"
 
 #: CMFPlone/resources/viewlets/settings.py:15
 msgid "Resource bundles for themes"
-msgstr "Resourcen Bündel für Designs"
+msgstr "Ressourcen Bündel für Designs"
 
 #: CMFPlone/interfaces/resources.py:81
 msgid "Resource name"
-msgstr "Resourcenname"
+msgstr "Ressourcenname"
 
 #: CMFPlone/interfaces/resources.py:16
 msgid "Resources base URL"
-msgstr "Resourcen Basis URL"
+msgstr "Ressourcen Basis URL"
 
 #. Default: "Restart"
 #: CMFPlone/controlpanel/browser/maintenance.pt:75

--- a/plone/app/locales/locales/de/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/widgets.po
@@ -62,7 +62,7 @@ msgstr "Pattern hinzufügen"
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Add resource"
-msgstr "Resource hinzufügen"
+msgstr "Ressource hinzufügen"
 
 #: ./patterns/resourceregistry/js/less.js
 msgid "Add variable"
@@ -94,11 +94,11 @@ msgstr "Sind Sie sicher, dass sie das Bundle ${name} löschen wollen?"
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Are you sure you want to delete the ${name} resource?"
-msgstr "Sind Sie sicher, dass sie die Resource ${name} löschen wollen?"
+msgstr "Sind Sie sicher, dass sie die Ressource ${name} löschen wollen?"
 
 #: ./patterns/filemanager/js/delete.js
 msgid "Are you sure you want to delete this resource?"
-msgstr "Sind Sie sicher, dass sie diese Resource löschen wollen?"
+msgstr "Sind Sie sicher, dass sie diese Ressource löschen wollen?"
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Automatically generated path to the compiled CSS."
@@ -198,7 +198,7 @@ msgstr "Bedingter Kommentar"
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Conditional expression to decide if this resource will run"
-msgstr "Bedingung die darüber entscheidet ob eine Resource verwendet wird"
+msgstr "Bedingung die darüber entscheidet ob eine Ressource verwendet wird"
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Configuration"
@@ -238,7 +238,7 @@ msgstr "Löschen"
 
 #: ./patterns/filemanager/pattern.js
 msgid "Delete currently selected resource"
-msgstr "Ausgewählte resource löschen"
+msgstr "Ausgewählte Ressource löschen"
 
 #: ./patterns/resourceregistry/js/overrides.js
 msgid "Delete customizations"
@@ -322,7 +322,7 @@ msgstr "Fehler beim kompilieren des css bundles"
 
 #: ./patterns/resourceregistry/js/builder.js
 msgid "Error building resources"
-msgstr "Fehler beim kompilieren der Resourcen"
+msgstr "Fehler beim kompilieren der Ressourcen"
 
 #: ./patterns/resourceregistry/js/builder.js
 msgid "Error compiling less"
@@ -386,7 +386,7 @@ msgstr "Dateiname"
 
 #: ./patterns/resourceregistry/js/overrides.js
 msgid "Filename must start with ++plone++static/"
-msgstr "Der Dateiname muss mus ++plone++static/ anfangen"
+msgstr "Der Dateiname muss mit ++plone++static/ anfangen"
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
@@ -398,7 +398,7 @@ msgstr "Filter..,"
 
 #: ./patterns/filemanager/js/customize.js
 msgid "Find resource in plone to override"
-msgstr "Resource zum Überschreiben in Plone suchen"
+msgstr "Ressource zum Überschreiben in Plone suchen"
 
 #: ./patterns/resourceregistry/js/builder.js
 msgid "Finished!"
@@ -466,7 +466,7 @@ msgstr "Less Variablen"
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "List of CSS/LESS files to use for resource"
-msgstr "Liste der CSS/LESS-Dateien für diese Resource"
+msgstr "Liste der CSS/LESS-Dateien für diese Ressource"
 
 #: ./patterns/structure/js/views/generic-popover.js
 msgid "Loading..."
@@ -498,7 +498,7 @@ msgstr "Kein JavaScript zu bauen, übergehe"
 
 #: ./patterns/resourceregistry/js/overrides.js
 msgid "Only ++plone++ resources are available to override"
-msgstr "Nur ++plone++ Resources können überschrieben werden"
+msgstr "Nur ++plone++ Ressourcen können überschrieben werden"
 
 #: ./patterns/tinymce/pattern.js
 msgid "Open in new window"


### PR DESCRIPTION
Resource is spelled Ressource in German, see [wikipedia/Ressource](https://de.wikipedia.org/wiki/Ressource) for example.