### PR TITLE
German translations: Fix typo in theming controlpanel

### DIFF
--- a/plone/app/locales/locales/de/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/plone.po
@@ -7434,7 +7434,7 @@ msgstr "Wenn Ihr Benutzername und Passwort korrekt sind, lässt Ihr Browser even
 #. Default: "Please note that this control panel page will never be themed."
 #: plone/app/theming/browser/controlpanel.pt:56
 msgid "description_notheme_controlpanel"
-msgstr "Bitte beachten Sie, das die diese Einstellungsseite niemals das Design erhält."
+msgstr "Bitte beachten Sie, dass diese Einstellungsseite niemals das Design erhält."
 
 #. Default: "Note: Some or all of your PAS groups source plugins do not allow listing of groups, so you may not see the groups defined by those plugins unless doing a specific search."
 #: CMFPlone/controlpanel/browser/usergroups_groupsoverview.pt:72


### PR DESCRIPTION
... in translation for "Please note that this control panel page will never be themed."