### PR TITLE
update german translations

### DIFF
--- a/docs/terms-de.txt
+++ b/docs/terms-de.txt
@@ -23,7 +23,7 @@ Last update: 14.03.2010
 Wenn wichtige Begriffe fehlen, bitte ersetzen.
 
      acquire        =
-     action         =
+     action         = Aktion
      Add-on Products = Erweiterung
      advanced       = erweitert
      area           = Bereich
@@ -34,17 +34,19 @@ Wenn wichtige Begriffe fehlen, bitte ersetzen.
      collection     = Kollektion
      comment        = Kommentar
      configuration, preference =
-     content        =
+     content        = Inhalt
      cookies        = Cookies
      criteria       = Kriterien
      criterion      = Kriterium
-     default        =
+     default        = Vorgabe, Vorgabewert
      delete         = entfernen
      description    = Zusammenfassung
      detail         =
      disable        = ausschalten
      discussion     =
      effect         =
+     effective date = Freigabedatum
+     expiration date = Ablaufdatum
      e-mail (also mail) = E-Mail
      enable         = einschalten
      entry          = Eintrag
@@ -92,7 +94,7 @@ Wenn wichtige Begriffe fehlen, bitte ersetzen.
      remove         =
      reply          =
      required       =
-     retract        =
+     retract        = zurückziehen
      reviewer       =
      review         =
      rights         =
@@ -112,12 +114,12 @@ Wenn wichtige Begriffe fehlen, bitte ersetzen.
      tool           =
      transaction    =
      transcript     =
-     undo           =
+     undo           = Rückgängig
      uncheck        =
      unique         =
      update         =
      upload         =
-     URL            =
+     URL            = URL
      validator      =
      visible        =
      web site       =
@@ -135,9 +137,10 @@ stubs of words that should be searched and replaced at the end of work:
 
 3) Verschiedene sprachspezifische Regeln
 
-Die Begriffe "Freigabe" und "Veröffentlichung" werden oft gleich verstanden. Damit innerhalb Plone zwischen dem Arbeitsabluaf (Workflow) und dem Zeitraum (Effective Range) keine Verwechslung entsteht, soll 
+Die Begriffe "Freigabe" und "Veröffentlichung" werden oft gleich verstanden.
+Damit innerhalb Plone zwischen dem Arbeitsablauf (Workflow) und dem Zeitraum (Effective Range) keine Verwechslung entsteht, soll
 
-- für alles Arbeitsablauf spezifische "Veröffentlung" bzw. Mutationen davon verwendet werden und
+- für alles Arbeitsablauf spezifische "Veröffentlichung" bzw. Mutationen davon verwendet werden und
 - für alles Zeitraum bezogene das Wort "Freigabe" bzw. Mutationen davon verwendet werden.
 
 

--- a/plone/app/locales/locales/de/LC_MESSAGES/atcontenttypes.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/atcontenttypes.po
@@ -281,12 +281,12 @@ msgstr "Bestimmen Sie welche Indices angezeigt werden sollen, wenn Sie Kriterien
 #. Default: "Select the types which will be addable inside this folder."
 #: ATContentTypes/lib/constraintypes.py:78
 msgid "description_constrain_allowed_types"
-msgstr "Bestimmen Sie welche Artikeltypen in diesem Ordner hinzufügbar sein sollen."
+msgstr "Bestimmen Sie welche Inhaltstypen in diesem Ordner hinzufügbar sein sollen."
 
 #. Default: "Select the types which will be addable from the \"Add new item\" menu. Any additional types set in the list above will be addable from a separate form."
 #: ATContentTypes/lib/constraintypes.py:102
 msgid "description_constrain_preferred_types"
-msgstr "Bestimmen Sie bitte, welche der oben ausgewählten Artikeltypen direkt durch das »Neuen Artikel hinzufügen«-Menü hinzugefügt werden können. Alle weiteren ausgewählten Artikeltypen können erst durch ein erweitertes Formular hinzugefügt werden."
+msgstr "Bestimmen Sie bitte, welche der oben ausgewählten Inhaltstypen direkt durch das »Neuen Artikel hinzufügen«-Menü hinzugefügt werden können. Alle weiteren ausgewählten Inhaltstypen können erst durch ein erweitertes Formular hinzugefügt werden."
 
 #. Default: "Select the constraint type mode for this folder."
 #: ATContentTypes/lib/constraintypes.py:57
@@ -479,7 +479,7 @@ msgstr "Ordner, in denen gesucht werden soll."
 #. Default: "One of the available content types."
 #: ATContentTypes/criteria/portaltype.py:22
 msgid "help_portal_type_criteria_value"
-msgstr "Einer der registrierten Artikeltypen."
+msgstr "Einer der registrierten Inhaltstypen."
 
 #. Default: "Select transformation method."
 #: ATContentTypes/skins/ATContentTypes/atct_image_transform.pt:34
@@ -551,12 +551,12 @@ msgstr "Kollektionsmetadaten"
 #. Default: "Permitted types"
 #: ATContentTypes/lib/constraintypes.py:76
 msgid "label_constrain_allowed_types"
-msgstr "Erlaubte Artikeltypen"
+msgstr "Erlaubte Inhaltstypen"
 
 #. Default: "Preferred types"
 #: ATContentTypes/lib/constraintypes.py:100
 msgid "label_constrain_preferred_types"
-msgstr "Bevorzugte Artikeltypen"
+msgstr "Bevorzugte Inhaltstypen"
 
 #. Default: "Contact E-mail"
 #: ATContentTypes/content/event.py:134

--- a/plone/app/locales/locales/de/LC_MESSAGES/cmfeditions.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/cmfeditions.po
@@ -106,7 +106,7 @@ msgstr "Speichere als neue Version"
 #: CMFEditions/skins/CMFEditions/versioning_config_form.pt:31
 msgid "description_version_settings"
 msgstr ""
-"Sie können unterschiedliche Einstellungen per Artikeltyp vornehmen. Artikel "
+"Sie können unterschiedliche Einstellungen per Inhaltstyp vornehmen. Artikel "
 "können automatisch versioniert werden und es können auch automatisch neue "
 "Versionen beim Zurückspringen zu einer alten Version erstellt werden."
 
@@ -213,7 +213,7 @@ msgstr "${version} (${date})"
 #. Default: "Item Type"
 #: CMFEditions/skins/CMFEditions/versioning_config_form.pt:66
 msgid "label_item_type"
-msgstr "Artikeltyp"
+msgstr "Inhaltstyp"
 
 #. Default: "modifications from revision ${version_id}"
 #: CMFEditions/skins/CMFEditions/versions_history_form.pt:69
@@ -278,17 +278,17 @@ msgstr "Änderungsnotiz"
 #. Default: "Versionable content types"
 #: CMFEditions/skins/CMFEditions/versioning_config_form.pt:43
 msgid "label_versionable_content_types"
-msgstr "Versionsfähige Artikeltypen "
+msgstr "Versionsfähige Inhaltstypen "
 
 #. Default: "Show all types"
 #: CMFEditions/skins/CMFEditions/versioning_config_form.pt:48
 msgid "label_versioning_config_show_all"
-msgstr "Zeige alle Artikeltypen"
+msgstr "Zeige alle Inhaltstypen"
 
 #. Default: "Show only searchable types"
 #: CMFEditions/skins/CMFEditions/versioning_config_form.pt:52
 msgid "label_versioning_config_show_friendly"
-msgstr "Zeige nur durchsuchbare Artikeltypen"
+msgstr "Zeige nur durchsuchbare Inhaltstypen"
 
 #. Default: "Policies"
 #: CMFEditions/skins/CMFEditions/versioning_config_form.pt:68
@@ -342,7 +342,7 @@ msgstr "(Es wurde noch keine Datei hochgeladen)"
 #. Default: "This object has no revision information."
 #: CMFEditions/browser/diff.pt:54
 msgid "no_history"
-msgstr "Dieses Objekt enthält keine Versioninformationen."
+msgstr "Dieser Artikel enthält keine Versioninformationen."
 
 #. Default: "Versions History"
 #: CMFEditions/skins/CMFEditions/versions_history.pt:13

--- a/plone/app/locales/locales/de/LC_MESSAGES/cmfeditions.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/cmfeditions.po
@@ -342,7 +342,7 @@ msgstr "(Es wurde noch keine Datei hochgeladen)"
 #. Default: "This object has no revision information."
 #: CMFEditions/browser/diff.pt:54
 msgid "no_history"
-msgstr "Dieser Artikel enthält keine Versioninformationen."
+msgstr "Dieser Inhalt enthält keine Versioninformationen."
 
 #. Default: "Versions History"
 #: CMFEditions/skins/CMFEditions/versions_history.pt:13

--- a/plone/app/locales/locales/de/LC_MESSAGES/cmfplacefulworkflow.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/cmfplacefulworkflow.po
@@ -19,15 +19,15 @@ msgstr ""
 
 #: ./profiles.zcml
 msgid "Add in Plone the capability to change workflow chains for types in every object."
-msgstr "Erweiter Plone um die Möglichkeit, Arbeitsabläufe für Artikeltypen in einzelnen Ordnern zu verändern"
+msgstr "Erweitert Plone um die Möglichkeit, Arbeitsabläufe für Inhaltstypen in einzelnen Ordnern zu verändern"
 
 #: CMFPlacefulWorkflow/profiles.zcml:12
 msgid "Add in Plone the capability to change workflow chains for types in every object. Includes a dependency on core Plone types."
-msgstr "Erweiter Plone um die Möglichkeit, Arbeitsabläufe für Artikeltypen in einzelnen Ordnern zu verändern"
+msgstr "Erweitert Plone um die Möglichkeit, Arbeitsabläufe für Inhaltstypen in einzelnen Ordnern zu verändern. Beinhaltet eine Abhängigkeit auf die Kern-Plone-Inhaltstypen."
 
 #: CMFPlacefulWorkflow/profiles.zcml:20
 msgid "Add in Plone the capability to change workflow chains for types in every object. With no dependency on core Plone types."
-msgstr "Erweiter Plone um die Möglichkeit, Arbeitsabläufe für Artikeltypen in einzelnen Ordnern zu verändern"
+msgstr "Erweitert Plone um die Möglichkeit, Arbeitsabläufe für Inhaltstypen in einzelnen Ordnern zu verändern.  Beinhaltet keine Abhängigkeit auf die Kern-Plone-Inhaltstypen."
 
 #: CMFPlacefulWorkflow/skins/CMFPlacefulWorkflow/placeful_workflow_configuration_set.py:36
 msgid "Changed policies."
@@ -136,7 +136,7 @@ msgstr "Aktualisierungssicherheit"
 #. Default: "Custom workflow policy which maps content types to workflows."
 #: CMFPlacefulWorkflow/skins/CMFPlacefulWorkflow/prefs_workflow_policy_mapping.pt:45
 msgid "description_workflow_custom_mapping"
-msgstr "Spezifische Richtlinie, die Artikeltypen Arbeitsabläufen zuordnet."
+msgstr "Spezifische Richtlinie, die Inhaltstypen Arbeitsabläufen zuordnet."
 
 #. Default: "Set your workflow policies' local configuration for this folder and below."
 #: CMFPlacefulWorkflow/skins/CMFPlacefulWorkflow/placeful_workflow_configuration.pt:38
@@ -161,7 +161,7 @@ msgstr "Lokale Konfiguration der Richtlinien für Arbeitsabläufe"
 #. Default: "Default workflow for content types."
 #: CMFPlacefulWorkflow/skins/CMFPlacefulWorkflow/prefs_workflow_policy_mapping.pt:113
 msgid "help_default_workflow_for_types"
-msgstr "Voreingestellter Arbeitsablauf für Artikeltypen."
+msgstr "Voreingestellter Arbeitsablauf für Inhaltstypen."
 
 #. Default: "The default workflow policy."
 #: CMFPlacefulWorkflow/skins/CMFPlacefulWorkflow/placeful_workflow_configuration.pt:130
@@ -171,7 +171,7 @@ msgstr "Die voreingestellte Richtlinie für Arbeitsabläufe."
 #. Default: "You can assign a workflow for all content types."
 #: CMFPlacefulWorkflow/skins/CMFPlacefulWorkflow/prefs_workflow_policy_mapping.pt:139
 msgid "help_workflow_assign_all_types"
-msgstr "Sie können allen Artikeltypen einen Arbeitsablauf zuweisen."
+msgstr "Sie können allen Inhaltstypen einen Arbeitsablauf zuweisen."
 
 #. Default: "A brief description of the workflow policy."
 #: CMFPlacefulWorkflow/skins/CMFPlacefulWorkflow/prefs_workflow_policy_mapping.pt:91
@@ -281,7 +281,7 @@ msgstr "Details der Richtlinien"
 #. Default: "Workflow to content type mapping."
 #: CMFPlacefulWorkflow/skins/CMFPlacefulWorkflow/prefs_workflow_policy_mapping.pt:143
 msgid "summary_workflow_type_mapping"
-msgstr "Zuordnung von Arbeitsabläufen und Artikeltypen"
+msgstr "Zuordnung von Arbeitsabläufen und Inhaltstypen"
 
 #. Default: "Workflow Policies Setup"
 #: CMFPlacefulWorkflow/skins/CMFPlacefulWorkflow/prefs_workflow_localpolicies_form.pt:60

--- a/plone/app/locales/locales/de/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/plone.po
@@ -304,11 +304,11 @@ msgstr "Ein einfacher Freigabe Workflow für Kommentare"
 
 #: CMFPlone/interfaces/controlpanel.py:1644
 msgid "A value for the quality of 2x high pixel density images, from 1 (lowest) to 95 (highest). A value of 0 will mean plone.scaling's default will be used, which is currently 62."
-msgstr "Ein Wert für die Qualität des 2x höherauflösenden skalierten Bildes, von 1 (niedrigste Qualität) bis 95 (höchste Qualität). Der Wert 0 bewirkt, dass die Voreinstellung von plone.scaling benutzt wird, die zurzeit 62 beträgt."
+msgstr "Ein Wert für die Qualität des skalierten Bildes mit 2-facher Auflösung, von 1 (niedrigste Qualität) bis 95 (höchste Qualität). Der Wert 0 bewirkt, dass die Voreinstellung von plone.scaling benutzt wird, die zurzeit 62 beträgt."
 
 #: CMFPlone/interfaces/controlpanel.py:1655
 msgid "A value for the quality of 3x high pixel density images, from 1 (lowest) to 95 (highest). A value of 0 will mean plone.scaling's default will be used, which is currently 51."
-msgstr "Ein Wert für die Qualität des 3x höherauflösenden skalierten Bildes, von 1 (niedrigste Qualität) bis 95 (höchste Qualität). Der Wert 0 bewirkt, dass die Voreinstellung von plone.scaling benutzt wird, die zurzeit 51 beträgt."
+msgstr "Ein Wert für die Qualität des skalierten Bildes mit 3-facher Auflösung, von 1 (niedrigste Qualität) bis 95 (höchste Qualität). Der Wert 0 bewirkt, dass die Voreinstellung von plone.scaling benutzt wird, die zurzeit 51 beträgt."
 
 #: CMFPlone/interfaces/controlpanel.py:1622
 msgid "A value for the quality of scaled images, from 1 (lowest) to 95 (highest). A value of 0 will mean plone.scaling's default will be used, which is currently 88."
@@ -435,7 +435,7 @@ msgstr "Neuen Inhaltstyp hinzufügen&hellip;"
 
 #: plone.directives.form/plone/directives/form/form.py:186
 msgid "Add New Item operation cancelled"
-msgstr "Operation “Neuer Artikel hinzufügen” abgebrochen"
+msgstr "Operation »Hinzufügen« abgebrochen"
 
 #: plone.app.portlets/plone/app/portlets/portlets/news.py:143
 msgid "Add News Portlet"
@@ -607,7 +607,7 @@ msgstr "Nach dem aktuellen Tag"
 
 #: CMFPlone/interfaces/controlpanel.py:745
 msgid "After the deadline (FLOSS)"
-msgstr ""
+msgstr "'After the Deadline' (FLOSS)"
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 msgid "After today"
@@ -1053,7 +1053,7 @@ msgstr "Änderungen wurden gespeichert."
 
 #: CMFPlone/interfaces/controlpanel.py:1493
 msgid "Characterset to use when sending e-mails."
-msgstr "Charakterset zum Versenden von E-Mails."
+msgstr "Zeichensatzkodierung zum Versenden von E-Mails."
 
 #. Default: "Check in"
 #: plone.app.iterate/plone/app/iterate/browser/checkin.pt:47
@@ -1406,7 +1406,7 @@ msgstr "Es konnte keine gültige E-Mail-Adresse gefunden werden."
 
 #: plone.app.content/plone/app/content/browser/contents/workflow.py:90
 msgid "Could not transition: ${title}"
-msgstr "Übergang konnte nicht durchgeführt werden für: ${title}"
+msgstr "Statusänderung konnte nicht durchgeführt werden für: ${title}"
 
 #: CMFPlone/controlpanel/browser/quickinstaller.py:724
 msgid "Could not uninstall ${product}."
@@ -1419,11 +1419,11 @@ msgstr "Erzeugen"
 
 #: CMFPlone/browser/templates/plone-addsite.pt:206
 msgid "Create Plone Site"
-msgstr "Erzeuge Plone-Site"
+msgstr "Erzeuge Plone-Seite"
 
 #: CMFPlone/browser/templates/plone-addsite.pt:13
 msgid "Create a Plone site"
-msgstr "Erzeuge eine Plone-Site"
+msgstr "Erzeuge eine Plone-Seite"
 
 #: CMFPlone/browser/templates/plone-overview.pt:122
 msgid "Create a new Plone site"
@@ -1466,7 +1466,7 @@ msgstr "IDs der Ersteller"
 
 #: CMFPlone/interfaces/controlpanel.py:1058
 msgid "Crop the item description in search result listings after a number of characters."
-msgstr "Abschneiden der Beschreibung des Inhalts in Suchresultaten auf eine bestimmte Zeichenzahl."
+msgstr "Kürzung der Beschreibung des Inhalts in Suchresultaten auf eine bestimmte Zeichenzahl."
 
 #: plone.app.widgets/plone/app/widgets/utils.py:170
 msgid "Current Content"
@@ -1598,7 +1598,7 @@ msgstr "Standard MIME Typ für Ausgabe"
 
 #: CMFPlone/interfaces/controlpanel.py:1309
 msgid "Default page IDs"
-msgstr "Vorgabe Seiten-IDs"
+msgstr "Standard Inhalts-Ids"
 
 #: plone.app.content/plone/app/content/browser/contents/defaultpage.py:7
 msgid "Default page set successfully"
@@ -1683,7 +1683,7 @@ msgstr "Abhängigkeiten des Shim"
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:44
 #: plone.app.contenttypes/plone/app/contenttypes/migration/custom_migration.pt:38
 msgid "Depending of the number of archetypes in your portal, it may take a <strong>really</strong> long time for the migration to be done. Stay calm, be patient and check your logs for progress-information."
-msgstr ""
+msgstr "Abhängig von der Anzahl der Archtypes in ihrem Portal, kann die Migration eine <strong>wirklich</strong> lange Zeit in Anspruch nehmen. Nehmen sie sich Zeit, seien sie geduldig und überprüfen sie ihre Protokolldateien auf Fortschrittsinformationen."
 
 #: CMFPlone/interfaces/resources.py:97
 msgid "Depends on another bundle"
@@ -1763,7 +1763,7 @@ msgstr "Das Ausschalten der Bearbeitungssperre wirkt sich nur auf die Benutzer a
 
 #: plone.app.content/plone/app/content/browser/contents/paste.py:57
 msgid "Disallowed subobject type \"${type}\""
-msgstr "Unerlaubte Unterinhalte vom Inhaltstyp \"${type}\""
+msgstr "Nicht erlaubte Unterinhalte vom Inhaltstyp \"${type}\""
 
 #: plone.app.discussion/plone/app/discussion/profiles/default/controlpanel.xml
 msgid "Discussion"
@@ -1846,7 +1846,7 @@ msgstr "E-Mail-Adresse"
 
 #: CMFPlone/interfaces/controlpanel.py:1492
 msgid "E-mail characterset"
-msgstr "E-Mail Charakterset"
+msgstr "E-Mail Zeichensatzkodierung"
 
 #: CMFPlone/interfaces/controlpanel.py:1254
 msgid "E.g. standard view; This default can be overriden individually."
@@ -2073,11 +2073,11 @@ msgstr "Persönliche Benutzerordner"
 
 #: CMFPlone/interfaces/controlpanel.py:478
 msgid "Enable auto resizing of the editor window."
-msgstr "Erlaube die automatsiche Größenveränderung des Editor-Fensters."
+msgstr "Erlaube die automatische Größenveränderung des Editor-Fensters."
 
 #: plone.app.iterate/plone/app/iterate/interfaces.py:318
 msgid "Enable checkout workflow"
-msgstr "Arbeitskopie Arbeitsablauf einschalten"
+msgstr "Arbeitskopien einschalten"
 
 #: CMFPlone/interfaces/controlpanel.py:124
 msgid "Enable link integrity checks"
@@ -2166,7 +2166,7 @@ msgstr "Geben Sie Ihr neues Passwort ein. ${errors}"
 
 #: CMFPlone/interfaces/controlpanel.py:836
 msgid "Entity encoding"
-msgstr ""
+msgstr "Entity Codierung"
 
 #: CMFPlone/skins/plone_prefs/prefs_error_log_update.py:23
 msgid "Entries cleared"
@@ -2214,7 +2214,7 @@ msgstr "Fehler: Die bereitgestelle Datei muss ein ZIP-Archiv sein."
 
 #: plone.app.dexterity/plone/app/dexterity/browser/modeleditor.py:64
 msgid "Error: all model elements must be 'schema'"
-msgstr "Fehler: Alle Model-Elemente müssen ein 'schema' sein"
+msgstr "Fehler: Alle Modell-Elemente müssen ein 'schema' sein"
 
 #: plone.app.dexterity/plone/app/dexterity/browser/modeleditor.py:58
 msgid "Error: root tag must be 'model'"
@@ -2495,7 +2495,7 @@ msgstr "Ordner"
 
 #: plone.app.dexterity/plone/app/dexterity/behaviors/configure.zcml:135
 msgid "Folder Addable Constrains"
-msgstr "Hinzufügen Einschränkungen des Ordners"
+msgstr "Einschränkung der erlaubten Inhaltstypen eines Ordners"
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:116
 msgid "Folder URL"
@@ -2512,7 +2512,7 @@ msgstr "Nur für angemeldete Benutzer"
 
 #: CMFPlone/interfaces/controlpanel.py:1177
 msgid "For enabling web statistics support from external providers (e.g. Google Analytics). Paste the provided code snippet here. It will be rendered as entered near the end of the page."
-msgstr "Gedacht für den Webstatistik-Support externer Anbieter (z.B. Google Analytics). Der bereitgestellte Code-Schnipsel wird hier eingefügt. Er wird unverändert nahe dem Ende der Webseite gerendert."
+msgstr "Für den Webstatistik-Support externer Anbieter (z.B. Google Analytics). Der bereitgestellte Code-Schnipsel wird hier eingefügt. Er wird unverändert nahe dem Ende der Webseite gerendert."
 
 #: CMFPlone/interfaces/controlpanel.py:1595
 msgid "For linking Open Graph data to a Facebook account"
@@ -2548,7 +2548,7 @@ msgstr "Allgemein"
 
 #: CMFPlone/controlpanel/browser/types.py:54
 msgid "General types settings."
-msgstr "Allgemeine Inhaltstypen Einstellungen"
+msgstr "Allgemeine Einstellungen der Inhaltstypen"
 
 #: CMFPlone/interfaces/controlpanel.py:907
 msgid "Generate tabs for items other than folders."
@@ -2556,11 +2556,11 @@ msgstr "Erzeuge Reiter nicht nur für Ordner, sondern für alle Inhaltstypen."
 
 #: plone.app.textfield/plone/app/textfield/interfaces.py:75
 msgid "Get the raw value as an encoded string"
-msgstr "Holt den Rohwert als encodierte Zeichenfolge"
+msgstr "Holt den Originalwert als codierte Zeichenfolge."
 
 #: plone.app.dexterity/plone/app/dexterity/behaviors/configure.zcml:145
 msgid "Gives the ability to rename an item from its edit form."
-msgstr "Ermöglicht das Umbenennen eines Artikels aus dem Bearbeiten-Formular heraus."
+msgstr "Ermöglicht das Umbenennen des Kurznames im Bearbeiten-Formular."
 
 #: CMFPlone/browser/templates/plone-logged-out.pt:29
 msgid "Go back to your site."
@@ -2572,7 +2572,7 @@ msgstr "Gehe zu übergeordneten Ordner"
 
 #: CMFPlone/controlpanel/browser/resourceregistry.pt:42
 msgid "Go to the ${configuration_registry} and manually edit the configuration to enable development mode on the resource registry and try to rebuild."
-msgstr ""
+msgstr "Gehen Sie zur ${configuration_registry} und schalten sie den Development Modus auf der Resource-Registry und versuchen sie zu kompilieren."
 
 #: CMFPlone/browser/templates/plone-overview.pt:137
 msgid "Go to the ZMI"
@@ -2621,11 +2621,11 @@ msgstr "HTML-Filtereinstellungen"
 
 #: CMFPlone/controlpanel/browser/filter.py:33
 msgid "HTML generation is heavily cached across Plone. You may have to edit existing content or restart your server to see the changes."
-msgstr ""
+msgstr "Das generierte HTML wird in Plone stark im Cache gehalten. Um die Änderungen zu sehen, müssen sie eventuell bestehe Inhalte bearbeiten und speichern oder den Plone-Service neu starten."
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:78
 msgid "Have a look above for more information."
-msgstr ""
+msgstr "Siehe oben für weitere Informationen."
 
 #: CMFPlone/interfaces/controlpanel.py:520
 msgid "Header styles"
@@ -2708,11 +2708,11 @@ msgstr ""
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:96
 msgid "Identifier of the parent content or login of managed user"
-msgstr ""
+msgstr "Kurzname des übergeordneten Inhalts oder der Login des bearbeitenden Benutzers"
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:312
 msgid "Identifier, actually URL of the content"
-msgstr "Kennung, in Wirklichkeit die URL des Inhalts"
+msgstr "Kurzname, die URL des Inhalts"
 
 #: CMFPlone/interfaces/controlpanel.py:989
 msgid "If an item has been excluded from navigation should it be shown in navigation when viewing content contained within it or within a subfolder."
@@ -2741,22 +2741,22 @@ msgstr "Wenn eingeschaltet, dann wird die Auflistung den Eintrag, auf dem das Po
 #: plone.app.portlets/plone/app/portlets/portlets/recent.py:34
 #: plone.app.portlets/plone/app/portlets/portlets/review.py:25
 msgid "If enabled, the portlet will not show document type icons"
-msgstr "Wenn eingeschaltet, dann zeigt das Portlet keine Dokument-Typ Icons"
+msgstr "Wenn eingeschaltet, dann zeigt das Portlet keine Inhaltstyp Icons"
 
 #: plone.app.portlets/plone/app/portlets/portlets/navigation.py:110
 #: plone.portlet.collection/plone/portlet/collection/collection.py:104
 msgid "If enabled, the portlet will not show document type icons."
-msgstr "Wenn eingeschaltet, dann zeigt das Portlet keine Dokument-Typ Icons."
+msgstr "Wenn eingeschaltet, dann zeigt das Portlet keine Inhaltstyp Icons."
 
 #: plone.app.portlets/plone/app/portlets/portlets/news.py:54
 msgid "If enabled, the portlet will not show thumbs"
-msgstr "Wenn eingeschaltet, dann zeigt das Portlet keine Mini-Bilder."
+msgstr "Wenn eingeschaltet, dann zeigt das Portlet keine Vorschaubilder."
 
 #: plone.app.portlets/plone/app/portlets/portlets/navigation.py:128
 #: plone.app.portlets/plone/app/portlets/portlets/recent.py:52
 #: plone.app.portlets/plone/app/portlets/portlets/review.py:43
 msgid "If enabled, the portlet will not show thumbs."
-msgstr "Wenn eingeschaltet, dann zeigt das Portlet keine Mini-Bilder."
+msgstr "Wenn eingeschaltet, dann zeigt das Portlet keine Vorschaubilder."
 
 #: plone.portlet.static/plone/portlet/static/static.py:90
 msgid "If given, the header and footer will link to this URL."
@@ -2764,7 +2764,7 @@ msgstr "Falls ausgefüllt, wird in Kopf- und Fußzeile des Portlets ein Verweis 
 
 #: CMFPlone/interfaces/resources.py:91
 msgid "If its true and you modify this bundle you need to build it before production"
-msgstr ""
+msgstr "Wenn diese Einstellung eingeschaltet ist und das Bundle verändert wurde, muss es vor dem Einsatz neu kompiliert werden."
 
 #: CMFPlone/interfaces/controlpanel.py:1108
 msgid "If not selected only logged-in users will be able to view information about who created an item and when it was modified."
@@ -2784,7 +2784,7 @@ msgstr "Ob die Syndizierungen für alle Ordner und Kollektionen aktiviert sein s
 
 #: CMFPlone/controlpanel/browser/resourceregistry.pt:35
 msgid "If you see this, it is because there was an error rendering the resource registry configuration. It's possible you saved a bundle that gives a JavaScript error and it is preventing the resource registry from loading."
-msgstr ""
+msgstr "Dieser Fehler tritt bei einem Problem während des Renderns der Resource Registry Konfiguration auf. Es ist wahrscheinlich, dass ein Bundle gespeichert wurde, das einen JavaScript-Fehler erzeugt und damit die Resource Registry am Laden hindert."
 
 #. Default: "If you submitted the item by mistake or want to perform additional edits, this will take it back."
 #: CMFPlone/profiles/default/workflows/folder_workflow/definition.xml
@@ -2847,19 +2847,19 @@ msgstr "Erfolgreich importiert."
 
 #: CMFPlone/interfaces/resources.py:65
 msgid "In case its a bundle we can have a condition to render it (it does not apply if the bundle is merged)."
-msgstr ""
+msgstr "Wenn es sich um ein Bundle handelt, so kann dies eine Bedingung haben wann es gerendert wird (dies wird bei verschmolzenen Bundles ignoriert)."
 
 #: CMFPlone/interfaces/resources.py:98
 msgid "In case you want to be the last: *, in case its the first should be empty"
-msgstr ""
+msgstr "Setzen sie '*', wenn es der Letzte sein soll. Lassen sie es leer, wenn es der erste sein soll."
 
 #: CMFPlone/interfaces/resources.py:72
 msgid "In case you want to render this resource on conditional comment (it does not apply if the bundle is merged)."
-msgstr ""
+msgstr "Wenn ein bedingter Kommentar gerendert werden soll (dies wird bei verschmolzenen Bundles ignoriert)."
 
 #: CMFPlone/interfaces/resources.py:121
 msgid "In production mode, bundles are merged together to reduce the quantity of JS and CSS resources loaded by the browser. Choose 'default' if this bundle must be available for all the visitors, choose 'logged-in' if it must be available for logged-in users only, or leave it empty if it must not be merged."
-msgstr ""
+msgstr "Im Produktions-Modus werden Bundles zu einem File zusammengefügt um die Menge der zu ladenden JS und CSS Ressourcen zu reduzieren. Der Wert 'default' sorgt dafür, dass das Bundle für alle Besucher geladen wird. Der Wert 'logged-in' sorgt dafür, dass es nur für angemeldete Benutzer geladen wird. Ist das Feld leer, so wird einzeln ausgeliefert."
 
 #: CMFPlone/interfaces/controlpanel.py:1570
 msgid "Include meta tags on pages to give hints to social media on how to better render your pages when shared"
@@ -2886,7 +2886,7 @@ msgstr "Information"
 
 #: CMFPlone/interfaces/resources.py:30
 msgid "Init instruction for shim"
-msgstr ""
+msgstr "Initialisierungs Anweisung für ein Shim"
 
 #: CMFPlone/interfaces/controlpanel.py:534
 msgid "Inline styles"
@@ -2907,7 +2907,7 @@ msgstr "Installieren"
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/pac_installer.pt:16
 msgid "Install dexterity and proceed to the migration-form?"
-msgstr ""
+msgstr "Dexterity installieren und mit dem Migrations-Formular fortfahren?"
 
 #: CMFPlone/controlpanel/browser/quickinstaller.py:689
 msgid "Installed ${product}!"
@@ -3120,7 +3120,7 @@ msgstr "Werteliste"
 
 #: CMFPlone/profiles.zcml:22
 msgid "Load all profiles from other packages/products that are needed for a full Plone site."
-msgstr ""
+msgstr "Lädt alle Profile anderer Pakete, die für eine komplette Plone-Seite benötigt werden."
 
 #: CMFPlone/interfaces/resources.py:78
 msgid "Loaded resources"
@@ -3173,7 +3173,7 @@ msgstr "Sperrunterstützung für Dexterity"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/configure.zcml:35
 msgid "Log a particular event"
-msgstr "Logge ein bestimmtes Ereignis"
+msgstr "Ein bestimmtes Ereignis protokollieren"
 
 #. Default: "Log in"
 #: CMFPlone/profiles/default/actions.xml
@@ -3337,7 +3337,7 @@ msgstr "Manager E-Mails"
 
 #: CMFPlone/profiles.zcml:22
 msgid "Mandatory dependencies for a Plone site"
-msgstr ""
+msgstr "Verpflichtend benötigte Abhängigkeiten einer Plone-Seite"
 
 #: CMFPlone/interfaces/controlpanel.py:1533
 msgid "Many groups?"
@@ -3349,11 +3349,11 @@ msgstr "Viele Benutzer?"
 
 #: CMFPlone/resources/viewlets/settings.py:16
 msgid "Maps skin names to lists of resource bundle names"
-msgstr ""
+msgstr "Verknüpft Skin-Namen mit Listen von Resource-Bundles"
 
 #: CMFPlone/interfaces/controlpanel.py:1714
 msgid "Mark special links"
-msgstr "Markiere spezielle Links"
+msgstr "Bestimmte Links hervorheben"
 
 #: CMFPlone/interfaces/controlpanel.py:1715
 msgid "Marks external or special protocol links with class."
@@ -3384,7 +3384,7 @@ msgstr "Maximale Länge"
 
 #: plone.app.textfield/plone/app/textfield/interfaces.py:82
 msgid "May be None if the transform cannot be completed"
-msgstr ""
+msgstr "Kann 'None' sein, wenn die Transformation nicht vollständig abgearbeitet werden kann."
 
 msgid "Member"
 msgstr "Benutzer"
@@ -3444,7 +3444,7 @@ msgstr ""
 
 #: CMFPlone/interfaces/resources.py:120
 msgid "Merge with"
-msgstr "Verschmelzen mit"
+msgstr "Zuammensetzen mit"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/logger.py:41
 #: plone.app.contentrules/plone/app/contentrules/actions/mail.py:61
@@ -3537,7 +3537,7 @@ msgstr "Portlet bearbeiten"
 
 #: plone.app.content/plone/app/content/browser/contents/properties.py:36
 msgid "Modify properties on items"
-msgstr "Verändert die Eigenschaften von Artikeln"
+msgstr "Metadaten von Inhalten verändern"
 
 #: plone/app/theming/browser/controlpanel.pt:273
 msgid "Modify theme"
@@ -3563,7 +3563,7 @@ msgstr "Ändere den Status des Inhalts in Wartend damit es durch einen Bearbeite
 
 #: plone.app.contentrules/plone/app/contentrules/actions/configure.zcml:125
 msgid "Move the triggering item to a specific folder"
-msgstr ""
+msgstr "Verschiebt den auslösenden Inhalt in einen bestimmten Ordner."
 
 #: plone.app.contentrules/plone/app/contentrules/actions/configure.zcml:125
 msgid "Move to folder"
@@ -3715,7 +3715,7 @@ msgstr "Nein"
 
 #: CMFPlone/interfaces/controlpanel.py:1216
 msgid "No Thumbs in portlets"
-msgstr "Keine Mini-Bilder in Portlets"
+msgstr "Keine Vorschaubilder in Portlets"
 
 #: plone.app.portlets/plone/app/portlets/browser/formhelper.py:205
 msgid "No changes"
@@ -3754,19 +3754,19 @@ msgstr "Kein Mailhost angegeben. Passwortänderung unmöglich."
 
 #: CMFPlone/interfaces/controlpanel.py:1225
 msgid "No thumbs in list views"
-msgstr "Keine Mini-Bilder in Ansicht Liste"
+msgstr "Keine Vorschaubilder in Ansicht Liste"
 
 #: CMFPlone/interfaces/controlpanel.py:1232
 msgid "No thumbs in summary views"
-msgstr "Keine Mini-Bilder in Ansicht Zusammenfassung"
+msgstr "Keine Vorschaubilder in Ansicht Zusammenfassung"
 
 #: CMFPlone/interfaces/controlpanel.py:1239
 msgid "No thumbs in table views"
-msgstr "Keine Mini-Bilder in Ansicht Tabelle"
+msgstr "Keine Vorschaubilder in Ansicht Tabelle"
 
 #: CMFPlone/controlpanel/browser/quickinstaller.pt:47
 msgid "No upgrades in this corner"
-msgstr "Kein Upgrades in diesem Bereich"
+msgstr "Keine Aktualisierungen in diesem Bereich"
 
 #: CMFPlone/controlpanel/browser/types.py:537
 msgid "No workflow"
@@ -3784,7 +3784,7 @@ msgstr "Notiz"
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:43
 #: plone.app.contenttypes/plone/app/contenttypes/migration/custom_migration.pt:37
 msgid "Note about how long it might take"
-msgstr "Notiz, wie lang es etwa dauern wird"
+msgstr "Bemerkung, wie lang es etwa dauern wird"
 
 #: plone.app.discussion/plone/app/discussion/interfaces.py:182
 msgid "Notify me of new comments via email."
@@ -3882,17 +3882,17 @@ msgstr "Optionale Migrationsschritte"
 
 #: plone.session/plone/session/profiles.zcml:12
 msgid "Optional plone.session refresh support."
-msgstr "Optionale Aktualisierungsunterstützung für plone.session"
+msgstr "Optionale Sitzungsaktualisierung mit plone.session"
 
 #: plone.session/plone/session/profiles.zcml:20
 msgid "Optional plone.session refresh support. [uninstall]"
-msgstr ""
+msgstr "Optionale Sitzungsaktualisierung mit plone.session. [deinstallieren]"
 
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/configure.zcml:63
 msgid "Options to suppress thumbs and/or icons and to override thumb size in listings, tables etc."
-msgstr "Einstellungen um Mini-Bilder und/oder Icons zu unterdrücken und um die Mini-Bildgrößen in Listen, Tabellen, usw. zu überschreiben."
+msgstr "Einstellungen um Vorschaubilder und/oder Icons zu unterdrücken und um die Mini-Bildgrößen in Listen, Tabellen, usw. zu überschreiben."
 
-#. Default: "Order in folder"
+#. Default: "Order in folder6 Unterstützung [deinstallieren]"
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 msgid "Order in folder"
 msgstr "Reihenfolge in einem Ordner"
@@ -4443,7 +4443,7 @@ msgstr ""
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/browser.py:303
 msgid "Rebuild the catalog after the migration."
-msgstr "Neubauen des Katalogs nach der Migration."
+msgstr "Katalog nach der Migration aktualisieren."
 
 #: CMFPlone/profiles/dependencies/portlets.xml
 #: plone.app.portlets/plone/app/portlets/portlets/recent.py:72
@@ -4588,7 +4588,7 @@ msgstr "Zurückziehen"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/configure.zcml:65
 msgid "Return a portal message to the user"
-msgstr "Eine Portal-Nachricht für den Benuzter zurückliefern"
+msgstr "Dem Benutzer eine Statusnachricht anzeigen"
 
 #: CMFPlone/interfaces/controlpanel.py:944
 msgid "Reversed sort order for tabs."
@@ -4876,7 +4876,7 @@ msgstr "Unterstützung für Sitzungsaktualisierung"
 
 #: plone.session/plone/session/profiles.zcml:20
 msgid "Session refresh support [uninstall]"
-msgstr ""
+msgstr "Unterstützung für Sitzungsaktualisierung [deinstallieren]"
 
 #. Default: "Set my password"
 #: CMFPlone/browser/templates/pwreset_form.pt:105
@@ -4990,7 +4990,7 @@ msgstr "Zeige Verweis auf Einstellungen"
 
 #: CMFPlone/interfaces/controlpanel.py:1206
 msgid "Show thumbnail images in listings"
-msgstr "Zeige Mini-Bilder in Listen"
+msgstr "Zeige Vorschaubilder in Listen"
 
 #: CMFPlone/skins/plone_prefs/prefs_error_log_update.py:14
 msgid "Showing all entries"
@@ -5244,40 +5244,40 @@ msgstr "Es hat funktioniert! Sieh in deinem Postfach nach der Test-Nachricht."
 
 #: plone.app.content/plone/app/content/browser/contents/copy.py:31
 msgid "Successfully copied items"
-msgstr "Erfolgreich kopierte Artikel"
+msgstr "Inhalt erfolgreich kopiert"
 
 #: plone.app.content/plone/app/content/browser/contents/cut.py:31
 msgid "Successfully cut items"
-msgstr "Erfolgreich ausgeschnittene Artikel"
+msgstr "Inhalt ausschneiden erfolgreich"
 
 #. Default: "Successfully deleted items"
 #: plone.app.content/plone/app/content/browser/contents/delete.py:47
 msgid "Successfully delete items"
-msgstr "Erfolgreich gelöschte Artikel"
+msgstr "Artikel löschen erfolgreich"
 
 #: plone.app.content/plone/app/content/browser/contents/workflow.py:40
 msgid "Successfully modified items"
-msgstr "Erfolgreich geänderte Artikel"
+msgstr "Inhalt erfolgreich geändert"
 
 #: plone.app.content/plone/app/content/browser/contents/rearrange.py:32
 msgid "Successfully moved item"
-msgstr "Erfolgreich verschobene Artikel"
+msgstr "Inhalt erfolgreich verschoben"
 
 #: plone.app.content/plone/app/content/browser/contents/paste.py:31
 msgid "Successfully pasted items"
-msgstr "Erfolgreich eingefügte Artikel"
+msgstr "Inhalt erfolgreich eingefügt"
 
 #: plone.app.content/plone/app/content/browser/contents/rearrange.py:71
 msgid "Successfully rearranged folder"
-msgstr "Erfolgreich umsortierte Ordner"
+msgstr "Ordner erfolgreich umsortiert"
 
 #: plone.app.content/plone/app/content/browser/contents/properties.py:47
 msgid "Successfully updated metadata"
-msgstr "Erfolgreich aktualisierte Metadaten"
+msgstr "Metadaten erfolgreich aktualisiert"
 
 #: plone.app.content/plone/app/content/browser/contents/tags.py:39
 msgid "Successfully updated tags on items"
-msgstr "Erfolgreich Stichworte auf den Inhalten aktualisiert"
+msgstr "Stichworte wurden erfolgreich aktualisiert"
 
 #. Default: "Summary view"
 #: plone.app.collection/plone/app/collection/browser/configure.zcml:62
@@ -5303,23 +5303,23 @@ msgstr "Unterdrücke Icons in den Ansichten Listen, Tabellen und Zusammenfassung
 #: plone.app.portlets/plone/app/portlets/portlets/news.py:53
 #: plone.app.portlets/plone/app/portlets/portlets/recent.py:51
 msgid "Suppress thumbs"
-msgstr "Unterdrücke Mini-Bilder"
+msgstr "Unterdrücke Vorschaubilder"
 
 #: CMFPlone/interfaces/controlpanel.py:1226
 msgid "Suppress thumbs in all list views; this default can be overriden individually"
-msgstr "Unterdrücke Mini-Bilder in allen Listen-Ansichten; diese Vorgabe kann individuell überschrieben werden."
+msgstr "Unterdrücke Vorschaubilder in allen Listen-Ansichten; diese Vorgabe kann individuell überschrieben werden."
 
 #: CMFPlone/interfaces/controlpanel.py:1217
 msgid "Suppress thumbs in all portlets; this default can be overridden individually in selected portlets"
-msgstr "Unterdrücke Mini-Bilder in allen Portlets; diese Vorgabe kann individuell überschrieben werden."
+msgstr "Unterdrücke Vorschaubilder in allen Portlets; diese Vorgabe kann individuell überschrieben werden."
 
 #: CMFPlone/interfaces/controlpanel.py:1233
 msgid "Suppress thumbs in all summary views; this default can be overriden individually"
-msgstr "Unterdrücke Mini-Bilder in allen Zusammenfassungs-Ansichten; diese Vorgabe kann individuell überschrieben werden."
+msgstr "Unterdrücke Vorschaubilder in allen Zusammenfassungs-Ansichten; diese Vorgabe kann individuell überschrieben werden."
 
 #: CMFPlone/interfaces/controlpanel.py:1239
 msgid "Suppress thumbs in all tableviews and in folder contents view; this default can be overriden individually"
-msgstr "Unterdrücke Mini-Bilder in allen Tabellen-Ansichten; diese Vorgabe kann individuell überschrieben werden."
+msgstr "Unterdrücke Vorschaubilder in allen Tabellen-Ansichten; diese Vorgabe kann individuell überschrieben werden."
 
 #. Default: "Syndication"
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/thumb_icon.py:68
@@ -5529,7 +5529,7 @@ msgstr "Terminende und -zeit"
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:56
 msgid "The estimated time for the migration is around: <strong> ${hours} hours ${minutes} minutes ${seconds} seconds </strong>"
-msgstr "Geschätzte Zeit für die Migration ist etwas:  <strong> ${hours} Stunden ${minutes} Minuten ${seconds} Sekunden </strong>"
+msgstr "Geschätzte Zeit für die Migration ist etwa:  <strong> ${hours} Stunden ${minutes} Minuten ${seconds} Sekunden </strong>"
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/fileextension.py:30
 msgid "The file extension to check for"
@@ -6218,7 +6218,7 @@ msgstr "Lade Zip Datei hoch"
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 msgid "Use '../' to navigate to parent objects."
-msgstr "Benutze '../' um zum Elterninhalt zu navigieren."
+msgstr "Benutze '../' um zum zum übergeordneten Inhalt zu navigieren."
 
 #: CMFPlone/interfaces/controlpanel.py:1130
 msgid "Use UUID user ids"
@@ -6474,7 +6474,7 @@ msgstr "Warnung"
 
 #: CMFPlone/interfaces/controlpanel.py:350
 msgid "Warning: disabling this can be dangerous. Only disable if you know what you are doing."
-msgstr "Warnung: Dies hier abschalten kann gefährlich sein. Nur abschalten, wenn Sie genau wissen was sie tun."
+msgstr "Warnung: Das Abschalten dieser Einstellung kann gefährlich sein. Nur abschalten, wenn Sie genau wissen was sie tun."
 
 #: CMFPlone/skins/plone_login/login_next.cpy:60
 msgid "Welcome! You are now logged in."
@@ -6573,7 +6573,7 @@ msgstr "Ja, löschen"
 
 #: plone.app.content/plone/app/content/browser/contents/delete.py:85
 msgid "You are not authorized to delete ${title}."
-msgstr "Sie sind nicht berechtigt ${title} zu löschen."
+msgstr "Die erforderlichen Rechte fehlen um ${title} zu löschen."
 
 #: plone.app.content/plone/app/content/browser/contents/paste.py:51
 msgid "You are not authorized to paste ${title} here."
@@ -7128,12 +7128,12 @@ msgstr "Ersteller"
 #. Default: "Current theme"
 #: plone/app/theming/interfaces.py:92
 msgid "current_theme"
-msgstr "Aktuelles Design"
+msgstr "Aktive Theme"
 
 #. Default: "The name of the current theme, i.e. the one applied most recently."
 #: plone/app/theming/interfaces.py:93
 msgid "current_theme_description"
-msgstr "Der Name des aktuellen Designs."
+msgstr "Der Name des aktuellen Themes."
 
 #: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:19
 msgid "daily_interval_1"
@@ -7342,7 +7342,7 @@ msgstr "Konfiguration von Plone und Erweiterungen."
 #. Default: "Required for the language selector viewlet to be rendered."
 #: CMFPlone/interfaces/controlpanel.py:265
 msgid "description_cookie_manual_override"
-msgstr "Benötigt um das Sprachauswahl-Viewlet zu rendern."
+msgstr "Wird benötigt um das Sprachauswahl-Viewlet zu rendern."
 
 #. Default: "The ${plonecms} is ${copyright} 2000-${current_year} by the ${plonefoundation} and friends."
 #: CMFPlone/browser/templates/footer.pt:23
@@ -8030,7 +8030,7 @@ msgstr "Gruppenzuweisung"
 #. Default: "Authenticated users only"
 #: CMFPlone/interfaces/controlpanel.py:276
 msgid "heading_auth_cookie_manual_override"
-msgstr "Nur angemeldete Benuzter"
+msgstr "Nur für angemeldete Benutzer"
 
 #. Default: "Latest content created by this user"
 #: CMFPlone/browser/templates/author.pt:190
@@ -8750,7 +8750,7 @@ msgstr "Wählen Sie diese Option aus, damit alle externen Links im Inhaltsbereic
 #. Default: "External URL (can be relative within this site or absolute if it starts with http:// or https://)"
 #: plone.app.z3cform/plone/app/z3cform/templates/link_input.pt:23
 msgid "help_external_url"
-msgstr "Externe URL (kann relativ innerhalb der Seite oder absolut sein, wenn sie mit http:// or https:// startet)"
+msgstr "Externe URL (kann relativ innerhalb der Webseite oder absolut sein, wenn sie mit http:// or https:// startet)"
 
 #. Default: "First day in the week."
 #: CMFPlone/interfaces/controlpanel.py:1367

--- a/plone/app/locales/locales/de/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/plone.po
@@ -8,12 +8,13 @@
 # Sven Deichmann <deichmann@werkbank.com>, 2008-2010.
 # Harald Friessnegger <harald@webmeisterei.com>, 2011.
 # Andreas Jung <info@zopyx.com>, 2012
+# Jens Klein <jk@kleinundpartner.at>, 2018
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI +ZONE\n"
-"PO-Revision-Date: 2016-10-22 16:41-0500\n"
-"Last-Translator: Max Jakob <max.jakob@ifi.lmu.de>\n"
+"PO-Revision-Date: 2018-03-13 20:49+0100\n"
+"Last-Translator: Jens W. Klein <jk@kleinundpartner.at>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -195,7 +196,7 @@ msgstr "Eine eindeutige ID des Kommentars"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/copy.py:149
 msgid "A copy action can copy an object to a different folder."
-msgstr "Mit einer Kopieraktion können Artikel in einen anderen Ordner kopiert werden."
+msgstr "Mit einer Kopieraktion können Inhalte in einen anderen Ordner kopiert werden."
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/fileextension.py:88
 msgid "A file extension condition can restrict a rule from executing unless the target is a File with a particular extension."
@@ -211,7 +212,7 @@ msgstr "Mit dieser Bedingung legen Sie fest, dass eine Aktion nur ausgeführt wi
 
 #: CMFPlone/interfaces/controlpanel.py:367
 msgid "A list of valid tags which will be not filtered out."
-msgstr ""
+msgstr "Eine Liste gültiger Stichworte, die nicht herausgefiltert werden sollen."
 
 #: plone.app.contentrules/plone/app/contentrules/actions/logger.py:119
 msgid "A logger action can output a message to the system log."
@@ -235,7 +236,7 @@ msgstr "Mit einer Benachrichtigungsaktion zeigen Sie dem Benutzer eine Nachricht
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/portaltype.py:96
 msgid "A portal type condition makes the rule apply only to certain content types."
-msgstr "Mit dieser Bedingung legen Sie fest, dass eine Aktion nur bei bestimmten Artikeltypen ausgeführt wird."
+msgstr "Mit dieser Bedingung legen Sie fest, dass eine Aktion nur bei bestimmten Inhaltstypen ausgeführt wird."
 
 #: CMFPlone/profiles/dependencies/portlets.xml
 msgid "A portlet that provides links of an action category"
@@ -303,11 +304,11 @@ msgstr "Ein einfacher Freigabe Workflow für Kommentare"
 
 #: CMFPlone/interfaces/controlpanel.py:1644
 msgid "A value for the quality of 2x high pixel density images, from 1 (lowest) to 95 (highest). A value of 0 will mean plone.scaling's default will be used, which is currently 62."
-msgstr ""
+msgstr "Ein Wert für die Qualität des 2x höherauflösenden skalierten Bildes, von 1 (niedrigste Qualität) bis 95 (höchste Qualität). Der Wert 0 bewirkt, dass die Voreinstellung von plone.scaling benutzt wird, die zurzeit 62 beträgt."
 
 #: CMFPlone/interfaces/controlpanel.py:1655
 msgid "A value for the quality of 3x high pixel density images, from 1 (lowest) to 95 (highest). A value of 0 will mean plone.scaling's default will be used, which is currently 51."
-msgstr ""
+msgstr "Ein Wert für die Qualität des 3x höherauflösenden skalierten Bildes, von 1 (niedrigste Qualität) bis 95 (höchste Qualität). Der Wert 0 bewirkt, dass die Voreinstellung von plone.scaling benutzt wird, die zurzeit 51 beträgt."
 
 #: CMFPlone/interfaces/controlpanel.py:1622
 msgid "A value for the quality of scaled images, from 1 (lowest) to 95 (highest). A value of 0 will mean plone.scaling's default will be used, which is currently 88."
@@ -348,7 +349,7 @@ msgstr "Barrierefreiheit"
 
 #: CMFPlone/controlpanel/browser/actions.py:171
 msgid "Action Settings"
-msgstr ""
+msgstr "Aktions-Einstellungen"
 
 #: plone.app.contentrules/plone/app/contentrules/browser/elements.py:66
 msgid "Action deleted."
@@ -398,7 +399,7 @@ msgstr "Inhaltstyp hinzufügen"
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/portaltype.py:95
 msgid "Add Content Type Condition"
-msgstr "Artikeltypbedingung hinzufügen"
+msgstr "Inhaltstypbedingung hinzufügen"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/copy.py:148
 msgid "Add Copy Action"
@@ -434,7 +435,7 @@ msgstr "Neuen Inhaltstyp hinzufügen&hellip;"
 
 #: plone.directives.form/plone/directives/form/form.py:186
 msgid "Add New Item operation cancelled"
-msgstr "Operation “Neues Objekt hinzufügen” abgebrochen"
+msgstr "Operation “Neuer Artikel hinzufügen” abgebrochen"
 
 #: plone.app.portlets/plone/app/portlets/portlets/news.py:143
 msgid "Add News Portlet"
@@ -494,7 +495,7 @@ msgstr "Erstellen Sie eine neue Regel. Nach dem Erstellen können Sie Aktionen u
 
 #: CMFPlone/controlpanel/browser/actions.pt:24
 msgid "Add new action"
-msgstr ""
+msgstr "Neue Aktion hinzufügen"
 
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/add_field.py:28
 msgid "Add new field"
@@ -598,7 +599,7 @@ msgstr "Nach dem"
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 #: plone.app.querystring/plone/app/querystring/profiles/upgrades/to_11/registry.xml
 msgid "After relative Date"
-msgstr ""
+msgstr "Nach dem relativen Datum"
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 msgid "After the current day"
@@ -649,7 +650,7 @@ msgstr "Erlaubt Diskussionsbeiträge für diesen Inhalt."
 
 #: plone.app.dexterity/plone/app/dexterity/behaviors/configure.zcml:110
 msgid "Allow discussion on this item"
-msgstr "Diskussion an diesem Objekt erlauben"
+msgstr "Diskussion an diesem Inhalt erlauben"
 
 #: CMFPlone/interfaces/controlpanel.py:1680
 msgid "Allow external login sites"
@@ -657,11 +658,11 @@ msgstr "Externe Loginseiten erlauben"
 
 #: plone.app.dexterity/plone/app/dexterity/behaviors/configure.zcml:90
 msgid "Allow items to be excluded from navigation"
-msgstr "Erlaubt es, Objekte von der Navigation auszuschließen"
+msgstr "Erlaubt es, Inhalte von der Navigation auszuschließen"
 
 #: plone.app.dexterity/plone/app/dexterity/behaviors/configure.zcml:102
 msgid "Allow items to have next previous navigation enabled"
-msgstr "Erlaubt für Objekte eine zurück/weiter-Navigation zu aktivieren"
+msgstr "Erlaubt für Inhalte eine zurück/weiter-Navigation zu aktivieren"
 
 #: CMFPlone/interfaces/syndication.py:155
 msgid "Allow syndication for collections and folders on site."
@@ -734,7 +735,7 @@ msgstr "Anonyme Kommentare"
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/configure.zcml:101
 msgid "Apply only to a objects in a particular workflow state"
-msgstr "Nur auf Objekte anwenden, die einen bestimmten Arbeitsablaufstatus haben"
+msgstr "Nur auf Inhalte anwenden, die einen bestimmten Arbeitsablaufstatus haben"
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/configure.zcml:71
 msgid "Apply only to a particular file extension"
@@ -742,7 +743,7 @@ msgstr "Nur auf eine bestimmte Dateiendung anwenden"
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/configure.zcml:41
 msgid "Apply only when the current content object is of a particular type"
-msgstr "Nur anwenden, wenn das aktuelle Objekt einen bestimmten Typ hat"
+msgstr "Nur anwenden, wenn der aktuelle Inhalt einen bestimmten Typ hat"
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/configure.zcml:189
 msgid "Apply only when the current user has the given role"
@@ -754,11 +755,11 @@ msgstr "Nur anwenden, wenn der aktuelle Benutzer zu einer vorgegebenen Gruppe ge
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/configure.zcml:131
 msgid "Apply only when the executed transition was as specified"
-msgstr ""
+msgstr "Wird nur angewendet, wenn die ausgeführte Transistion angewendet wurde"
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/configure.zcml:219
 msgid "Apply only when the result of a TALES expression is True"
-msgstr ""
+msgstr "Wird nur angewendet, wenn das Ergebnis des TALES Ausdrucks wahr ist."
 
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/manage-elements.pt:217
 msgid "Apply rule on the whole site"
@@ -770,7 +771,7 @@ msgstr "Bestätigen"
 
 #: plone.app.discussion/plone/app/discussion/profiles/default/workflows/comment_review_workflow/definition.xml
 msgid "Approving the comment makes it visible to other users."
-msgstr ""
+msgstr "Kommentare genehmigen macht sie sichtbar für andere Benuzter."
 
 #: Archetypes/profiles.zcml:12
 msgid "Archetypes"
@@ -778,7 +779,7 @@ msgstr "Archetypes"
 
 #: Archetypes/profiles.zcml:19
 msgid "Archetypes uninstall"
-msgstr ""
+msgstr "Archetypes deinstallieren"
 
 #: plone.app.collection/plone/app/collection/configure.zcml:19
 msgid "Archetypes-based collections"
@@ -807,15 +808,15 @@ msgstr "Zuweisung aktiviert."
 
 #: CMFPlone/interfaces/controlpanel.py:767
 msgid "AtD error types to show"
-msgstr ""
+msgstr "Anzuzeigende AtD Fehler Typen"
 
 #: CMFPlone/interfaces/controlpanel.py:751
 msgid "AtD ignore strings"
-msgstr ""
+msgstr "Zu ignorierende AtD Zeichenfolgen"
 
 #: CMFPlone/interfaces/controlpanel.py:790
 msgid "AtD service URL"
-msgstr ""
+msgstr "AtD Service URL"
 
 #: CMFPlone/interfaces/controlpanel.py:1668
 msgid "Auth cookie length"
@@ -834,7 +835,7 @@ msgstr "Automatische Erstellung einer Kurz-URL für Inhalt, basierend auf dem Da
 
 #: CMFPlone/interfaces/controlpanel.py:898
 msgid "Automatically generate tabs"
-msgstr "Automatisch erzeugte Einträge in der Hauptnavigation"
+msgstr "Automatisch erzeugte Reiter in der Hauptnavigation"
 
 #: CMFPlone/controlpanel/browser/resourceregistry.pt:39
 msgid "Available Options"
@@ -884,12 +885,12 @@ msgstr "Vor dem"
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:37
 #: plone.app.contenttypes/plone/app/contenttypes/migration/custom_migration.pt:32
 msgid "Before migrating your content please read the ${migrationsection}"
-msgstr ""
+msgstr "Vor der Migration Ihres Inhalts lesen Sie die ${migrationsection}"
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 #: plone.app.querystring/plone/app/querystring/profiles/upgrades/to_11/registry.xml
 msgid "Before relative Date"
-msgstr ""
+msgstr "Vor dem relativen Datum"
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 msgid "Before the current day"
@@ -918,7 +919,7 @@ msgstr "Zwischen"
 
 #: CMFPlone/interfaces/controlpanel.py:548
 msgid "Block styles"
-msgstr ""
+msgstr "Block Stile"
 
 #. Default: "Boolean (True/False)"
 #: criterion description of criterion ATBooleanCriterion
@@ -931,11 +932,11 @@ msgstr "Defekte Erweiterungen"
 
 #: CMFPlone/interfaces/controlpanel.py:899
 msgid "By default, all items created at the root level will appear as tabs. You can turn this off if you prefer manually constructing this part of the navigation."
-msgstr ""
+msgstr "Nach Vorgabe werden alle auf Wurzel-Ebene erstellten Inhalte als Reiter erscheinen. Sie können dies komplett abschalten, wenn Sie es vorziehen diesen Teils der Navigation manuell zu erstellen."
 
 #: CMFPlone/interfaces/controlpanel.py:908
 msgid "By default, any content item in the root of the portal will appear as a tab. If you turn this option off, only folders will be shown. This only has an effect if 'automatically generate tabs' is enabled."
-msgstr ""
+msgstr "Nach Vorgabe werden alle auf Wurzel-Ebene erstellten Inhalte als Reiter erscheinen. Wenn Sie diese Einstellung abschalten, dann werden nur Ordner angezeigt. Dies funktioniert nur, wenn die Option 'Automatisch erzeugte Einträge in der Hauptnavigation' angeschaltet ist."
 
 #: CMFPlone/interfaces/resources.py:24
 msgid "CSS/LESS files"
@@ -943,7 +944,7 @@ msgstr "CSS/LESS Dateien"
 
 #: plone.cachepurging/plone/cachepurging/interfaces.py:23
 msgid "Caching proxies"
-msgstr ""
+msgstr "Caching Proxies"
 
 #: plone.app.content/plone/app/content/browser/contents/rearrange.py:72
 msgid "Can not rearrange folder"
@@ -994,11 +995,11 @@ msgstr "Kategorisierung"
 
 #: CMFPlone/interfaces/controlpanel.py:1723
 msgid "Category"
-msgstr ""
+msgstr "Kategorie"
 
 #: CMFPlone/browser/templates/explainPWResetTool.pt:37
 msgid "Change"
-msgstr ""
+msgstr "Ändern"
 
 #. Default: "Change Password"
 #: CMFPlone/profiles/default/controlpanel.xml
@@ -1052,7 +1053,7 @@ msgstr "Änderungen wurden gespeichert."
 
 #: CMFPlone/interfaces/controlpanel.py:1493
 msgid "Characterset to use when sending e-mails."
-msgstr ""
+msgstr "Charakterset zum Versenden von E-Mails."
 
 #. Default: "Check in"
 #: plone.app.iterate/plone/app/iterate/browser/checkin.pt:47
@@ -1084,11 +1085,11 @@ msgstr "Erzeugung einer Arbeitskopie abgebrochen"
 
 #: plone.app.iterate/plone/app/iterate/interfaces.py:325
 msgid "Checkout workflow policy"
-msgstr "Checkout Workflow Policy"
+msgstr "Arbeitskopie Arbeitsauflauf Regel"
 
 #: CMFPlone/interfaces/controlpanel.py:504
 msgid "Choose the CSS used in WYSIWYG Editor Area"
-msgstr ""
+msgstr "Wähle das CSS zur Verwendung im WYSIWYG-Editor Bereich"
 
 #: CMFPlone/profiles/dependencies/portlets.xml
 msgid "Classic portlet"
@@ -1104,7 +1105,7 @@ msgstr "Cache löschen"
 
 #: plone.app.content/plone/app/content/browser/contents/rearrange.py:63
 msgid "Client/server ordering mismatch"
-msgstr ""
+msgstr "Client/Server Sortierungsfehler."
 
 #: plone.app.dexterity/plone/app/dexterity/browser/types.py:70
 msgid "Clone"
@@ -1132,7 +1133,7 @@ msgstr "Kollektionsportlet"
 
 #: CMFPlone/interfaces/resources.py:35
 msgid "Comma separated values of resource for shim"
-msgstr ""
+msgstr "Komma-separierte Werte der Ressource für das Shim."
 
 #: plone.app.discussion/plone/app/discussion/profiles/default/types/Discussion_Item.xml
 #: plone.stringinterp/plone/stringinterp/adapters.py:696
@@ -1141,7 +1142,7 @@ msgstr "Kommentar"
 
 #: plone.app.discussion/plone/app/discussion/profiles/default/workflows/comment_review_workflow/definition.xml
 msgid "Comment Review Workflow"
-msgstr ""
+msgstr "Kommentarüberprüfungs-Arbeitsablauf"
 
 #. Default: "Comment about the last transition"
 #: CMFPlone/profiles/default/workflows/folder_workflow/definition.xml
@@ -1196,7 +1197,7 @@ msgstr "Kommentare"
 
 #: plone.app.discussion/plone/app/discussion/profiles/default/types/Discussion_Item.xml
 msgid "Comments added to a content item."
-msgstr "Kommentare zum Inhaltsobjekt hinzugefügt."
+msgstr "Kommentare zum Inhalt hinzugefügt."
 
 #. Default: "Community Workflow"
 #: CMFPlone/profiles/default/workflows/plone_workflow/definition.xml
@@ -1235,7 +1236,7 @@ msgstr "Konfigurationseinträge"
 
 #: CMFPlone/interfaces/resources.py:43
 msgid "Configuration in JSON for the widget"
-msgstr ""
+msgstr "Konfiguration als JSON für das Widget"
 
 #: plone.app.registry/plone/app/registry/configure.zcml:34
 msgid "Configuration registry"
@@ -1257,7 +1258,7 @@ msgstr "Regel bearbeiten"
 
 #: CMFPlone/controlpanel/browser/resourceregistry.pt:23
 msgid "Configure, enable, disable, debug and build Plone JavaScript/LESS/CSS resources. Plone utilizes RequireJS and LESS CSS to build its resources. Re-building a Plone bundle TTW requires a modern web browser."
-msgstr ""
+msgstr "Konfigurieren, ein- und auschalten, debuggen and bauen der Plone JavaScript/LESS/CSS resourcen. Plone verwendet RequireJS und LESS CSS um seine Ressourcen zu bauen."
 
 #: plone.app.dexterity/plone/app/dexterity/configure.zcml:27
 msgid "Configures various components needed for full Dexterity support."
@@ -1294,7 +1295,7 @@ msgstr "Beinhaltet"
 
 #: CMFPlone/interfaces/controlpanel.py:815
 msgid "Contains objects"
-msgstr "Enthält Objekte"
+msgstr "Enthaltene Inhalte"
 
 #: CMFPlone/PloneControlPanel.py:69
 #: CMFPlone/browser/templates/author.pt:201
@@ -1312,7 +1313,7 @@ msgstr "Inhaltseinstellung"
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:156
 msgid "Content Type"
-msgstr "Artikeltyp"
+msgstr "Inhaltstyp"
 
 #: plone.app.collection/plone/app/collection/browser/templates/tabular_view.pt:32
 msgid "Content listing"
@@ -1320,7 +1321,7 @@ msgstr "Artikelliste"
 
 #: plone.app.contentmenu/plone/app/contentmenu/configure.zcml:11
 msgid "Content menu - contains contextual actions related to the content"
-msgstr ""
+msgstr "Kontext-bezogenes Menu - enthält Inhalts-bezogene Aktionen"
 
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/controlpanel.pt:35
 msgid "Content rule settings updated."
@@ -1337,11 +1338,11 @@ msgstr "Regeln wurden global aktiviert"
 #: plone.app.contentrules/plone/app/contentrules/conditions/configure.zcml:41
 #: plone.app.contentrules/plone/app/contentrules/conditions/portaltype.py:29
 msgid "Content type"
-msgstr "Artikeltyp"
+msgstr "Inhaltstyp"
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/portaltype.py:58
 msgid "Content types are: ${names}"
-msgstr "Artikeltypen: ${names}"
+msgstr "Inhaltstypen sind: ${names}"
 
 #. Default: "Contents"
 #: CMFPlone/profiles/default/actions.xml
@@ -1385,7 +1386,7 @@ msgstr "Kopie zur Publikation eingereicht - Auf Überprüfung wartend"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/configure.zcml:95
 msgid "Copy the triggering item to a specific folder"
-msgstr ""
+msgstr "Kopiert den auslösenden Artikel in einen definierten Ordner. "
 
 #: plone.app.contentrules/plone/app/contentrules/actions/configure.zcml:95
 msgid "Copy to folder"
@@ -1405,11 +1406,11 @@ msgstr "Es konnte keine gültige E-Mail-Adresse gefunden werden."
 
 #: plone.app.content/plone/app/content/browser/contents/workflow.py:90
 msgid "Could not transition: ${title}"
-msgstr ""
+msgstr "Übergang konnte nicht durchgeführt werden für: ${title}"
 
 #: CMFPlone/controlpanel/browser/quickinstaller.py:724
 msgid "Could not uninstall ${product}."
-msgstr ""
+msgstr "Konnte ${product} nicht deinstallieren."
 
 #: plone.app.layout/plone/app/layout/viewlets/content.py:354
 #: plone/app/theming/browser/controlpanel.pt:246
@@ -1465,13 +1466,11 @@ msgstr "IDs der Ersteller"
 
 #: CMFPlone/interfaces/controlpanel.py:1058
 msgid "Crop the item description in search result listings after a number of characters."
-msgstr ""
-"Beschreibung des Objekts in Suchresultaten auf eine  \n"
-"Crop the item description in search result listings after a number of characters."
+msgstr "Abschneiden der Beschreibung des Inhalts in Suchresultaten auf eine bestimmte Zeichenzahl."
 
 #: plone.app.widgets/plone/app/widgets/utils.py:170
 msgid "Current Content"
-msgstr ""
+msgstr "Aktueller Inhalt"
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:570
 msgid "Current User"
@@ -1487,19 +1486,19 @@ msgstr "Aktuell eingeloggter Benutzer"
 
 #: CMFPlone/interfaces/controlpanel.py:459
 msgid "Custom attributes"
-msgstr ""
+msgstr "Zusätzliche Attribute"
 
 #: CMFPlone/interfaces/controlpanel.py:721
 msgid "Custom buttons"
-msgstr ""
+msgstr "Zusätzliche Buttons"
 
 #: CMFPlone/interfaces/controlpanel.py:711
 msgid "Custom plugins"
-msgstr ""
+msgstr "Zusätzliche Plugins"
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/custom_migration.pt:21
 msgid "Custom types migration control panel"
-msgstr ""
+msgstr "Einstellungen zur Migration angepasster Inhaltstypen."
 
 #. Default: "Cut"
 #: CMFPlone/profiles/default/actions.xml
@@ -1546,7 +1545,7 @@ msgstr "Zeitspanne"
 
 #: CMFPlone/interfaces/resources.py:60
 msgid "Date time of the last compilation of this bundle"
-msgstr ""
+msgstr "Zeitstempel der letzten Kompilierung dieses Bundles"
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 msgid "Dates"
@@ -1558,7 +1557,7 @@ msgstr "Tag"
 
 #: CMFPlone/interfaces/controlpanel.py:881
 msgid "Days of object history to keep after packing"
-msgstr "Tage der Objekthistorie, die nach dem Packen erhalten bleiben sollen."
+msgstr "Tage der Inhaltshistorie, die nach dem Packen erhalten bleiben sollen."
 
 #: plone/app/theming/browser/controlpanel.pt:170
 msgid "Deactivate"
@@ -1599,7 +1598,7 @@ msgstr "Standard MIME Typ für Ausgabe"
 
 #: CMFPlone/interfaces/controlpanel.py:1309
 msgid "Default page IDs"
-msgstr ""
+msgstr "Vorgabe Seiten-IDs"
 
 #: plone.app.content/plone/app/content/browser/contents/defaultpage.py:7
 msgid "Default page set successfully"
@@ -1615,11 +1614,11 @@ msgstr "Standard-Zeitzone"
 
 #: CMFPlone/interfaces/resources.py:112
 msgid "Define list of modules that will be defined empty on RequireJS build steps to prevent loading modules multiple times."
-msgstr ""
+msgstr "Legt eine Liste von Modulen fest, die während des Bauens im RequireJS Schritt nicht hinzugefügt werden sollen um das mehrfache Laden von Modulen zu unterbinden."
 
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/collection.py:43
 msgid "Define the search terms for the items you want to list by choosing what to match on. The list of results will be dynamically updated"
-msgstr ""
+msgstr "Legt die Suchbegriffe für die aufzulistenden Artikel fest. Es wird ausgewählt welche Artikel passen. Die Liste der Ergebnisse wird stetig dynamisch erneuert."
 
 #: plone.app.collection/plone/app/collection/collection.py:32
 msgid "Define the search terms for the items you want to list by choosing what to match on. The list of results will be dynamically updated."
@@ -1627,11 +1626,11 @@ msgstr "Legen Sie die Suchbegriffe fest um die Inhalte zu finden, die sie auflis
 
 #: CMFPlone/interfaces/controlpanel.py:1038
 msgid "Define the types that should be searched and be available in the user facing part of the site. Note that if new content types are installed, they will be enabled by default unless explicitly turned off here or by the relevant installer."
-msgstr "Wählen Sie die Artikeltypen aus, die Benutzern für eine Suche zur Verfügung stehen sollen. Beachten Sie bitte, dass neu installierte Artikeltypen standardmäßig zur Verfügung stehen, solange sie hier oder durch das jeweilige Installationsskript nicht ausdrücklich ausgeblendet wurden."
+msgstr "Wählen Sie die Inhaltstypen aus, die Benutzern für eine Suche zur Verfügung stehen sollen. Beachten Sie bitte, dass neu installierte Inhaltstypen standardmäßig zur Verfügung stehen, solange sie hier oder durch das jeweilige Installationsskript nicht ausdrücklich ausgeblendet wurden."
 
 #: CMFPlone/interfaces/controlpanel.py:1037
 msgid "Define the types to be shown in the site and searched"
-msgstr "Artikeltypen auswählen"
+msgstr "Inhaltstypen auswählen"
 
 #. Default: "Delete"
 #: CMFPlone/controlpanel/browser/actions.pt:49
@@ -1646,7 +1645,7 @@ msgstr "${override} löschen"
 
 #: plone.app.registry/plone/app/registry/browser/templates/delete_layout.pt:15
 msgid "Delete Record"
-msgstr ""
+msgstr "Lösche Datensatz"
 
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:125
 msgid "Delete field"
@@ -1659,19 +1658,19 @@ msgstr "Artikel löschen"
 
 #: plone.app.registry/plone/app/registry/browser/templates/records.pt:108
 msgid "Delete record"
-msgstr ""
+msgstr "Lösche Datensatz"
 
 #: plone.app.content/plone/app/content/browser/contents/delete.py:35
 msgid "Delete selected items"
-msgstr "Ausgewählte Objekte löschen"
+msgstr "Ausgewählte Inhalte löschen"
 
 #: CMFPlone/controlpanel/browser/actions.pt:49
 msgid "Delete the action?"
-msgstr ""
+msgstr "Diese Aktion löschen?"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/configure.zcml:147
 msgid "Delete the triggering item"
-msgstr ""
+msgstr "Lösche den auslösenden Artikel"
 
 #: plone/app/theming/interfaces.py:201
 msgid "Dependencies"
@@ -1679,7 +1678,7 @@ msgstr "Abhängigkeiten"
 
 #: CMFPlone/interfaces/resources.py:34
 msgid "Dependencies for shim"
-msgstr ""
+msgstr "Abhängigkeiten des Shim"
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:44
 #: plone.app.contenttypes/plone/app/contenttypes/migration/custom_migration.pt:38
@@ -1688,7 +1687,7 @@ msgstr ""
 
 #: CMFPlone/interfaces/resources.py:97
 msgid "Depends on another bundle"
-msgstr ""
+msgstr "Hängt von anderem Bundle ab"
 
 #: CMFPlone/interfaces/controlpanel.py:1732
 #: plone.app.content/plone/app/content/browser/contents/__init__.py:202
@@ -1740,7 +1739,7 @@ msgstr "Unterstützung für Diazo Designs"
 
 #: CMFPlone/interfaces/controlpanel.py:349
 msgid "Disable HTML filtering"
-msgstr ""
+msgstr "HTML Filter abschalten"
 
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/controlpanel.pt:51
 msgid "Disable globally"
@@ -1748,11 +1747,11 @@ msgstr "Deaktiviere global"
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/custom_migration.pt:101
 msgid "Disable reindexing objects during migration"
-msgstr ""
+msgstr "Die Neuindizierung von Artikeln während der Migration abschalten"
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/browser.py:310
 msgid "Disable reindexing objects during migration?"
-msgstr ""
+msgstr "Artikel-Neuindizierung während Migration abschalten?"
 
 #: plone.app.discussion/plone/app/discussion/vocabularies.py:44
 msgid "Disabled"
@@ -1764,7 +1763,7 @@ msgstr "Das Ausschalten der Bearbeitungssperre wirkt sich nur auf die Benutzer a
 
 #: plone.app.content/plone/app/content/browser/contents/paste.py:57
 msgid "Disallowed subobject type \"${type}\""
-msgstr "Unerlaubtes Unterobjekt vom Typ \"${type}\""
+msgstr "Unerlaubte Unterinhalte vom Inhaltstyp \"${type}\""
 
 #: plone.app.discussion/plone/app/discussion/profiles/default/controlpanel.xml
 msgid "Discussion"
@@ -1790,7 +1789,7 @@ msgstr "Publikationsdatum anzeigen"
 
 #: CMFPlone/interfaces/controlpanel.py:951
 msgid "Displayed content types"
-msgstr "Angezeigte Artikeltypen"
+msgstr "Angezeigte Inhaltstypen"
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/custom_migration.pt:119
 msgid "Do not migrate"
@@ -1810,7 +1809,7 @@ msgstr "Das aktuelle Passwort stimmt nicht."
 
 #: CMFPlone/interfaces/resources.py:90
 msgid "Does your bundle contains any RequireJS or LESS file?"
-msgstr ""
+msgstr "Enthält Ihr Bundle eine RequireJS oder LESS Datei?"
 
 #: plone.cachepurging/plone/cachepurging/interfaces.py:55
 msgid "Domains"
@@ -1847,15 +1846,15 @@ msgstr "E-Mail-Adresse"
 
 #: CMFPlone/interfaces/controlpanel.py:1492
 msgid "E-mail characterset"
-msgstr ""
+msgstr "E-Mail Charakterset"
 
 #: CMFPlone/interfaces/controlpanel.py:1254
 msgid "E.g. standard view; This default can be overriden individually."
-msgstr ""
+msgstr "Z.B. Liste; Dieser Vorgabewert kann individuell überschrieben werden."
 
 #: CMFPlone/interfaces/controlpanel.py:1262
 msgid "E.g., tabular view, folder content listing; This default can be overriden individually."
-msgstr ""
+msgstr "Z.B. Tabellen Ansicht; Dieser Vorgabewert kann individuell überschrieben werden."
 
 msgid "EPS image"
 msgstr "EPS Grafik"
@@ -1885,7 +1884,7 @@ msgstr "Kollektionsportlet bearbeiten"
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/portaltype.py:116
 msgid "Edit Content Type Condition"
-msgstr "Artikeltypenbedingung bearbeiten"
+msgstr "Inhaltstypenbedingung bearbeiten"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/copy.py:163
 msgid "Edit Copy Action"
@@ -1914,7 +1913,7 @@ msgstr "E-Mail-Aktion bearbeiten"
 #: plone.app.users/plone/app/users/browser/schema_layout.pt:19
 #: plone.app.users/plone/app/users/browser/schemaeditor.py:98
 msgid "Edit Member Form Fields"
-msgstr ""
+msgstr "Bearbeiten der Benutzer-Formularfelder"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/move.py:191
 msgid "Edit Move Action"
@@ -1942,7 +1941,7 @@ msgstr "Portlet »Aktuelle Änderungen« bearbeiten"
 
 #: plone.app.portlets/plone/app/portlets/portlets/review.py:166
 msgid "Edit Review Portlet"
-msgstr ""
+msgstr "Bearbeite "
 
 #: plone.app.contentrules/plone/app/contentrules/browser/rule.py:50
 msgid "Edit Rule"
@@ -2020,7 +2019,7 @@ msgstr "Breite des Editors"
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:543
 msgid "Editors E-Mails"
-msgstr ""
+msgstr "E-Mail des Bearbeiters"
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 msgid "Effective date"
@@ -2074,11 +2073,11 @@ msgstr "Persönliche Benutzerordner"
 
 #: CMFPlone/interfaces/controlpanel.py:478
 msgid "Enable auto resizing of the editor window."
-msgstr ""
+msgstr "Erlaube die automatsiche Größenveränderung des Editor-Fensters."
 
 #: plone.app.iterate/plone/app/iterate/interfaces.py:318
 msgid "Enable checkout workflow"
-msgstr ""
+msgstr "Arbeitskopie Arbeitsablauf einschalten"
 
 #: CMFPlone/interfaces/controlpanel.py:124
 msgid "Enable link integrity checks"
@@ -2094,11 +2093,11 @@ msgstr "Aktiviert die zurück/vor-Navigation für alle Artikel dieses Inhaltstyp
 
 #: plone.cachepurging/plone/cachepurging/interfaces.py:17
 msgid "Enable purging"
-msgstr ""
+msgstr "Purging einschalten"
 
 #: CMFPlone/interfaces/controlpanel.py:471
 msgid "Enable resizing the editor window."
-msgstr ""
+msgstr "Automatische Größenänderung Editor-Fenster"
 
 #: CMFPlone/interfaces/controlpanel.py:1080
 msgid "Enable self-registration"
@@ -2125,29 +2124,29 @@ msgstr "Enddatum"
 
 #: CMFPlone/interfaces/controlpanel.py:581
 msgid "Enter a JSON-formatted style format configuration. A format is for example the style that get applied when you press the bold button inside the editor. See https://www.tinymce.com/docs/configure/content-formatting/#formats"
-msgstr ""
+msgstr "Erwartet wird eine JSON-formatierte Konfiguration. Das Format ist z.B. der Stil, der angewendet werden soll, wenn der Fettdruck Button innerhalb des Editors gedrückt wurde. Siehe https://www.tinymce.com/docs/configure/content-formatting/#formats"
 
 #: CMFPlone/interfaces/controlpanel.py:828
 msgid "Enter a list of content types which can be used as images. Format is one contenttype per line."
-msgstr ""
+msgstr "Erwartet wird eine Liste von Inhaltstypen, die als Bilder verwendet werden können. Das Format ist ein Inhaltstyp pro Zeile."
 
 #: CMFPlone/interfaces/controlpanel.py:816
 msgid "Enter a list of content types which can contain other objects. Format is one contenttype per line."
-msgstr ""
+msgstr "Erwartet wird eine Liste von Inhaltstypen, die als Container für andere Artikel verwendet werden können. Das Format ist ein Inhaltstyp pro Zeile."
 
 #: CMFPlone/interfaces/controlpanel.py:722
 msgid "Enter a list of custom buttons which will be added to toolbar"
-msgstr ""
+msgstr "Erwartet wird einen Liste von zusätzlichen Buttons, um diese zur Werkzeugleiste hinzuzufügen."
 
 #: CMFPlone/interfaces/controlpanel.py:712
 msgid "Enter a list of custom plugins which will be loaded in the editor. Format is pluginname|location, one per line."
-msgstr ""
+msgstr "Erwartet wird einen Liste von zusätzlichen Buttons, um diese zur im Editor zu laden. Das Format ist Pluigin-Name|Ort, einer pro Zeile."
 
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/thumb_icon.py:29
 #: plone.app.portlets/plone/app/portlets/portlets/navigation.py:117
 #: plone.app.portlets/plone/app/portlets/portlets/news.py:43
 msgid "Enter a valid scale name (see 'Image Handling' control panel) to override (e.g. icon, tile, thumb, mini, preview, ... ). Leave empty to use default (see 'Site' control panel)."
-msgstr ""
+msgstr "Erwartet wird ein gültiger Skalierungsname zum Überschreiben (z.B. icon, tile, thumb, minim, preview, ... Siehe Einstellungen zur 'Bildbehandlung'). Leer lassen um die Vorgabewerte zu verwenden (siehe Einstellungen 'Webseite')."
 
 #: plone.schemaeditor/plone/schemaeditor/schema.py:94
 msgid "Enter allowed choices one per line."
@@ -2187,7 +2186,7 @@ msgstr "Fehler"
 
 #: plone.app.content/plone/app/content/browser/contents/rearrange.py:33
 msgid "Error moving item"
-msgstr "Fehler beim Bewegen des Objekts"
+msgstr "Fehler beim Positionieren des Inhalts"
 
 #: plone.app.content/plone/app/content/browser/contents/rename.py:107
 msgid "Error renaming ${title}"
@@ -2195,7 +2194,7 @@ msgstr "Fehler beim Umbenennen von ${title}"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/mail.py:125
 msgid "Error sending email from content rule. You must provide a source address for mail actions or enter an email in the portal properties"
-msgstr ""
+msgstr "Fehler beim Senden der E-Mail aus der Inhaltsregel. Es muss eine Absender-Adresse für E-Mail Aktionen angegeben werden oder zumindest eine Adresse in den E-Mail Einstellungen."
 
 #: CMFPlone/controlpanel/browser/quickinstaller.py:715
 msgid "Error uninstalling ${product}."
@@ -2207,15 +2206,15 @@ msgstr "Fehler bei der Aktualisierung von ${product}."
 
 #: plone.app.dexterity/plone/app/dexterity/browser/import_types.py:56
 msgid "Error: The file submitted must be a zip archive containing only type profile information."
-msgstr ""
+msgstr "Fehler: Die bereitgestelle Datei muss ein ZIP-Archiv sein, welches rein die Profil-Information enthält."
 
 #: plone.app.dexterity/plone/app/dexterity/browser/import_types.py:47
 msgid "Error: The file submitted must be a zip archive."
-msgstr ""
+msgstr "Fehler: Die bereitgestelle Datei muss ein ZIP-Archiv sein."
 
 #: plone.app.dexterity/plone/app/dexterity/browser/modeleditor.py:64
 msgid "Error: all model elements must be 'schema'"
-msgstr ""
+msgstr "Fehler: Alle Model-Elemente müssen ein 'schema' sein"
 
 #: plone.app.dexterity/plone/app/dexterity/browser/modeleditor.py:58
 msgid "Error: root tag must be 'model'"
@@ -2264,11 +2263,11 @@ msgstr "Ausführenden nicht benachrichtigen"
 
 #: plone.portlet.collection/plone/portlet/collection/collection.py:95
 msgid "Exclude the Current Context"
-msgstr "Ausschließen des aktuellen Contexts"
+msgstr "Ausschließen des aktuellen Kontexts"
 
 #: plone.app.content/plone/app/content/browser/contents/__init__.py:205
 msgid "Excluded from navigation"
-msgstr "Von der Navigation ausschließen"
+msgstr "Navigations-Ausschluss "
 
 #: plone.app.contentrules/plone/app/contentrules/actions/workflow.py:43
 msgid "Execute transition ${transition}"
@@ -2281,7 +2280,7 @@ msgstr "Ablaufdatum"
 
 #: CMFPlone/browser/templates/explainPWResetTool.pt:43
 msgid "Expired reset requests: ${n} (expired requests deleted after 10 days)"
-msgstr ""
+msgstr "Abgelaufene Zurücksetzen-Anfrage: ${n} (abgelaufene Anfragen werden nach 10 Tagen gelöscht)"
 
 #: plone.app.dexterity/plone/app/dexterity/browser/types.py:99
 msgid "Export Schema Models"
@@ -2293,7 +2292,7 @@ msgstr "Inhaltstyp-Profile exportieren"
 
 #: CMFPlone/interfaces/resources.py:39
 msgid "Export vars for shim"
-msgstr ""
+msgstr "Exportieren der 'vars' für das Shim"
 
 #: CMFPlone/interfaces/controlpanel.py:1156
 msgid "Expose Dublin Core metadata"
@@ -2309,24 +2308,24 @@ msgstr "Die Dublin-Core-Metadaten werden als Metatags in den HTML-Code eingebund
 
 #: CMFPlone/interfaces/controlpanel.py:1163
 msgid "Exposes your content as a file according to the <a href='http://sitemaps.org'>sitemaps.org</a> standard. You can submit this to compliant search engines like Google, Yahoo and Microsoft. It allows these search engines to more intelligently crawl your site."
-msgstr ""
+msgstr "Stellt Ihre Inhalte im <a href='http://sitemaps.org'>sitemaps.org</a> Standard bereit. Sie können die Sitemap bei standardkonformen Suchmaschinen wie Google, Yahoo and Microsoft einreichen. Die Suchmaschinen können somit die Inhalte der Seite optimierter verarbeiten."
 
 #: CMFPlone/interfaces/resources.py:64
 msgid "Expression to render"
-msgstr ""
+msgstr "Ausdruck zum Rendern"
 
 #: Archetypes/profiles.zcml:12
 msgid "Extension profile for default Archetypes setup."
-msgstr ""
+msgstr "Erweiterungsprofil für die Standard-Archetypes Installation"
 
 #: plone.app.referenceablebehavior/plone/app/referenceablebehavior/profiles.zcml:20
 msgid "Extension profile for plone.app.referenceablebehavior"
-msgstr ""
+msgstr "Erweiterungsprofil für plone.app.referenceablebehavior"
 
 #: CMFPlone/profiles.zcml:31
 #: plone.app.iterate/plone/app/iterate/configure.zcml:45
 msgid "Extension profile to configure a test fixture"
-msgstr ""
+msgstr "Erweiterungsprofil für plone.app.referenceablebehavior um eine Test-Fixture zu Konfigurieren"
 
 #. Default: "External Edit"
 #: CMFPlone/profiles/default/types/Discussion_Item.xml
@@ -2335,7 +2334,7 @@ msgstr "Extern bearbeiten"
 
 #: CMFPlone/interfaces/controlpanel.py:1699
 msgid "External login iframe"
-msgstr ""
+msgstr "Externer Login im Iframe"
 
 #: CMFPlone/interfaces/controlpanel.py:1687
 msgid "External login url"
@@ -2360,39 +2359,39 @@ msgstr "Facebook Benutzername"
 
 #: plone.app.content/plone/app/content/browser/contents/copy.py:32
 msgid "Failed to copy items"
-msgstr "Kopieren der Objekte ist fehlgeschlagen"
+msgstr "Kopieren der Inhalte ist fehlgeschlagen"
 
 #: plone.app.content/plone/app/content/browser/contents/cut.py:32
 msgid "Failed to cut items"
-msgstr "Ausschneiden der Objekte ist fehlgeschlagen"
+msgstr "Ausschneiden der Inhalte ist fehlgeschlagen"
 
 #: plone.app.content/plone/app/content/browser/contents/delete.py:48
 msgid "Failed to delete items"
-msgstr "Löschen der Objekte ist fehlgeschlagen"
+msgstr "Löschen der Inhalte ist fehlgeschlagen"
 
 #: CMFPlone/controlpanel/browser/quickinstaller.py:696
 msgid "Failed to install ${product}."
-msgstr ""
+msgstr "Installation fehlgeschlagen: ${product}"
 
 #: plone.app.content/plone/app/content/browser/contents/workflow.py:41
 msgid "Failed to modify items"
-msgstr "Änderung der Objekte ist fehlgeschlagen"
+msgstr "Änderung der Inhalte ist fehlgeschlagen"
 
 #: plone.app.content/plone/app/content/browser/contents/tags.py:40
 msgid "Failed to modify tags on items"
-msgstr "Änderung der Tags von Objekten ist fehlgeschlagen"
+msgstr "Änderung der Stichworte von Inhalten ist fehlgeschlagen"
 
 #: plone.app.content/plone/app/content/browser/contents/paste.py:32
 msgid "Failed to paste items"
-msgstr "Einfügen der Objekte ist fehlgeschlagen"
+msgstr "Einfügen der Inhalte ist fehlgeschlagen"
 
 #: plone.app.content/plone/app/content/browser/contents/rename.py:48
 msgid "Failed to rename all items"
-msgstr "Umbenennung aller Objekte ist fehlgeschlagen"
+msgstr "Umbenennung aller Inhalte ist fehlgeschlagen"
 
 #: plone.app.content/plone/app/content/browser/contents/defaultpage.py:8
 msgid "Failed to set default page"
-msgstr ""
+msgstr "Standardseite setzen ist fehlgeschlagen"
 
 #: plone.app.content/plone/app/content/browser/contents/__init__.py:51
 msgid "Failure"
@@ -2400,7 +2399,7 @@ msgstr "Fehler"
 
 #: plone.app.content/plone/app/content/browser/contents/properties.py:48
 msgid "Failure updating metadata"
-msgstr ""
+msgstr "Fehler beim Verändern der Metadaten"
 
 #: CMFPlone/interfaces/syndication.py:231
 msgid "Feed Types"
@@ -2496,7 +2495,7 @@ msgstr "Ordner"
 
 #: plone.app.dexterity/plone/app/dexterity/behaviors/configure.zcml:135
 msgid "Folder Addable Constrains"
-msgstr ""
+msgstr "Hinzufügen Einschränkungen des Ordners"
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:116
 msgid "Folder URL"
@@ -2513,11 +2512,11 @@ msgstr "Nur für angemeldete Benutzer"
 
 #: CMFPlone/interfaces/controlpanel.py:1177
 msgid "For enabling web statistics support from external providers (e.g. Google Analytics). Paste the provided code snippet here. It will be rendered as entered near the end of the page."
-msgstr ""
+msgstr "Gedacht für den Webstatistik-Support externer Anbieter (z.B. Google Analytics). Der bereitgestellte Code-Schnipsel wird hier eingefügt. Er wird unverändert nahe dem Ende der Webseite gerendert."
 
 #: CMFPlone/interfaces/controlpanel.py:1595
 msgid "For linking Open Graph data to a Facebook account"
-msgstr ""
+msgstr "Um Open Graph Daten mit einem Facebook-Konto zu verknüpfen."
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:292
 msgid "Format"
@@ -2529,7 +2528,7 @@ msgstr "Formate"
 
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:103
 msgid "From the ${behavior_name} behavior:"
-msgstr ""
+msgstr "Vom ${behavior_name} Behavior:"
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:588
 msgid "Full Name"
@@ -2549,19 +2548,19 @@ msgstr "Allgemein"
 
 #: CMFPlone/controlpanel/browser/types.py:54
 msgid "General types settings."
-msgstr ""
+msgstr "Allgemeine Inhaltstypen Einstellungen"
 
 #: CMFPlone/interfaces/controlpanel.py:907
 msgid "Generate tabs for items other than folders."
-msgstr "Erzeuge Einträge nicht nur für Ordner, sondern für alle Artikeltypen."
+msgstr "Erzeuge Reiter nicht nur für Ordner, sondern für alle Inhaltstypen."
 
 #: plone.app.textfield/plone/app/textfield/interfaces.py:75
 msgid "Get the raw value as an encoded string"
-msgstr ""
+msgstr "Holt den Rohwert als encodierte Zeichenfolge"
 
 #: plone.app.dexterity/plone/app/dexterity/behaviors/configure.zcml:145
 msgid "Gives the ability to rename an item from its edit form."
-msgstr ""
+msgstr "Ermöglicht das Umbenennen eines Artikels aus dem Bearbeiten-Formular heraus."
 
 #: CMFPlone/browser/templates/plone-logged-out.pt:29
 msgid "Go back to your site."
@@ -2581,7 +2580,7 @@ msgstr "Ins ZMI gehen"
 
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/manage-elements.pt:209
 msgid "Go to the folder where you want the rule to apply, or at the site root, click on 'rule' tab, and then locally setup the rules."
-msgstr ""
+msgstr "Gehen sie zu dem Ordner (oder zur Seiten-Wurzel) in dem die Regel angewendet werden soll. Klicken Sie auf den 'Regeln' Menupunkt und setzen Sie in diesem Umfeld die Regeln."
 
 #: CMFPlone/controlpanel/browser/overview.pt:32
 msgid "Go to the upgrade page"
@@ -2630,7 +2629,7 @@ msgstr ""
 
 #: CMFPlone/interfaces/controlpanel.py:520
 msgid "Header styles"
-msgstr ""
+msgstr "Überschriften Stile"
 
 #: plone/app/theming/browser/controlpanel.pt:109
 msgid "Help"
@@ -2642,19 +2641,19 @@ msgstr "Hilfetext"
 
 #: CMFPlone/controlpanel/browser/actions.pt:38
 msgid "Hide"
-msgstr ""
+msgstr "Verstecken"
 
 #: CMFPlone/interfaces/controlpanel.py:1015
 msgid "Hide children of these types"
-msgstr ""
+msgstr "Verstecke Kind-Artikel dieser Inhaltstypen"
 
 #: CMFPlone/interfaces/controlpanel.py:1016
 msgid "Hide content inside the following types in Navigation."
-msgstr ""
+msgstr "Verstecke Inhalte der folgenden Typen in der Navigation."
 
 #: CMFPlone/interfaces/controlpanel.py:1632
 msgid "High pixel density mode"
-msgstr ""
+msgstr "Modus für hochauflösende Geräte"
 
 #. Default: "History"
 #: CMFPlone/profiles/default/actions.xml
@@ -2713,15 +2712,15 @@ msgstr ""
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:312
 msgid "Identifier, actually URL of the content"
-msgstr ""
+msgstr "Kennung, in Wirklichkeit die URL des Inhalts"
 
 #: CMFPlone/interfaces/controlpanel.py:989
 msgid "If an item has been excluded from navigation should it be shown in navigation when viewing content contained within it or within a subfolder."
-msgstr "Soll ein Artikel, der von der Navigation ausgeschlossen wurde, in der Navigation aufgeführt werden, wenn ein Aritkel angezeigt wird, der sich in dem Artikel oder in einem Unterordner des Artikels befindet?"
+msgstr "Soll ein Inhalt, der grundsätzlich von der Navigation ausgeschlossen wurde, dann in der Navigation aufgeführt werden, wenn ein Inmhalt angezeigt wird, der sich in dem Artikel oder in einem Unterordner des Artikels befindet?"
 
 #: plone.cachepurging/plone/cachepurging/interfaces.py:18
 msgid "If disabled, no purging will take place"
-msgstr ""
+msgstr "Wenn abgeschaltet, dann wird kein Purging ausgeführt."
 
 #: plone.portlet.collection/plone/portlet/collection/collection.py:81
 msgid "If enabled, a more... link will appear in the footer of the portlet, linking to the underlying Collection."
@@ -2737,27 +2736,27 @@ msgstr "Falls aktiviert werden die Artikel zufällig ausgewählt und nicht nach 
 
 #: plone.portlet.collection/plone/portlet/collection/collection.py:96
 msgid "If enabled, the listing will not include the current item the portlet is rendered for if it otherwise would be."
-msgstr ""
+msgstr "Wenn eingeschaltet, dann wird die Auflistung den Eintrag, auf dem das Portlet im Moment gerendert wird, nicht enthalten. Sonst jedoch schon."
 
 #: plone.app.portlets/plone/app/portlets/portlets/recent.py:34
 #: plone.app.portlets/plone/app/portlets/portlets/review.py:25
 msgid "If enabled, the portlet will not show document type icons"
-msgstr ""
+msgstr "Wenn eingeschaltet, dann zeigt das Portlet keine Dokument-Typ Icons"
 
 #: plone.app.portlets/plone/app/portlets/portlets/navigation.py:110
 #: plone.portlet.collection/plone/portlet/collection/collection.py:104
 msgid "If enabled, the portlet will not show document type icons."
-msgstr ""
+msgstr "Wenn eingeschaltet, dann zeigt das Portlet keine Dokument-Typ Icons."
 
 #: plone.app.portlets/plone/app/portlets/portlets/news.py:54
 msgid "If enabled, the portlet will not show thumbs"
-msgstr ""
+msgstr "Wenn eingeschaltet, dann zeigt das Portlet keine Mini-Bilder."
 
 #: plone.app.portlets/plone/app/portlets/portlets/navigation.py:128
 #: plone.app.portlets/plone/app/portlets/portlets/recent.py:52
 #: plone.app.portlets/plone/app/portlets/portlets/review.py:43
 msgid "If enabled, the portlet will not show thumbs."
-msgstr ""
+msgstr "Wenn eingeschaltet, dann zeigt das Portlet keine Mini-Bilder."
 
 #: plone.portlet.static/plone/portlet/static/static.py:90
 msgid "If given, the header and footer will link to this URL."
@@ -2807,19 +2806,19 @@ msgstr "Handhabung von Bildern"
 
 #: CMFPlone/controlpanel/browser/imaging.py:13
 msgid "Image Handling Settings"
-msgstr ""
+msgstr "Einstellungen zur Handhabung von Bildern"
 
 #: CMFPlone/interfaces/controlpanel.py:827
 msgid "Image objects"
-msgstr "Bild Objekte"
+msgstr "Bild Inhalte"
 
 #: CMFPlone/interfaces/controlpanel.py:1643
 msgid "Image quality at 2x"
-msgstr ""
+msgstr "Bildqualität bei 2x"
 
 #: CMFPlone/interfaces/controlpanel.py:1654
 msgid "Image quality at 3x"
-msgstr ""
+msgstr "Bildqualität bei 3x"
 
 #: plone.app.contenttypes/plone/app/contenttypes/profiles/default/types/Image.xml
 msgid "Images can be referenced in pages or displayed in an album."
@@ -2835,7 +2834,7 @@ msgstr "Inhaltstypen importieren"
 
 #: plone.app.dexterity/plone/app/dexterity/browser/types_listing.pt:30
 msgid "Import Type Profiles&hellip;"
-msgstr ""
+msgstr "Importieren des Inhaltstyp-Profiles&hellip;"
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:36
 #: plone.app.contenttypes/plone/app/contenttypes/migration/custom_migration.pt:31
@@ -2864,7 +2863,7 @@ msgstr ""
 
 #: CMFPlone/interfaces/controlpanel.py:1570
 msgid "Include meta tags on pages to give hints to social media on how to better render your pages when shared"
-msgstr ""
+msgstr "Erzeuge Meta-Tags auf Artikeln um Social Media Seiten für das Teilen Hinweise zum besseren Rendern ihrer Seiten zu geben."
 
 #: plone.app.users/plone/app/users/browser/passwordpanel.py:91
 msgid "Incorrect value for current password"
@@ -2872,7 +2871,7 @@ msgstr "Falsches aktuelles Passwort"
 
 #: CMFPlone/interfaces/controlpanel.py:918
 msgid "Index used to sort the tabs"
-msgstr ""
+msgstr "Index, der zum Sortieren der Reiter verwendet werden soll, auswählen."
 
 #. Default: "Info"
 #: Archetypes/skins/archetypes/edit_macros.pt:36
@@ -2883,7 +2882,7 @@ msgstr "Information"
 
 #: CMFPlone/browser/templates/explainPWResetTool.pt:40
 msgid "Information"
-msgstr ""
+msgstr "Information"
 
 #: CMFPlone/interfaces/resources.py:30
 msgid "Init instruction for shim"
@@ -2891,7 +2890,7 @@ msgstr ""
 
 #: CMFPlone/interfaces/controlpanel.py:534
 msgid "Inline styles"
-msgstr ""
+msgstr "Inline Stile"
 
 #: plone.app.textfield/plone/app/textfield/editor.py:22
 msgid "Input format"
@@ -2976,11 +2975,11 @@ msgstr "Ist innerhalb (relativ)"
 
 #: CMFPlone/interfaces/controlpanel.py:1277
 msgid "It can be on the side (vertical mode) or on the top (horizontal mode)"
-msgstr ""
+msgstr "Die Darstellung kann an der Seite (senkrecht) oder oben (horizontal) sein."
 
 #: CMFPlone/interfaces/resources.py:85
 msgid "It's enabled?"
-msgstr ""
+msgstr "Ist es eingeschaltet?"
 
 #: CMFPlone/skins/plone_form_scripts/content_status_modify.cpy:88
 #: CMFPlone/skins/plone_scripts/folder_publish.cpy:34
@@ -3001,7 +3000,7 @@ msgstr "Artikel diese Typs können andere Artikel enthalten."
 
 #: plone.app.content/plone/app/content/browser/contents/rename.py:47
 msgid "Items renamed"
-msgstr "Objekte umbenannt"
+msgstr "Inhalte umbenannt"
 
 msgid "JPEG image"
 msgstr "JPEG Grafik"
@@ -3022,7 +3021,7 @@ msgstr "Arbeitskopie behalten"
 
 #: CMFPlone/controlpanel/browser/filter.py:14
 msgid "Keep in mind that editors like TinyMCE might have additional filters."
-msgstr ""
+msgstr "Bitte beachten, dass ein Editor wie TinyMCE weitere Filter konfiguriert haben kann."
 
 #. Default: "Keywords"
 #: index friendly name of index Subject
@@ -3052,11 +3051,11 @@ msgstr "Größer als"
 
 #: plone.app.content/plone/app/content/browser/contents/__init__.py:210
 msgid "Last comment date"
-msgstr "Letztes Kommentierungsdatum"
+msgstr "Datum neuester Kommentar"
 
 #: CMFPlone/interfaces/resources.py:59
 msgid "Last compiled date"
-msgstr "Datum der letzten Übersetzung"
+msgstr "Datum der letzten Kompilierung"
 
 #: plone.app.content/plone/app/content/browser/contents/__init__.py:212
 msgid "Last modified"
@@ -3099,11 +3098,11 @@ msgstr "Suchresultate eingrenzen"
 
 #: CMFPlone/interfaces/controlpanel.py:144
 msgid "Limit tags aka keywords vocabulary used for Tags field and in searches to the terms used inside the subtree of the current navigation root. This can be used together with Plone's multilingual extension plone.app.multilingual to only offer keywords of the current selected language. Other addons may utilize this feature for its specific purposes."
-msgstr ""
+msgstr "Schränke das Stichworte-Vokabular für das Stichworte-Feld und in Suchanfragen auf die Stichworte ein, die im Unterbaum der aktuellen Navigations-Wurzel vorkommen. Dies kann zusammen mir der Erweiterung 'plone.app.multilingual' verwendet werden um nur Stichworte der aktuell ausgewählten Sprache zu verwenden. Andere Erweiterungen können diese Fähigkeit für ihre spezifischen Anwendungsfälle nutzen."
 
 #: CMFPlone/interfaces/controlpanel.py:143
 msgid "Limit tags/keywords to the current navigation root"
-msgstr ""
+msgstr "Stichworte auf aktuelle Navigationswurzel einschränken"
 
 #. Default: "Link"
 #: plone.app.contenttypes/plone/app/contenttypes/profiles/default/types/Link.xml
@@ -3157,7 +3156,7 @@ msgstr "Ein Pfad zu einem Ort in der Website, relativ zur aktuellen Position"
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 #: plone.app.querystring/plone/app/querystring/profiles/upgrades/to_5/registry.xml
 msgid "Location in the navigation structure"
-msgstr ""
+msgstr "Pfad in der Navigationsstruktur"
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 #: plone.app.querystring/plone/app/querystring/profiles/upgrades/to_5/registry.xml
@@ -3174,7 +3173,7 @@ msgstr "Sperrunterstützung für Dexterity"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/configure.zcml:35
 msgid "Log a particular event"
-msgstr ""
+msgstr "Logge ein bestimmtes Ereignis"
 
 #. Default: "Log in"
 #: CMFPlone/profiles/default/actions.xml
@@ -3277,7 +3276,7 @@ msgstr "Haupt Javascript-Datei"
 
 #: plone.app.textfield/plone/app/textfield/interfaces.py:70
 msgid "Mainly used internally"
-msgstr ""
+msgstr "Hauptsächlich intern genutzt"
 
 #: CMFPlone/profiles/default/controlpanel.xml
 msgid "Maintenance"
@@ -3285,7 +3284,7 @@ msgstr "Wartung"
 
 #: CMFPlone/controlpanel/browser/maintenance.py:30
 msgid "Maintenance Settings"
-msgstr ""
+msgstr "Wartungseinstellungen"
 
 #: plone.app.dexterity/plone/app/dexterity/behaviors/configure.zcml:82
 msgid "Make all items of this type a navigation root"
@@ -3334,7 +3333,7 @@ msgstr "Verwalten"
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:552
 msgid "Managers E-Mails"
-msgstr ""
+msgstr "Manager E-Mails"
 
 #: CMFPlone/profiles.zcml:22
 msgid "Mandatory dependencies for a Plone site"
@@ -3354,11 +3353,11 @@ msgstr ""
 
 #: CMFPlone/interfaces/controlpanel.py:1714
 msgid "Mark special links"
-msgstr ""
+msgstr "Markiere spezielle Links"
 
 #: CMFPlone/interfaces/controlpanel.py:1715
 msgid "Marks external or special protocol links with class."
-msgstr ""
+msgstr "Markiere externe Links oder spezielle Protokolle mit einer CSS-Klasse."
 
 #. Default: "Markup"
 #: CMFPlone/profiles/default/controlpanel.xml
@@ -3367,7 +3366,7 @@ msgstr "Textauszeichnung"
 
 #: CMFPlone/controlpanel/browser/markup.py:11
 msgid "Markup Settings"
-msgstr ""
+msgstr "Markup Einstellungen"
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 #: plone.app.querystring/plone/app/querystring/profiles/upgrades/to_8/registry.xml
@@ -3392,7 +3391,7 @@ msgstr "Benutzer"
 
 #: plone.app.users/plone/app/users/browser/schemaeditor.py:111
 msgid "Member Fields"
-msgstr ""
+msgstr "Member Felder"
 
 # Member Preferences Header
 #. Default: "Member Preferences"
@@ -3445,7 +3444,7 @@ msgstr ""
 
 #: CMFPlone/interfaces/resources.py:120
 msgid "Merge with"
-msgstr "Mischen mit"
+msgstr "Verschmelzen mit"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/logger.py:41
 #: plone.app.contentrules/plone/app/contentrules/actions/mail.py:61
@@ -3538,7 +3537,7 @@ msgstr "Portlet bearbeiten"
 
 #: plone.app.content/plone/app/content/browser/contents/properties.py:36
 msgid "Modify properties on items"
-msgstr ""
+msgstr "Verändert die Eigenschaften von Artikeln"
 
 #: plone/app/theming/browser/controlpanel.pt:273
 msgid "Modify theme"
@@ -3665,7 +3664,7 @@ msgstr "Nie"
 
 #: CMFPlone/controlpanel/browser/actions.py:179
 msgid "New action"
-msgstr ""
+msgstr "Neue Aktion"
 
 #: plone.app.contentrules/plone/app/contentrules/browser/adding.py:43
 msgid "New content rule created. Please add conditions and actions at the bottom of the page."
@@ -3716,7 +3715,7 @@ msgstr "Nein"
 
 #: CMFPlone/interfaces/controlpanel.py:1216
 msgid "No Thumbs in portlets"
-msgstr ""
+msgstr "Keine Mini-Bilder in Portlets"
 
 #: plone.app.portlets/plone/app/portlets/browser/formhelper.py:205
 msgid "No changes"
@@ -3739,7 +3738,7 @@ msgstr "Es gibt keine zu migrierenden Inhalte"
 
 #: CMFPlone/RegistrationTool.py:118
 msgid "No email address is registered for member: ${member_id}"
-msgstr ""
+msgstr "Keine registrierte E-Mail-Adresse für das Mitglied: ${member_id}"
 
 #: plone.formwidget.namedfile/plone/formwidget/namedfile/validator.py:9
 msgid "No file provided."
@@ -3755,19 +3754,19 @@ msgstr "Kein Mailhost angegeben. Passwortänderung unmöglich."
 
 #: CMFPlone/interfaces/controlpanel.py:1225
 msgid "No thumbs in list views"
-msgstr ""
+msgstr "Keine Mini-Bilder in Ansicht Liste"
 
 #: CMFPlone/interfaces/controlpanel.py:1232
 msgid "No thumbs in summary views"
-msgstr ""
+msgstr "Keine Mini-Bilder in Ansicht Zusammenfassung"
 
 #: CMFPlone/interfaces/controlpanel.py:1239
 msgid "No thumbs in table views"
-msgstr ""
+msgstr "Keine Mini-Bilder in Ansicht Tabelle"
 
 #: CMFPlone/controlpanel/browser/quickinstaller.pt:47
 msgid "No upgrades in this corner"
-msgstr ""
+msgstr "Kein Upgrades in diesem Bereich"
 
 #: CMFPlone/controlpanel/browser/types.py:537
 msgid "No workflow"
@@ -3775,7 +3774,7 @@ msgstr "Kein Arbeitsablauf"
 
 #: plone.app.content/plone/app/content/browser/contents/rearrange.py:94
 msgid "Not explicit orderable"
-msgstr ""
+msgstr "Nicht explizit sortierbar"
 
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.pt:56
 #: plone/app/theming/browser/controlpanel.pt:55
@@ -3785,7 +3784,7 @@ msgstr "Notiz"
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:43
 #: plone.app.contenttypes/plone/app/contenttypes/migration/custom_migration.pt:37
 msgid "Note about how long it might take"
-msgstr ""
+msgstr "Notiz, wie lang es etwa dauern wird"
 
 #: plone.app.discussion/plone/app/discussion/interfaces.py:182
 msgid "Notify me of new comments via email."
@@ -3801,11 +3800,11 @@ msgstr "Die Nachricht ${message} mitteilen"
 
 #: CMFPlone/interfaces/controlpanel.py:1009
 msgid "Number of folder levels to show in the site map."
-msgstr ""
+msgstr "Anzahl anzuzeigender Ordnerebenen in der Sitemap"
 
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/collection.py:75
 msgid "Number of items that will show up in one batch."
-msgstr ""
+msgstr "Anzahl der Artikel, die in einem Stapel angezeigt werden sollen."
 
 #: plone.app.portlets/plone/app/portlets/portlets/news.py:25
 #: plone.app.portlets/plone/app/portlets/portlets/recent.py:26
@@ -3828,7 +3827,7 @@ msgstr "ODT Dokument"
 
 #: plone.app.content/plone/app/content/browser/contents/__init__.py:207
 msgid "Object Size"
-msgstr "Objektgröße"
+msgstr "Größe"
 
 #: plone.app.contentrules/plone/app/contentrules/configure.zcml:54
 msgid "Object added to this container"
@@ -3836,7 +3835,7 @@ msgstr "Artikel wurde diesem Ordner hinzugefügt"
 
 #: plone.app.contentrules/plone/app/contentrules/configure.zcml:72
 msgid "Object copied"
-msgstr "Objekt kopiert"
+msgstr "Inhalt kopiert"
 
 #: plone.app.contentrules/plone/app/contentrules/configure.zcml:66
 msgid "Object modified"
@@ -3855,7 +3854,7 @@ msgstr "Rahmen des Portlets verbergen"
 
 #: plone.app.users/plone/app/users/browser/schemaeditor.py:129
 msgid "One image field maximum."
-msgstr ""
+msgstr "Maximal ein Bild-Feld"
 
 #: CMFPlone/interfaces/controlpanel.py:1708
 msgid "Open external links in new a window"
@@ -3863,7 +3862,7 @@ msgstr "Öffne externe Links in einem neuen Fenster"
 
 #: CMFPlone/browser/templates/explainPWResetTool.pt:42
 msgid "Open reset requests: ${n}"
-msgstr ""
+msgstr "Offene Zurücksetzen-Anfragen: ${n}"
 
 msgid "OpenOffice Calc spreadsheet"
 msgstr "OpenOffice Calc Arbeitsblatt"
@@ -3891,7 +3890,7 @@ msgstr ""
 
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/configure.zcml:63
 msgid "Options to suppress thumbs and/or icons and to override thumb size in listings, tables etc."
-msgstr ""
+msgstr "Einstellungen um Mini-Bilder und/oder Icons zu unterdrücken und um die Mini-Bildgrößen in Listen, Tabellen, usw. zu überschreiben."
 
 #. Default: "Order in folder"
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
@@ -3906,19 +3905,19 @@ msgstr "Ursprüngliche URL"
 #: plone.app.portlets/plone/app/portlets/portlets/news.py:42
 #: plone.app.portlets/plone/app/portlets/portlets/recent.py:40
 msgid "Override thumb scale"
-msgstr ""
+msgstr "Überschreibe Mini-Bild Größe"
 
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/thumb_icon.py:28
 msgid "Override thumb scale for list view"
-msgstr ""
+msgstr "Überschreibe Mini-Bild Größe für Ansicht Liste"
 
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/thumb_icon.py:50
 msgid "Override thumb scale for summary view"
-msgstr ""
+msgstr "Überschreibe Mini-Bild Größe für Ansicht Zusammenfassung"
 
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/thumb_icon.py:39
 msgid "Override thumb scale for table view"
-msgstr ""
+msgstr "Überschreibe Mini-Bild Größe für Ansicht Tabelle"
 
 #: plone.app.dexterity/plone/app/dexterity/browser/layout.py:14
 #: plone.app.dexterity/plone/app/dexterity/browser/overview.py:35
@@ -4015,7 +4014,7 @@ msgstr "Pfadkennung"
 
 #: CMFPlone/interfaces/controlpanel.py:999
 msgid "Path to be used as navigation root, relative to Plone site root.Starts with '/'"
-msgstr "Pfad der als Navigations"
+msgstr "Pfad, der als Navigationswurzel verwendet werden soll. Die Angabe ist relativ zur Plone Seitenwurzel. Sie startet mit '/'."
 
 #: plone/app/theming/interfaces.py:38
 msgid "Path to rules"
@@ -4043,7 +4042,7 @@ msgstr "Zur Redaktion eingereicht"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/configure.zcml:177
 msgid "Perform a workflow transition on the triggering object"
-msgstr "Führe eine Workflowtransition durch auf dem triggernden Objekt"
+msgstr "Führe eine Workflowtransition auf dem auslösenden Inhalt durch"
 
 #: plone.app.content/plone/app/content/browser/contents/__init__.py:122
 msgid "Permission denied for \"${title}\""
@@ -4129,7 +4128,7 @@ msgstr "Bitte benutze folgendes Format: JJJJ/MM/TT"
 
 #: plone.app.dexterity/plone/app/dexterity/interfaces.py:30
 msgid "Please use only letters, numbers and the following characters: .-_"
-msgstr ""
+msgstr "Verwenden Sie bitte nur Buchstaben, Nummern und die folgenden Zeichen: .-_"
 
 #: plone.schemaeditor/plone/schemaeditor/interfaces.py:149
 msgid "Please use only letters, numbers and the following characters: _."
@@ -4172,7 +4171,7 @@ msgstr "Plone läuft."
 
 #: CMFPlone/browser/templates/plone-addsite.pt:24
 msgid "Plone logo"
-msgstr ""
+msgstr "Plone Logo"
 
 #: plone.app.z3cform/plone/app/z3cform/profiles.zcml:15
 msgid "Plone z3c.form support"
@@ -4204,7 +4203,7 @@ msgstr "Portal Titel"
 
 #: plone.app.discussion/plone/app/discussion/interfaces.py:143
 msgid "Portal type"
-msgstr "Artikeltyp"
+msgstr "Inhaltstyp"
 
 #: plone.portlet.static/plone/portlet/static/static.py:84
 msgid "Portlet footer"
@@ -4429,11 +4428,11 @@ msgstr "RSS-Feed dieser Liste"
 
 #: CMFPlone/interfaces/controlpanel.py:848
 msgid "Raw"
-msgstr ""
+msgstr "Rohwert"
 
 #: plone.app.textfield/plone/app/textfield/interfaces.py:54
 msgid "Raw value in the original MIME type"
-msgstr ""
+msgstr "Rohwert im Original MIME-Type"
 
 msgid "Reader"
 msgstr "Ansehen"
@@ -4444,7 +4443,7 @@ msgstr ""
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/browser.py:303
 msgid "Rebuild the catalog after the migration."
-msgstr ""
+msgstr "Neubauen des Katalogs nach der Migration."
 
 #: CMFPlone/profiles/dependencies/portlets.xml
 #: plone.app.portlets/plone/app/portlets/portlets/recent.py:72
@@ -4457,7 +4456,7 @@ msgstr "Empfänger verweigerte die Annahme von diesem Server."
 
 #: plone.app.registry/plone/app/registry/browser/templates/delete_layout.pt:22
 msgid "Record"
-msgstr ""
+msgstr "Datensatz"
 
 #: CMFPlone/interfaces/controlpanel.py:1394
 msgid "Redirect links"
@@ -4486,7 +4485,7 @@ msgstr "Registrierungseinstellungen für dieses Website."
 
 #: plone.app.registry/plone/app/registry/browser/templates/records.pt:141
 msgid "Registry XML File"
-msgstr ""
+msgstr "Registry XML Datei"
 
 #. Default: "Reject"
 #: workflow action defined in plone_workflow - title Reviewer rejects submission new state visible
@@ -4500,7 +4499,7 @@ msgstr "Verweise zu"
 
 #: CMFPlone/interfaces/controlpanel.py:1287
 msgid "Relative URL for the toolbar logo"
-msgstr ""
+msgstr "Relative URL für das Toolbar-Logo"
 
 #. Default: "Relative date"
 #: criterion description of criterion ATFriendlyDateCriteria
@@ -4589,11 +4588,11 @@ msgstr "Zurückziehen"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/configure.zcml:65
 msgid "Return a portal message to the user"
-msgstr ""
+msgstr "Eine Portal-Nachricht für den Benuzter zurückliefern"
 
 #: CMFPlone/interfaces/controlpanel.py:944
 msgid "Reversed sort order for tabs."
-msgstr "Tabs in umgekehrter Reihenfolge"
+msgstr "Reiter in umgekehrter Reihenfolge"
 
 #: plone.app.layout/plone/app/layout/viewlets/content_history.pt:17
 #, fuzzy
@@ -4683,7 +4682,7 @@ msgstr "Rollen: ${names}"
 
 #: CMFPlone/interfaces/controlpanel.py:1323
 msgid "Roles that can add keywords"
-msgstr ""
+msgstr "Rollen, die Stichworten hinzufügen dürfen"
 
 #: CMFPlone/interfaces/controlpanel.py:997
 msgid "Root"
@@ -4781,7 +4780,7 @@ msgstr "Wählen Sie Erweiterungen aus, die aktiviert werden sollen. Sie können 
 #. Default: "Select content types"
 #: criterion description of criterion ATPortalTypeCriterion
 msgid "Select content types"
-msgstr "Artikeltypen auswählen"
+msgstr "Inhaltstypen auswählen"
 
 #: plone.portlet.collection/plone/portlet/collection/collection.py:73
 msgid "Select random items"
@@ -4819,7 +4818,7 @@ msgstr "Wählen Sie Einträge aus der Liste"
 
 #: CMFPlone/interfaces/controlpanel.py:1310
 msgid "Select which IDs (short names) can act as fallback default pages for a container."
-msgstr ""
+msgstr "Wähle, welche IDs (Kurznamen) als Rückfallwert für die Standardseite eines Containers agieren können."
 
 #: plone.app.collection/plone/app/collection/collection.py:84
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/collection.py:83
@@ -4833,15 +4832,15 @@ msgstr "Legen Sie fest, welche Formate dem Benutzer als Alternative zum Standard
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 #: plone.app.querystring/plone/app/querystring/profiles/upgrades/to_3/registry.xml
 msgid "Select which roles have the permission to view inactive objects"
-msgstr ""
+msgstr "Wähle, welche Rollen die Berechtigung haben sollen inaktive Inhalte anzuschauen."
 
 #: plone.cachepurging/plone/cachepurging/interfaces.py:30
 msgid "Send PURGE requests with virtual hosting paths"
-msgstr ""
+msgstr "Sende PURGE Anfragen mit Virtual-Hosting Pfaden"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/configure.zcml:207
 msgid "Send an email on the triggering object"
-msgstr ""
+msgstr "Versende ein E-Mail auf dem auslösenden Inhalt."
 
 #. Default: "Send back"
 #: CMFPlone/profiles/default/workflows/intranet_workflow/definition.xml
@@ -4886,7 +4885,7 @@ msgstr "Passwort neu setzen"
 
 #: plone.app.textfield/plone/app/textfield/interfaces.py:27
 msgid "Set to None to disable checking"
-msgstr ""
+msgstr "Auf 'None' setzen um die Überprüfung abzuschalten"
 
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/tableofcontents.py:15
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/thumb_icon.py:17
@@ -4900,7 +4899,7 @@ msgstr "Einstellungen&hellip;"
 
 #: CMFPlone/interfaces/controlpanel.py:1569
 msgid "Share social data"
-msgstr ""
+msgstr "Teile Social Media Daten"
 
 # Sharing tab
 #. Default: "Sharing"
@@ -4940,7 +4939,7 @@ msgstr "Sollen beispielhafte Inhalte in die Website eingefügt werden?"
 
 #: CMFPlone/controlpanel/browser/actions.pt:41
 msgid "Show"
-msgstr ""
+msgstr "Anzeigen"
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 #: plone.app.querystring/plone/app/querystring/profiles/upgrades/to_3/registry.xml
@@ -4949,7 +4948,7 @@ msgstr "Inaktive anzeigen"
 
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:592
 msgid "Show all available content types"
-msgstr "Zeige alle verfügbaren Artikeltypen"
+msgstr "Zeige alle verfügbaren Inhaltstypen"
 
 #: CMFPlone/interfaces/syndication.py:171
 msgid "Show author info"
@@ -4969,7 +4968,7 @@ msgstr "Icons in Auflistungen anzeigen"
 
 #: CMFPlone/interfaces/controlpanel.py:1188
 msgid "Show in the byline the date a content item was published."
-msgstr ""
+msgstr "Zeige das Freigabedatum in der Autoreninformation."
 
 #. Default: "Show internally"
 #: CMFPlone/profiles/default/workflows/intranet_folder_workflow/definition.xml
@@ -4991,7 +4990,7 @@ msgstr "Zeige Verweis auf Einstellungen"
 
 #: CMFPlone/interfaces/controlpanel.py:1206
 msgid "Show thumbnail images in listings"
-msgstr ""
+msgstr "Zeige Mini-Bilder in Listen"
 
 #: CMFPlone/skins/plone_prefs/prefs_error_log_update.py:14
 msgid "Showing all entries"
@@ -5009,7 +5008,7 @@ msgstr "Herunterfahren"
 
 #: CMFPlone/interfaces/controlpanel.py:1282
 msgid "Side"
-msgstr ""
+msgstr "Seite"
 
 #. Default: "Simple Publication Workflow"
 #: CMFPlone/profiles/default/workflows/simple_publication_workflow/definition.xml
@@ -5108,11 +5107,11 @@ msgstr "Social Media Teilen Voreinstellungen"
 
 #: CMFPlone/interfaces/controlpanel.py:945
 msgid "Sort tabs in descending."
-msgstr "Tab Sortierung \"Absteigend\""
+msgstr "Reiter Sortierung \"Absteigend\""
 
 #: CMFPlone/interfaces/controlpanel.py:917
 msgid "Sort tabs on"
-msgstr "Sortierungs-Tabs an"
+msgstr "Sortierung der Reiter"
 
 #: plone.app.collection/plone/app/collection/collection.py:45
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/collection.py:55
@@ -5121,7 +5120,7 @@ msgstr "Kollektion nach diesem Index sortieren"
 
 #: CMFPlone/interfaces/controlpanel.py:1066
 msgid "Sort the default search on this index"
-msgstr ""
+msgstr "Vorgabe-Suche nach diesem Index sortieren"
 
 #: plone.app.collection/plone/app/collection/collection.py:57
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/collection.py:61
@@ -5142,7 +5141,7 @@ msgstr "Spezieller Ordner für temporäre Daten"
 
 #: CMFPlone/interfaces/controlpanel.py:1603
 msgid "Specify all allowed maximum image dimensions, one per line. The required format is &lt;name&gt; &lt;width&gt;:&lt;height&gt;."
-msgstr ""
+msgstr "Festlegen aller erlaubten maximalen Bild-Größen. Eine pro Zeile. Das Format muss sein: &lt;name&gt; &lt;width&gt;:&lt;height&gt;."
 
 #: plone.portlet.collection/plone/portlet/collection/collection.py:68
 msgid "Specify the maximum number of items to show in the portlet. Leave this blank to show all items."
@@ -5158,7 +5157,7 @@ msgstr "Rechtschreibprüfung"
 
 #: CMFPlone/interfaces/controlpanel.py:737
 msgid "Spellchecker plugin to use"
-msgstr ""
+msgstr "Rechtschreibprüfungs-Plugin"
 
 #. Default: "Standard view"
 #: plone.app.collection/plone/app/collection/browser/configure.zcml:58
@@ -5172,7 +5171,7 @@ msgstr "Startdatum"
 
 #: plone.app.widgets/plone/app/widgets/utils.py:173
 msgid "Start Page"
-msgstr ""
+msgstr "Start-Seite"
 
 #. Default: "Start password reset"
 #: CMFPlone/browser/templates/mail_password_form.pt:62
@@ -5199,7 +5198,7 @@ msgstr "Keine weiteren Regeln ausführen"
 
 #: CMFPlone/interfaces/resources.py:111
 msgid "Stub JavaScript modules"
-msgstr ""
+msgstr "Stub JavaScript Module"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/mail.py:36
 #: plone.stringinterp/plone/stringinterp/adapters.py:282
@@ -5278,7 +5277,7 @@ msgstr "Erfolgreich aktualisierte Metadaten"
 
 #: plone.app.content/plone/app/content/browser/contents/tags.py:39
 msgid "Successfully updated tags on items"
-msgstr "Erfolgreich aktualisierte Tags an Objekten"
+msgstr "Erfolgreich Stichworte auf den Inhalten aktualisiert"
 
 #. Default: "Summary view"
 #: plone.app.collection/plone/app/collection/browser/configure.zcml:62
@@ -5289,44 +5288,41 @@ msgstr "Kurzfassung"
 #: plone.app.portlets/plone/app/portlets/portlets/navigation.py:109
 #: plone.portlet.collection/plone/portlet/collection/collection.py:103
 msgid "Suppress Icons"
-msgstr ""
+msgstr "Unterdrücke Icons"
 
 #: plone.app.portlets/plone/app/portlets/portlets/recent.py:33
 #: plone.app.portlets/plone/app/portlets/portlets/review.py:24
 msgid "Suppress Icons "
-msgstr ""
+msgstr "Unterdrücke Icons"
 
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/thumb_icon.py:61
 msgid "Suppress icons in list, table or summary view"
-msgstr ""
+msgstr "Unterdrücke Icons in den Ansichten Listen, Tabellen und Zusammenfassung"
 
 #: plone.app.portlets/plone/app/portlets/portlets/navigation.py:127
 #: plone.app.portlets/plone/app/portlets/portlets/news.py:53
 #: plone.app.portlets/plone/app/portlets/portlets/recent.py:51
 msgid "Suppress thumbs"
-msgstr ""
+msgstr "Unterdrücke Mini-Bilder"
 
 #: CMFPlone/interfaces/controlpanel.py:1226
 msgid "Suppress thumbs in all list views; this default can be overriden individually"
-msgstr ""
+msgstr "Unterdrücke Mini-Bilder in allen Listen-Ansichten; diese Vorgabe kann individuell überschrieben werden."
 
 #: CMFPlone/interfaces/controlpanel.py:1217
 msgid "Suppress thumbs in all portlets; this default can be overridden individually in selected portlets"
-msgstr ""
+msgstr "Unterdrücke Mini-Bilder in allen Portlets; diese Vorgabe kann individuell überschrieben werden."
 
 #: CMFPlone/interfaces/controlpanel.py:1233
 msgid "Suppress thumbs in all summary views; this default can be overriden individually"
-msgstr ""
+msgstr "Unterdrücke Mini-Bilder in allen Zusammenfassungs-Ansichten; diese Vorgabe kann individuell überschrieben werden."
 
 #: CMFPlone/interfaces/controlpanel.py:1239
 msgid "Suppress thumbs in all tableviews and in folder contents view; this default can be overriden individually"
-msgstr ""
-
-#: plone.app.contenttypes/plone/app/contenttypes/behaviors/thumb_icon.py:68
-msgid "Suppress thumbs in list, table or summary view"
-msgstr ""
+msgstr "Unterdrücke Mini-Bilder in allen Tabellen-Ansichten; diese Vorgabe kann individuell überschrieben werden."
 
 #. Default: "Syndication"
+#: plone.app.contenttypes/plone/app/contenttypes/behaviors/thumb_icon.py:68
 #: CMFPlone/profiles/default/actions.xml
 #: CMFPlone/profiles/default/controlpanel.xml
 msgid "Syndication"
@@ -5443,11 +5439,11 @@ msgstr "Dieser Benutzer hat keine E-Mail-Adresse."
 
 #: plone.app.contentmenu/plone/app/contentmenu/configure.zcml:19
 msgid "The 'actions' menu - allows the user to execute actions on an object"
-msgstr "Das  Menü ‘Aktionen’ - erlaubt den Benutzer Aktionen an einem Objekt aufzuführen"
+msgstr "Das  Menü ‘Aktionen’ - erlaubt den Benutzer Aktionen an einem Inhalt aufzuführen"
 
 #: plone.app.contentmenu/plone/app/contentmenu/configure.zcml:31
 msgid "The 'add' menu - allows the user to add new content items in the context"
-msgstr "Das  Menü ‘Hinzufügen’ - erlaubt dem Benutzer neue Inhaltsobjekte im Kontext hinzuzufügen"
+msgstr "Das  Menü ‘Hinzufügen’ - erlaubt dem Benutzer neue Inhalte im Kontext hinzuzufügen"
 
 #: plone.schemaeditor/plone/schemaeditor/interfaces.py:207
 msgid "The 'description' field must be a Text field."
@@ -5455,11 +5451,11 @@ msgstr "Das Feld ’Beschreibung’ muss den Typ ‘Textfeld’ haben."
 
 #: plone.app.contentmenu/plone/app/contentmenu/configure.zcml:25
 msgid "The 'display' menu - allows the user to select the view of an object"
-msgstr "Das Menü ’Anzeigen’ - erlaubt dem Benutzer die Ansicht eines Objekts auszuwählen"
+msgstr "Das Menü ’Anzeigen’ - erlaubt dem Benutzer die Ansicht eines Inhalts auszuwählen"
 
 #: plone.app.contentmenu/plone/app/contentmenu/configure.zcml:43
 msgid "The 'portlet' menu - allows the user to manage portlets"
-msgstr ""
+msgstr "Das 'portlet' menu erlaubt dem Benutzer portlets zu verwalten"
 
 #: plone.schemaeditor/plone/schemaeditor/interfaces.py:202
 msgid "The 'title' field must be a Text line (string) field."
@@ -5471,7 +5467,7 @@ msgstr "Das Menü ‘Arbeitsablauf’ - erlaubt dem Benutzer Arbeitsablaufüberg
 
 #: CMFPlone/browser/templates/plone-addsite.pt:48
 msgid "The ID of the site. This ends up as part of the URL.<br /> No special characters or spaces are allowed."
-msgstr ""
+msgstr "Die ID der Seite. Diese wird Teil der URL.<br />Keine Spezial-Zeichen oder Leerzeichen erlaubt."
 
 #. Default: "The ID of the user who performed the last transition"
 #: CMFPlone/profiles/default/workflows/folder_workflow/definition.xml
@@ -5492,7 +5488,7 @@ msgstr "Der TALES-Ausdruck, der ausgewertet werden soll."
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/portaltype.py:30
 msgid "The content type to check for."
-msgstr "Artikeltypen, auf die geprüft werden soll."
+msgstr "Inhaltstypen, auf die geprüft werden soll."
 
 #: CMFPlone/interfaces/controlpanel.py:1406
 msgid "The content types that should be available for selection when setting a default page."
@@ -5500,7 +5496,7 @@ msgstr "Inhaltstypen, die bei der Einstellung der Standardseite verfügbar sein 
 
 #: CMFPlone/interfaces/controlpanel.py:952
 msgid "The content types that should be shown in the navigation and site map."
-msgstr "Artikeltypen, die in der Navigation und der Übersicht angezeigt werden soll."
+msgstr "Inhaltstypen, die in der Navigation und der Übersicht angezeigt werden soll."
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 msgid "The current day"
@@ -5512,7 +5508,7 @@ msgstr "Das Datum, an dem ein Artikel erzeugt wurde"
 
 #: CMFPlone/browser/templates/plone-addsite.pt:98
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
-msgstr ""
+msgstr "Die Vorgabe-Zeitzone des Portals. Benutzer werden in der Lage sein ihre Zeitzone zu setzen, sobald die verfügbaren Zeitzonen in den 'Datum und Zeit' Einstellungen gesetzt sind."
 
 #: CMFPlone/RegistrationTool.py:357
 msgid "The email address did not validate."
@@ -5533,7 +5529,7 @@ msgstr "Terminende und -zeit"
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:56
 msgid "The estimated time for the migration is around: <strong> ${hours} hours ${minutes} minutes ${seconds} seconds </strong>"
-msgstr ""
+msgstr "Geschätzte Zeit für die Migration ist etwas:  <strong> ${hours} Stunden ${minutes} Minuten ${seconds} Sekunden </strong>"
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/fileextension.py:30
 msgid "The file extension to check for"
@@ -5553,7 +5549,7 @@ msgstr "Der eingegebende Gruppenname ist nicht gültig."
 
 #: plone.app.content/plone/app/content/browser/actions.py:298
 msgid "The item you are trying to paste could not be found. It may have been moved or deleted after you copied or cut it."
-msgstr "Das Objekt, das Sie einfügen wollen, wurde nicht gefunden. Es wurde eventuell verschoben oder gelöscht nachdem Sie es kopiert oder ausgeschnitten haben."
+msgstr "Der Inhalt, den Sie einfügen wollen, wurde nicht gefunden. Er wurde eventuell verschoben oder gelöscht nachdem Sie ihn kopiert oder ausgeschnitten haben."
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 msgid "The item's title, transformed for sorting"
@@ -5604,7 +5600,7 @@ msgstr "Die Person die den Artikel erstellt hat"
 
 #: plone.formwidget.recurrence/plone/formwidget/recurrence/z3cform/interfaces.py:21
 msgid "The recurrence rule couldn't be parsed."
-msgstr ""
+msgstr "Die Wiederholungs-Regel kann nicht geparst werden."
 
 #: CMFPlone/interfaces/resources.py:79
 msgid "The resources that are going to be loaded on this bundle in order"
@@ -5616,7 +5612,7 @@ msgstr "Die Funktionen, auf die geprüft werden soll."
 
 #: CMFPlone/profiles/default/types/Plone_Site.xml
 msgid "The root object in a Plone site."
-msgstr "Das Wurzelobjekt einer PlDas Wurzelobjekt einer PLone-Website.one-Website."
+msgstr "Die Wurzel in der Plone-Website."
 
 #: plone.app.contentrules/plone/app/contentrules/browser/elements.py:76
 msgid "The rule has been enabled on site root and all its subfolders"
@@ -5624,7 +5620,7 @@ msgstr "Die Regel wurde auf der Hauptseite und allen Unterordnern aktiviert"
 
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/manage-elements.pt:205
 msgid "The rule is enabled but will perform nothing since it is not assigned anywhere."
-msgstr ""
+msgstr "Die Regel ist eingeschaltet, wird aber nie ausgeführt da sie nirgends zugewiesen ist."
 
 #: plone.app.discussion/plone/app/discussion/interfaces.py:56
 msgid "The set of unique commentators (usernames)"
@@ -5632,7 +5628,7 @@ msgstr "Liste von Benutzern, die Kommentare abgegeben haben"
 
 #: plone.app.discussion/plone/app/discussion/interfaces.py:61
 msgid "The set of unique commentators (usernames) of published_comments"
-msgstr ""
+msgstr "Die Menge an einheitlichen Kommentatoren (Benutzernamen) der veröffentlichten Kommentare."
 
 #. Default: "The short name of an item (used in the url)"
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
@@ -5692,7 +5688,7 @@ msgstr "Der gesuchte Benutzername konnte nicht gefunden werden."
 
 #: CMFPlone/interfaces/controlpanel.py:972
 msgid "The workflow states that should be shown in the navigation and the site map."
-msgstr ""
+msgstr "Die Arbeitsablauf Status, die in der Navigation und der Site-Map angezeigt werden sollen."
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/wfstate.py:25
 msgid "The workflow states to check for."
@@ -5740,11 +5736,11 @@ msgstr "Es existiert bereits ein Artikel mit dem Namen ${name} in diesem Ordner.
 #: plone.app.content/plone/app/content/browser/contents/defaultpage.py:16
 #: plone.app.content/plone/app/content/browser/selection.py:82
 msgid "There is no object with short name ${name} in this folder."
-msgstr "Es gibt kein Objekt mit dem Kurznamen ${name} in diesem Ordner."
+msgstr "Es gibt keinen Inhalt mit dem Kurznamen ${name} in diesem Ordner."
 
 #: CMFPlone/controlpanel/browser/quickinstaller.pt:95
 msgid "There is no upgrade procedure defined for this addon. Please consult the addon documentation for upgrade information, or contact the addon author."
-msgstr ""
+msgstr "Es ist keine Aktualisierungsprozedur für diese Erweiterung definiert. Bitte lesen die Dokumentation der Erweiterung für Aktualisierungsinformationen oder kontaktieren sie dessen Autor."
 
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/manage-elements.pt:122
 msgid "There is not any action performed by this rule. Click on Add button to setup an action."
@@ -5770,11 +5766,11 @@ msgstr "Es gab Fehler"
 
 #: CMFPlone/interfaces/controlpanel.py:460
 msgid "These attributes are additionally allowed."
-msgstr ""
+msgstr "Diese Attribute sind zusätzlich erlaubt."
 
 #: CMFPlone/interfaces/controlpanel.py:357
 msgid "These tags and their content are completely blocked when a page is saved or rendered. They are only deleted if they are not marked as valid_tags"
-msgstr ""
+msgstr "Diese Tags und ihr Inhalt werden vollständig blockiert, wenn eine Seite gespeichert oder gerendert wird. Sie werden nur gelöscht, wenn sie nicht als 'valid_tags' markiert wurden"
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:108
 msgid "These types are installed and have the image-behavior: ${types}"
@@ -5799,7 +5795,7 @@ msgstr ""
 
 #: CMFPlone/interfaces/controlpanel.py:1247
 msgid "This default can be overriden individually."
-msgstr ""
+msgstr "Dieser Vorgabewert kann individuell überschrieben werden."
 
 #: CMFPlone/browser/password_reset.py:131
 #: CMFPlone/skins/plone_form_scripts/validate_content_status_modify.vpy:15
@@ -5816,7 +5812,7 @@ msgstr "Dies ist das Konfigurations-Menü für Erweiterungen. Sie können die Er
 
 #: CMFPlone/interfaces/controlpanel.py:1288
 msgid "This must be a URL relative to the site root. By default it is /++plone++static/plone-toolbarlogo.svg"
-msgstr ""
+msgstr "Dies muss eine URL relativ zur Seitenwurzel sein. Die Vorgabe ist /++plone++static/plone-toolbarlogo.svg"
 
 #: plone.app.dexterity/plone/app/dexterity/behaviors/id.py:28
 msgid "This name will be displayed in the URL."
@@ -5824,11 +5820,11 @@ msgstr "Dieser Name wird in der Adressleiste des Browsers angezeigt."
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/browser.py:304
 msgid "This operation can take a very long time."
-msgstr ""
+msgstr "Diese Arbeit kann eine lange Zeit in Anspruch nehmen."
 
 #: CMFPlone/interfaces/controlpanel.py:738
 msgid "This option allows you to choose the spellchecker for TinyMCE."
-msgstr ""
+msgstr "Diese Einstellung erlaubt die Auswahl der Rechtschreibprüfung für TinyMCE."
 
 #: CMFPlone/interfaces/controlpanel.py:837
 msgid "This option controls how entities/characters get processed. Named: Characters will be converted into named entities based on the entities option. Numeric: Characters will be converted into numeric entities. Raw: All characters will be stored in non-entity form except these XML default entities: amp lt gt quot"
@@ -5892,15 +5888,15 @@ msgstr "Dieses Portlet zeigt ein Suchfeld an."
 
 #: CMFPlone/controlpanel/browser/quickinstaller.pt:158
 msgid "This product cannot be uninstalled!"
-msgstr ""
+msgstr "Diese Erweiterung kann nicht deinstalliert werden!"
 
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/manage-elements.pt:202
 msgid "This rule is not assigned to any location"
-msgstr ""
+msgstr "Diese Regel wird nirgendwo verwendet"
 
 #: CMFPlone/interfaces/controlpanel.py:1151
 msgid "This shows a custom logo on your site."
-msgstr ""
+msgstr "Hiermit wird ein angepasstes Logo in Ihrer Seite angezeigt."
 
 #: CMFPlone/interfaces/controlpanel.py:1144
 msgid "This shows up in the title bar of browsers and in syndication feeds."
@@ -5924,19 +5920,19 @@ msgstr ""
 
 #: CMFPlone/interfaces/controlpanel.py:1253
 msgid "Thumb scale for listings"
-msgstr ""
+msgstr "Mini-Bild Skalierung für Listings"
 
 #: CMFPlone/interfaces/controlpanel.py:1246
 msgid "Thumb scale for portlets"
-msgstr ""
+msgstr "Mini-Bild Skalierung für Portlets"
 
 #: CMFPlone/interfaces/controlpanel.py:1269
 msgid "Thumb scale for summary view"
-msgstr ""
+msgstr "Mini-Bild Skalierung für Zusammenfasung"
 
 #: CMFPlone/interfaces/controlpanel.py:1261
 msgid "Thumb scale for tables"
-msgstr ""
+msgstr "Mini-Bild Skalierung für Tabelle"
 
 #: CMFPlone/interfaces/controlpanel.py:1205
 msgid "Thumb visibility"
@@ -5949,7 +5945,7 @@ msgstr "Album"
 
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/configure.zcml:63
 msgid "Thumbs and icon handling"
-msgstr ""
+msgstr "Mini-Bild und Icon Handhabung"
 
 #: plone.portlet.static/plone/portlet/static/static.py:76
 msgid "Tick this box if you want to render the text above without the standard header, border or footer."
@@ -5995,11 +5991,11 @@ msgstr "Titel des Portlets"
 
 #: CMFPlone/interfaces/controlpanel.py:1588
 msgid "To be used with some integrations like Open Graph data"
-msgstr ""
+msgstr "Zur Verwendung mit Integrationen wie etwa OpenGraph Daten"
 
 #: CMFPlone/interfaces/controlpanel.py:1577
 msgid "To identify things like Twitter Cards. Do not include the \"@\" prefix character."
-msgstr ""
+msgstr "Um Dinge wie Twitter-Cards zu identifizieren. Das \"@\"-Prefix darf nicht verwendet werden."
 
 #: CMFPlone/controlpanel/browser/quickinstaller.pt:34
 msgid "To make new add-ons show up here, add them to your buildout configuration, run buildout, and restart the server process. For detailed instructions see ${third_party_product}."
@@ -6012,15 +6008,15 @@ msgstr "Heute"
 
 #: CMFPlone/interfaces/controlpanel.py:1276
 msgid "Toolbar position"
-msgstr ""
+msgstr "Toolbar Position"
 
 #: CMFPlone/interfaces/controlpanel.py:1283
 msgid "Top"
-msgstr ""
+msgstr "Oben"
 
 #: plone.app.content/plone/app/content/browser/contents/__init__.py:217
 msgid "Total comments"
-msgstr "Gesamtzahl Kommentare"
+msgstr "Kommentare gesamt"
 
 #: plone.app.discussion/plone/app/discussion/profiles/default/portal_atct.xml
 msgid "Total number of comments"
@@ -6028,7 +6024,7 @@ msgstr "Gesamtzahl Kommentare"
 
 #: plone.app.discussion/plone/app/discussion/profiles/default/portal_atct.xml
 msgid "Total number of comments on this item."
-msgstr "Gesamtzahl Kommentare an diesem Objekt"
+msgstr "Gesamtzahl Kommentare an diesem Inhalt"
 
 #: plone.app.discussion/plone/app/discussion/interfaces.py:45
 msgid "Total number of public comments on this item"
@@ -6056,12 +6052,12 @@ msgstr "Auslösendes Ereignis"
 
 #: CMFPlone/interfaces/controlpanel.py:1576
 msgid "Twitter username"
-msgstr ""
+msgstr "Twitter Benutzername"
 
 #: plone.app.content/plone/app/content/browser/contents/__init__.py:216
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 msgid "Type"
-msgstr "Artikeltyp"
+msgstr "Inhaltstyp"
 
 #: plone.app.dexterity/plone/app/dexterity/interfaces.py:48
 msgid "Type Name"
@@ -6077,7 +6073,7 @@ msgstr "Inhaltstyp erfolgreich dupliziert."
 
 #: plone.app.dexterity/plone/app/dexterity/browser/import_types.py:33
 msgid "Type profiles archive file"
-msgstr ""
+msgstr "Archiv-Datei des Inhaltstypen-Profils"
 
 #: CMFPlone/controlpanel/browser/types.py:53
 msgid "Types Settings"
@@ -6085,7 +6081,7 @@ msgstr "Typen Voreinstellungen"
 
 #: plone.app.dexterity/plone/app/dexterity/browser/import_types.py:74
 msgid "Types in archive must be only Dexterity types."
-msgstr ""
+msgstr "Inhaltsypen im Profil dürfen nur Dexterity Typen sein."
 
 #: CMFPlone/controlpanel/browser/types.py:55
 msgid "Types settings"
@@ -6097,7 +6093,7 @@ msgstr "Inhaltstypen, die als Standardseite verwendet werden können"
 
 #: CMFPlone/interfaces/controlpanel.py:1380
 msgid "Types which use the view action in listing views."
-msgstr ""
+msgstr "Inhaltypen, welche die Ansichts-Aktion in Listen-Ansichten nutzen."
 
 #: CMFPlone/interfaces/resources.py:25
 #: plone.app.contenttypes/plone/app/contenttypes/schema/link.xml
@@ -6210,7 +6206,7 @@ msgstr "Aktualisierung der existierenden Inhalte nach Dexterity"
 
 #: CMFPlone/controlpanel/browser/quickinstaller.py:674
 msgid "Upgraded products."
-msgstr ""
+msgstr "Aktualisierte Erweiterungen"
 
 #: CMFPlone/controlpanel/browser/quickinstaller.pt:44
 msgid "Upgrades"
@@ -6222,15 +6218,15 @@ msgstr "Lade Zip Datei hoch"
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 msgid "Use '../' to navigate to parent objects."
-msgstr "Benutze '../' um zum Eltenobjekt zu navigieren."
+msgstr "Benutze '../' um zum Elterninhalt zu navigieren."
 
 #: CMFPlone/interfaces/controlpanel.py:1130
 msgid "Use UUID user ids"
-msgstr ""
+msgstr "Benutze UUID als Benutzer-Id"
 
 #: CMFPlone/interfaces/controlpanel.py:1131
 msgid "Use automatically generated UUIDs as user id for new users. When not turned on, the default is to use the same as the login name, or when using the email address as login name we generate a user id based on the fullname."
-msgstr ""
+msgstr "Neue Benutzer bekommen eine automatisch generierte UUID als Benutzer-Id. Wenn dies nicht eingeschaltet ist, dann wird der Login-Name genommen bzw. wenn die E-Mailadresse als Login-Name verwendet wird, dann wir aus dem Vor- und Nachname die Benutzer-Id generiert."
 
 #: CMFPlone/interfaces/controlpanel.py:1116
 msgid "Use email address as login name"
@@ -6242,7 +6238,7 @@ msgstr ""
 
 #: plone.schemaeditor/plone/schemaeditor/interfaces.py:220
 msgid "Used for programmatic access to the fieldset."
-msgstr ""
+msgstr "Benutzernamen Überprüfung"
 
 #: plone.app.dexterity/plone/app/dexterity/interfaces.py:53
 msgid "Used for programmatic access to the type."
@@ -6302,7 +6298,7 @@ msgstr "Benutzer- und Gruppeneinstellungen"
 
 #: CMFPlone/browser/templates/explainPWResetTool.pt:35
 msgid "Username check"
-msgstr ""
+msgstr "Benutzernamen Überprüfung"
 
 #: plone.app.discussion/plone/app/discussion/interfaces.py:188
 msgid "Username of the commenter"
@@ -6321,11 +6317,11 @@ msgstr "Benutzer und Gruppen"
 
 #: plone.app.discussion/plone/app/discussion/profiles/default/portal_atct.xml
 msgid "Users who have commented on the item"
-msgstr "Benutzer, die dieses Objekt kommentiert haben"
+msgstr "Benutzer, die diesen Inhalt kommentiert haben"
 
 #: CMFPlone/interfaces/controlpanel.py:366
 msgid "Valid tags"
-msgstr ""
+msgstr "Gültige Tags"
 
 #: validation/validators/RegexValidator.py:47
 msgid "Validation failed($name): $value of type $type, expected 'string'"
@@ -6478,7 +6474,7 @@ msgstr "Warnung"
 
 #: CMFPlone/interfaces/controlpanel.py:350
 msgid "Warning: disabling this can be dangerous. Only disable if you know what you are doing."
-msgstr ""
+msgstr "Warnung: Dies hier abschalten kann gefährlich sein. Nur abschalten, wenn Sie genau wissen was sie tun."
 
 #: CMFPlone/skins/plone_login/login_next.cpy:60
 msgid "Welcome! You are now logged in."
@@ -6486,7 +6482,7 @@ msgstr "Willkommen! Sie sind jetzt angemeldet."
 
 #: plone.app.layout/plone/app/layout/viewlets/content_history.pt:11
 msgid "What"
-msgstr ""
+msgstr "Was"
 
 #. Default: "When the previous transition was performed"
 #: CMFPlone/profiles/default/workflows/folder_workflow/definition.xml
@@ -6573,7 +6569,7 @@ msgstr "Ja"
 
 #: plone.app.registry/plone/app/registry/browser/templates/delete_layout.pt:27
 msgid "Yes, delete"
-msgstr ""
+msgstr "Ja, löschen"
 
 #: plone.app.content/plone/app/content/browser/contents/delete.py:85
 msgid "You are not authorized to delete ${title}."
@@ -6617,7 +6613,7 @@ msgstr ""
 
 #: plone.app.content/plone/app/content/browser/constraintypes.py:105
 msgid "You cannot have a type as a secondary type without having it allowed. You have selected ${types}."
-msgstr ""
+msgstr "Ein sekundärer Inhaltstyp kann nicht gesetzt werden, wenn er nicht auch erlaubt ist. Sie haben ausgewählt: ${types}"
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:51
 msgid "You currently have ${number_of_objects} archetypes objects to be migrated."
@@ -6633,7 +6629,7 @@ msgstr "Sie haben mehrere Plone-Websites:"
 
 #: plone.app.dexterity/plone/app/dexterity/browser/import_types.py:100
 msgid "You may import types by uploading a zip archive containing type profiles. The import archive should contain a types.xml file and a types directory containing one or more Dexterity type information files. For a sample, create a content type and export it from the Dexterity Content Types page."
-msgstr ""
+msgstr "Sie können Inhaltsyp-Definitionen importieren indem sie ein ZIP-Archiv mit dem Profil bereitstellen. Das Importarchiv muss eine 'types.xml' Datei und ein 'types' Verzeichnis mit einem oder mehreren Inhaltstyp-Definitionen enthalten. Um ein Beispiel zu erhalten, erstellen sie einen Inhaltstyp auf der Dexterity-Inhaltstypen Seite und exportieren sie diesen."
 
 #: CMFPlone/skins/plone_login/login_form_validate.vpy:22
 #: CMFPlone/skins/plone_login/login_password_validate.vpy:17
@@ -6734,12 +6730,12 @@ msgstr "Absoluter URL Prefix"
 #. Default: "A boolean expression"
 #: CMFPlone/interfaces/controlpanel.py:1751
 msgid "action_condition_description"
-msgstr ""
+msgstr "Ein Boolescher Ausdruck"
 
 #. Default: "Condition"
 #: CMFPlone/interfaces/controlpanel.py:1750
 msgid "action_condition_heading"
-msgstr ""
+msgstr "Bedingung"
 
 #. Default: "There are legacy portlets defined here. Click the button to convert them to new-style portlets."
 #: plone.app.portlets/plone/app/portlets/browser/templates/manage-contextual.pt:68
@@ -6749,27 +6745,27 @@ msgstr "Hier werden veraltete Portlets definiert. Klicken Sie auf die Schaltflä
 #. Default: "Permissions"
 #: CMFPlone/interfaces/controlpanel.py:1758
 msgid "action_permissions_heading"
-msgstr ""
+msgstr "Berechtigung"
 
 #. Default: "Position"
 #: CMFPlone/interfaces/controlpanel.py:1773
 msgid "action_position_heading"
-msgstr ""
+msgstr "Position"
 
 #. Default: "An expression producing the called URL. Example: string:${globals_view/navigationRootUrl}/page"
 #: CMFPlone/interfaces/controlpanel.py:1742
 msgid "action_url_description"
-msgstr ""
+msgstr "Ein Ausdruck der die aufzurufenden URL erzeugt. Beispiel: string:${globals_view/navigationRootUrl}/page"
 
 #. Default: "Action URL"
 #: CMFPlone/interfaces/controlpanel.py:1741
 msgid "action_url_heading"
-msgstr ""
+msgstr "Aktions-URL"
 
 #. Default: "Visible?"
 #: CMFPlone/interfaces/controlpanel.py:1768
 msgid "action_visibility_heading"
-msgstr ""
+msgstr "Sichtbar?"
 
 #: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:13
 msgid "add"
@@ -6787,12 +6783,12 @@ msgstr "Termin hinzufügen"
 #. Default: "Add new fieldset…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:13
 msgid "add_fieldset_hellip"
-msgstr "Hinzufügen neuer Fieldset..."
+msgstr "Fieldset hinzufügen..."
 
 #. Default: "Add new field…"
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:7
 msgid "add_new_field_hellip"
-msgstr "Hinzufügen eines neuen Felds ..."
+msgstr "Feld hinzufügen..."
 
 #: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:10
 msgid "add_rules"
@@ -7036,7 +7032,7 @@ msgstr "${author_name} zu ${content}"
 #. Default: "Are you certain you want to delete the selected items?"
 #: plone.app.content/plone/app/content/browser/contents/templates/delete.pt:5
 msgid "confirm_delete_items"
-msgstr "Möchten Sie die ausgewählten Objekte wirklich löschen?"
+msgstr "Möchten Sie die ausgewählten Inhalte wirklich löschen?"
 
 #: validation/validators/BaseValidators.py:23
 msgid "contains unprintable characters"
@@ -7127,7 +7123,7 @@ msgstr "Urheberrecht"
 #. Default: "Creators"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:18
 msgid "creators"
-msgstr ""
+msgstr "Ersteller"
 
 #. Default: "Current theme"
 #: plone/app/theming/interfaces.py:92
@@ -7184,22 +7180,22 @@ msgstr "Löschen"
 #. Default: "Following content within <strong>${content}</strong> will also be deleted:"
 #: plone.app.linkintegrity/plone/app/linkintegrity/browser/delete_confirmation_info.pt:64
 msgid "deleting_contents"
-msgstr ""
+msgstr "Folgende Inhalte unterhalb <strong>${content}</strong> werden ebenfalls gelöscht:"
 
 #. Default: "Deleting overview"
 #: plone.app.linkintegrity/plone/app/linkintegrity/browser/delete_confirmation_info.pt:54
 msgid "deleting_overview"
-msgstr ""
+msgstr "Zu löschende Inhalte"
 
 #. Default: "Missing dependency"
 #: CMFPlone/controlpanel/browser/quickinstaller.py:256
 msgid "dependency_missing"
-msgstr ""
+msgstr "Fehlende Abhängigkeit"
 
 #. Default: "The default is <em>7 days</em>. If you leave the field blank, the timeout interval will reset to the default."
 #: CMFPlone/browser/templates/explainPWResetTool.pt:16
 msgid "desc2_set_exp_interval"
-msgstr ""
+msgstr "Die Vorgabe ist <em>7 Tage</em>. Wenn das Feld leer gelassen wird, so wird das Ablaufintervall auf die Vorgabe zurückgesetzt."
 
 #. Default: "If the default page is also a folder, add items to it from here."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:636
@@ -7259,7 +7255,7 @@ msgstr "Die unten angegeben Einstellungsmöglichkeiten kontrollieren die Präsen
 #. Default: "Related to: use cookie for manual override"
 #: CMFPlone/interfaces/controlpanel.py:278
 msgid "description_auth_ookie_manual_override"
-msgstr ""
+msgstr "Bezieht sich auf: Benutze Cookie für manuelles Überschreiben"
 
 #. Default: "If you want to contact this author, fill in the form below."
 #: CMFPlone/browser/templates/author.pt:170
@@ -7279,7 +7275,7 @@ msgstr "Verwende die Knöpfe um neue Diazo Designs zu erzeugen, hochzuladen oder
 #. Default: "Use browser language request negotiation."
 #: CMFPlone/interfaces/controlpanel.py:322
 msgid "description_browser_language_request_negotiation"
-msgstr ""
+msgstr "Benuzte Browser-Request-Header zur Sprachaushandlung"
 
 #. Default: "Canceling the check-out will delete this working copy, and any modifications made to it will be lost. The existing version of the content will become unlocked."
 #: plone.app.iterate/plone/app/iterate/browser/cancel.pt:22
@@ -7309,7 +7305,7 @@ msgstr "Füllen Sie dieses Formular aus, um den Verantwortlichen für die Websit
 #. Default: "Thank you for your feedback"
 #: CMFPlone/browser/templates/contact-info.pt:46
 msgid "description_contact_site_owner_success"
-msgstr ""
+msgstr "Danke für Ihre Nachricht"
 
 #. Default: "Please set a descriptive title for the rule."
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/manage-elements.pt:252
@@ -7346,7 +7342,7 @@ msgstr "Konfiguration von Plone und Erweiterungen."
 #. Default: "Required for the language selector viewlet to be rendered."
 #: CMFPlone/interfaces/controlpanel.py:265
 msgid "description_cookie_manual_override"
-msgstr ""
+msgstr "Benötigt um das Sprachauswahl-Viewlet zu rendern."
 
 #. Default: "The ${plonecms} is ${copyright} 2000-${current_year} by the ${plonefoundation} and friends."
 #: CMFPlone/browser/templates/footer.pt:23
@@ -7361,7 +7357,7 @@ msgstr "Ihre Website läuft im \"Entwicklungsmodus\". Dieser Modus ist für Entw
 #. Default: "This information, also referred to as <em>metadata</em> is the collection of information that is used to categorize an object, assign effective dates and expiration dates, language, and keywords."
 #: Archetypes/skins/archetypes/metadata_macros.pt:32
 msgid "description_edit_properties"
-msgstr "Diese Informationen, auch <em>Metadaten</em> genannt, sind eine Sammlung von Daten, die dazu benutzt werden, ein Objekt zu kategorisieren, ihm ein Freigabedatum oder ein Ablaufdatum zuzuteilen, seine Sprache oder Stichwörter festzulegen.<br />Ändern Sie die Metadateneinträge mit Hilfe des unten stehenden Formulars. Beachten Sie, dass Metadaten sehr leistungsfähig sind und Sie mit Ihnen sehr viele nützliche Kategorisierungen vornehmen können. Benutzen Sie beim Eintrag prägnante Formulierungen und lassen Sie die Felder, zu denen Ihnen nichts einfällt, leer."
+msgstr "Diese Informationen, auch <em>Metadaten</em> genannt, sind eine Sammlung von Daten, die dazu benutzt werden, einen Inhalt zu kategorisieren, ihm ein Freigabedatum oder ein Ablaufdatum zuzuteilen, seine Sprache oder Stichwörter festzulegen.<br />Ändern Sie die Metadateneinträge mit Hilfe des unten stehenden Formulars. Beachten Sie, dass Metadaten sehr leistungsfähig sind und Sie mit Ihnen sehr viele nützliche Kategorisierungen vornehmen können. Benutzen Sie beim Eintrag prägnante Formulierungen und lassen Sie die Felder, zu denen Ihnen nichts einfällt, leer."
 
 #. Default: "Note: If you do not remain logged in after leaving this page, it is because you need to enable cookies in your browser."
 #: CMFPlone/skins/plone_login/external_login_return.cpt:51
@@ -7422,7 +7418,7 @@ msgstr "Sprachcode aus der URL extrahieren"
 #. Default: "Use the language of the content item."
 #: CMFPlone/interfaces/controlpanel.py:245
 msgid "description_language_of_the_content"
-msgstr "Sprache des Inhaltsobjekts verwenden"
+msgstr "Sprache des Inhalts verwenden"
 
 #. Default: "Settings related to interface languages and content translations."
 #: CMFPlone/controlpanel/browser/language.py:14
@@ -7437,7 +7433,7 @@ msgstr "Lizensiert unter der ${license}."
 #. Default: "The link is used almost verbatim, relative links become absolute and the strings \"${navigation_root_url}\" and \"${portal_url}\" get replaced with the real navigation_root_url or portal_url. If in doubt which one to use, please use navigation_root_url."
 #: plone.app.contenttypes/plone/app/contenttypes/schema/link.xml
 msgid "description_linktype_url"
-msgstr ""
+msgstr "Der Link wird nahezu unverändert verwendet. Relative Links werden zu absoluten und die Zeichenfolgen \"${navigation_root_url}\" and \"${portal_url}\" werden mit den echten dazu passenden URLs ersetzt. Im Zweifel bitte die 'navigation_root_url' verwenden."
 
 #. Default: "This is the first time that you've logged in to ${here}."
 #: CMFPlone/skins/plone_login/login_password.cpt:28
@@ -7475,7 +7471,7 @@ msgstr "Wenn Ihnen dies nicht hilft, weil Sie zum Beispiel Ihre E-Mail-Adresse g
 #. Default: "The left and right portlet slots will now display only those portlets assigned to this content type. Use the up, down, delete and edit links to manage user portlets. Use the drop-down list to add new portlets."
 #: plone.app.portlets/plone/app/portlets/browser/templates/manage-content-type.pt:28
 msgid "description_manage_contenttype_portlets"
-msgstr "Die linke und rechte Portletspalte wird nur diejenigen Portlets anzeigen, die diesem Artikeltyp zugeordnet wurden. Benutzen Sie die Links Hoch, Runter, Entfernen und Bearbeiten, um die Benutzerportlets zu verwalten. Über die Auswahlliste können Sie neue Portlets hinzufügen."
+msgstr "Die linke und rechte Portletspalte wird nur diejenigen Portlets anzeigen, die diesem Inhaltstyp zugeordnet wurden. Benutzen Sie die Links Hoch, Runter, Entfernen und Bearbeiten, um die Benutzerportlets zu verwalten. Über die Auswahlliste können Sie neue Portlets hinzufügen."
 
 #. Default: "The portlet columns will first display portlets explicitly assigned in this context. Use the buttons on each portlet to move them up or down, delete or edit them. To add a new portlet, use the drop-down list at the top of the column."
 #: plone.app.portlets/plone/app/portlets/browser/templates/manage-contextual.pt:51
@@ -7594,7 +7590,7 @@ msgstr "Verwenden Sie die Auswahlmenüs, um bestimmte Arten von Portlets aus- od
 #. Default: "Personal settings for $name"
 #: plone.app.users/plone/app/users/browser/personalpreferences.py:79
 msgid "description_preferences_form_otheruser"
-msgstr ""
+msgstr "Persönliche Einstellungen von $name"
 
 #. Default: "You are running in \"production mode\". This is the preferred mode of operation for a live Plone site, but means that some configuration changes will not take effect until your server is restarted or a product refreshed. If this is a development instance, and you want to enable debug mode, stop the server, set 'debug-mode=on' in your buildout.cfg, re-run bin/buildout and then restart the server process."
 #: CMFPlone/controlpanel/browser/overview.pt:139
@@ -7625,7 +7621,7 @@ msgstr "Alle veröffentlichten Artikel, in zeitlich absteigender Reihenfolge."
 #. Default: "Are you certain you want to delete this record? This can not be undone and can be potentially harmful if you don't know what you are doing."
 #: plone.app.registry/plone/app/registry/browser/templates/delete_layout.pt:17
 msgid "description_record_delete"
-msgstr ""
+msgstr "Sind sie sicher, dass sie diesen Datensatz löschen wollen? Dies kann nicht rückgängig gemacht werden und ist potentiell gefährlich, falls sie nicht wissen was sie tun."
 
 #. Default: "Use the form below to edit the value of this particular record."
 #: plone.app.registry/plone/app/registry/browser/templates/edit_layout.pt:17
@@ -7670,7 +7666,7 @@ msgstr "Der Link, um das Passwort neu zu setzen, wurde Ihnen zugesendet. Die E-M
 #. Default: "i.e. also when the 'set_language' request parameter is absent"
 #: CMFPlone/interfaces/controlpanel.py:290
 msgid "description_set_language_cookie_always"
-msgstr ""
+msgstr "also auch wenn der 'set_language' Request-Parameter nicht gesetzt wurde"
 
 #. Default: "You can control who can view and edit your item using the list below."
 #: plone.app.workflow/plone/app/workflow/browser/sharing.pt:38
@@ -7745,7 +7741,7 @@ msgstr "z.B. www.plone.de"
 #. Default: "Workflow, visibility and versioning settings for your content types."
 #: CMFPlone/controlpanel/browser/types.pt:16
 msgid "description_types_setup"
-msgstr "Einstellungen für Arbeitsablauf, Sichtbarkeit und Versionierung für Artikeltypen."
+msgstr "Einstellungen für Arbeitsablauf, Sichtbarkeit und Versionierung für Inhaltstypen."
 
 #. Default: "Please use the form below to change your password."
 #: CMFPlone/skins/plone_login/login_password.cpt:38
@@ -7802,7 +7798,7 @@ msgstr "Keine Wiederholungen"
 
 #: plone.app.portlets/plone/app/portlets/portlets/review.py:167
 msgid "displays a queue of documents awaiting review."
-msgstr ""
+msgstr "Zeigt eine Warteschlange der Inhalte, die auf eine Überprüfung warten."
 
 #. Default: "Doctype"
 #: plone/app/theming/interfaces.py:163
@@ -7817,7 +7813,7 @@ msgstr "Sie können einen \"Doctype\" Text definieren, welcher für alle ausgehe
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/custom_migration.pt:36
 msgid "documentation"
-msgstr ""
+msgstr "Dokumentation"
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:673
 msgid "edit"
@@ -7826,12 +7822,12 @@ msgstr "Bearbeiten"
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:77
 msgid "edit_comment_form_button"
-msgstr ""
+msgstr "Bearbeite Kommentar"
 
 #. Default: "Edit comment"
 #: plone.app.discussion/plone/app/discussion/browser/comment.py:61
 msgid "edit_comment_form_title"
-msgstr ""
+msgstr "Bearbeite Kommentar"
 
 #: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:11
 msgid "edit_rules"
@@ -7910,22 +7906,22 @@ msgstr "Ausgenommen"
 #. Default: "Exclude from navigation"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:34
 msgid "exclude_from_nav"
-msgstr ""
+msgstr "Von Navigation auschließen"
 
 #. Default: "Expiration Date"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:9
 msgid "expiration_date"
-msgstr ""
+msgstr "Ablaufdatum"
 
 #. Default: "Export"
 #: plone.app.registry/plone/app/registry/browser/templates/records.pt:128
 msgid "export"
-msgstr ""
+msgstr "Exportieren"
 
 #. Default: "Export Now"
 #: plone.app.registry/plone/app/registry/browser/templates/records.pt:133
 msgid "export_button"
-msgstr ""
+msgstr "Exportiere jetzt"
 
 #. Default: "The '${value1}' vocabulary value conflicts with '${value2}'."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:191
@@ -7974,7 +7970,7 @@ msgstr "Einschränkungen…"
 #. Default: "Click to configure what type of items can be added here…"
 #: plone.app.content/plone/app/content/browser/folderfactories.pt:29
 msgid "folder_add_settings_long"
-msgstr "Klicken Sie hier, um festzulegen, welche Artikeltypen hier hinzugefügt werden dürfen…"
+msgstr "Klicken Sie hier, um festzulegen, welche Inhaltstypen hier hinzugefügt werden dürfen…"
 
 #. Default: "Up to rule management"
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/manage-elements.pt:24
@@ -8009,7 +8005,7 @@ msgstr "Aktion"
 #. Default: "Add actions portlet"
 #: plone.app.portlets/plone/app/portlets/portlets/actions.py:177
 msgid "heading_add_actions_portlet"
-msgstr ""
+msgstr "Aktions-Portlet hinzufügen"
 
 #. Default: "Add ${itemtype}"
 #: Archetypes/skins/archetypes/edit_macros.pt:16
@@ -8034,7 +8030,7 @@ msgstr "Gruppenzuweisung"
 #. Default: "Authenticated users only"
 #: CMFPlone/interfaces/controlpanel.py:276
 msgid "heading_auth_cookie_manual_override"
-msgstr ""
+msgstr "Nur angemeldete Benuzter"
 
 #. Default: "Latest content created by this user"
 #: CMFPlone/browser/templates/author.pt:190
@@ -8136,7 +8132,7 @@ msgstr "Dateiinhalt"
 #. Default: "Find duplicate login names"
 #: CMFPlone/controlpanel/browser/emaillogin.pt:11
 msgid "heading_find_duplicate_login_names"
-msgstr ""
+msgstr "Finde doppelte Login-Namen"
 
 #. Default: "Full review list:"
 #: plone.app.content/plone/app/content/browser/full_review_list.pt:14
@@ -8167,12 +8163,12 @@ msgstr "Kommentar zu"
 #. Default: "Use language codes in URL path for manual override"
 #: CMFPlone/interfaces/controlpanel.py:252
 msgid "heading_language_codes_in_URL"
-msgstr ""
+msgstr "Benutze Sprache aus der URL zum manuellen Überschreiben"
 
 #. Default: "Use the language of the content item"
 #: CMFPlone/interfaces/controlpanel.py:243
 msgid "heading_language_of_the_content"
-msgstr ""
+msgstr "Benutze Sprache des Inhalts"
 
 #. Default: "Language Settings"
 #: CMFPlone/controlpanel/browser/language.py:13
@@ -8192,7 +8188,7 @@ msgstr "Nach Benutzern suchen"
 #. Default: "Member tools"
 #: plone.app.layout/plone/app/layout/viewlets/membertools.pt:7
 msgid "heading_member_tools"
-msgstr ""
+msgstr "Mitglieds-Werkzeuge"
 
 #. Default: "Current group memberships"
 #: CMFPlone/controlpanel/browser/usergroups_usermembership.pt:69
@@ -8349,12 +8345,12 @@ msgstr "Bestätigung des Passwort-Zurücksetzens gesendet."
 #. Default: "Restrict what types of content can be added"
 #: plone.app.content/plone/app/content/browser/constraintypes.py:135
 msgid "heading_set_content_type_restrictions"
-msgstr "Hinzufügbare Artikeltypen einschränken"
+msgstr "Hinzufügbare Inhaltstypen einschränken"
 
 #. Default: "Set the language cookie always"
 #: CMFPlone/interfaces/controlpanel.py:287
 msgid "heading_set_language_cookie_always"
-msgstr ""
+msgstr "Setze immer das Sprach-Cookie"
 
 #. Default: "Please log in"
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:8
@@ -8467,17 +8463,17 @@ msgstr "Wenn Ihr Design relative Pfade für Bilder, CSS Dateien oder andere Ress
 #. Default: "Select an action category"
 #: plone.app.portlets/plone/app/portlets/portlets/actions.py:37
 msgid "help_actions_category"
-msgstr ""
+msgstr "Wähle eine Aktions-Kategorie"
 
 #. Default: "An action portlet displays actions from a category"
 #: plone.app.portlets/plone/app/portlets/portlets/actions.py:179
 msgid "help_add_actions_portlet"
-msgstr ""
+msgstr "Ein Aktions-Portlet zeigt Aktionen von einer Kategorie"
 
 #. Default: "Select the restriction policy in this location"
 #: plone.app.content/plone/app/content/browser/constraintypes.py:64
 msgid "help_add_restriction_mode"
-msgstr "Bitte wählen Sie den Modus aus, der bestimmt, welche Artikeltypen in diesem Ordner hinzugefügt werden können."
+msgstr "Bitte wählen Sie den Modus aus, der bestimmt, welche Inhaltstypen in diesem Ordner hinzugefügt werden können."
 
 #. Default: "Content types show up on Plone's \"Add Item\" menu and allow you to store custom data in your site. Click the \"Add Content Type\" button to begin creating a new content type with its own fields."
 #: plone.app.dexterity/plone/app/dexterity/browser/types.py:199
@@ -8497,7 +8493,7 @@ msgstr "Sollen Benutzer diesen Artikel kommentieren können?"
 #. Default: "Only the following roles can add new keywords "
 #: CMFPlone/interfaces/controlpanel.py:1324
 msgid "help_allow_roles_to_add_keywords"
-msgstr ""
+msgstr "Nur die folgende Rollen können neue Stichworte hinzufügen "
 
 #. Default: "If selected, anonymous users are able to post comments without logging in. It is highly recommended to use a captcha solution to prevent spam if this setting is enabled."
 #: plone.app.discussion/plone/app/discussion/interfaces.py:228
@@ -8646,12 +8642,12 @@ msgstr "Der Anfang des zu durchsuchenden Zeitraums"
 #. Default: "What icon we should use for actions with no specific icons. A 16*16 pixels image."
 #: plone.app.portlets/plone/app/portlets/portlets/actions.py:53
 msgid "help_default_icon"
-msgstr ""
+msgstr "Welches Icon soll für jeden aKtionen verwendet werden, die kein eigenes Icon haben? Ein 16*16 Pixel großes Bild."
 
 #. Default: "If selected, supports deleting of own comments for users with the \"Delete own comments\" permission."
 #: plone.app.discussion/plone/app/discussion/interfaces.py:283
 msgid "help_delete_own_comment_enabled"
-msgstr ""
+msgstr "Wenn ausgewählt können eigenen Kommentare gelöscht werden, sofern die Benutzer die \"Delete own comments\" Berechtigung haben."
 
 #. Default: "Used in item listings and search results."
 #: Archetypes/ExtensibleMetadata.py:91
@@ -8663,9 +8659,9 @@ msgstr "Die Zusammenfassung wird in Auflistungen und Suchresultaten angezeigt."
 #: plone.app.discussion/plone/app/discussion/browser/controlpanel.py:27
 msgid "help_discussion_settings_editform"
 msgstr ""
-"Einige Kommentierungseinstellungen müssen an anderer Stelle vorgenommen werden. Um die Kommentierung einzelner Artikeltypen einzuschalten, gehen Sie in der 'Plone-Konfiguration' zu 'Artikeltypen', wählen Sie den gewünschten Artikeltyp aus und schalten Sie die Option 'Kommentieren erlauben' ein.\n"
+"Einige Kommentierungseinstellungen müssen an anderer Stelle vorgenommen werden. Um die Kommentierung einzelner Inhaltstypen einzuschalten, gehen Sie in der 'Plone-Konfiguration' zu 'Inhaltstypen', wählen Sie den gewünschten Inhaltstyp aus und schalten Sie die Option 'Kommentieren erlauben' ein.\n"
 "\n"
-"Um die Moderation von Kommentaren zu aktivieren, wählen Sie den Artikeltyp 'Kommentar' aus und wählen Sie als neuen Arbeitsablauf 'Arbeitsablauf für moderierte Kommentare'."
+"Um die Moderation von Kommentaren zu aktivieren, wählen Sie den Inhaltstyp 'Kommentar' aus und wählen Sie als neuen Arbeitsablauf 'Arbeitsablauf für moderierte Kommentare'."
 
 #. Default: "You can specify a Doctype string which will be set on the output, for example \"&lt;!DOCTYPE html&gt;\". If left blank the default XHTML 1.0 transistional Doctype or that set in the Diazo theme is used."
 #: plone/app/theming/browser/controlpanel.pt:426
@@ -8702,12 +8698,12 @@ msgstr "Tragen Sie Ihre E-Mail-Adresse ein, mit der Sie sich künftig anmelden m
 #. Default: "Email Address"
 #: plone.app.z3cform/plone/app/z3cform/templates/link_input.pt:34
 msgid "help_email_url"
-msgstr ""
+msgstr "E-Mail-Adresse"
 
 #. Default: "Email Subject (optional)"
 #: plone.app.z3cform/plone/app/z3cform/templates/link_input.pt:40
 msgid "help_email_url_subject"
-msgstr ""
+msgstr "E-Mail Betreff (optional)"
 
 #. Default: "Select this option to enable the newly created theme immediately."
 #: plone/app/theming/browser/controlpanel.pt:239
@@ -8722,12 +8718,12 @@ msgstr "Aktivieren sie diese Option, um das gerade hochgeladene Design sofort zu
 #. Default: "Table of contents"
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/tableofcontents.py:19
 msgid "help_enable_table_of_contents"
-msgstr ""
+msgstr "Inhaltsverzeichnis"
 
 #. Default: "If selected, this will show a table of contents at the top of the page."
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/tableofcontents.py:22
 msgid "help_enable_table_of_contents_description"
-msgstr ""
+msgstr "Wenn ausgewählt wird ein Inhaltsverzeichnis oben auf der Seite angezeigt."
 
 #. Default: "Date and Time related settings like timezone(s), etc."
 #: CMFPlone/controlpanel/browser/dateandtime.py:15
@@ -8754,7 +8750,7 @@ msgstr "Wählen Sie diese Option aus, damit alle externen Links im Inhaltsbereic
 #. Default: "External URL (can be relative within this site or absolute if it starts with http:// or https://)"
 #: plone.app.z3cform/plone/app/z3cform/templates/link_input.pt:23
 msgid "help_external_url"
-msgstr ""
+msgstr "Externe URL (kann relativ innerhalb der Seite oder absolut sein, wenn sie mit http:// or https:// startet)"
 
 #. Default: "First day in the week."
 #: CMFPlone/interfaces/controlpanel.py:1367
@@ -8797,7 +8793,7 @@ msgstr "Wenn es \"Hostnamen\" gibt, der nicht das Design erhalten soll, können 
 #. Default: "Controls what types are addable in this location"
 #: plone.app.content/plone/app/content/browser/constraintypes.py:73
 msgid "help_immediately_addable_types"
-msgstr "Bestimmen Sie, welche Artikeltypen in diesem Ordner überhaupt hinzugefügt werden dürfen."
+msgstr "Bestimmen Sie, welche Inhaltstypen in diesem Ordner überhaupt hinzugefügt werden dürfen."
 
 #. Default: "If checked, this will attempt to modify the status of all content in any selected folders and their subfolders."
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:62
@@ -8829,7 +8825,7 @@ msgstr "Ist dies ausgewählt, wird nur die angegebene Anzahl von Artikeln angeze
 #. Default: "Select which types should be available in the 'More…' submenu <em>instead</em> of in the main pulldown. This is useful to indicate that these are not the preferred types in this location, but are allowed if you really need them."
 #: plone.app.content/plone/app/content/browser/constraintypes.py:83
 msgid "help_locally_allowed_types"
-msgstr "Bestimmen Sie bitte, welche der erlaubten Artikeltypen selten benutzt werden und nicht gleich im Hinzufügen-Menü auftauchen, sondern erst über den Eintrag »Erweitert« erreichbar sein sollen. Wenn Sie selten benutzte Artikeltypen aus dem Hinzufügen-Menü herausnehmen, sorgen Sie für mehr Übersicht."
+msgstr "Bestimmen Sie bitte, welche der erlaubten Inhaltstypen selten benutzt werden und nicht gleich im Hinzufügen-Menü auftauchen, sondern erst über den Eintrag »Erweitert« erreichbar sein sollen. Wenn Sie selten benutzte Inhaltstypen aus dem Hinzufügen-Menü herausnehmen, sorgen Sie für mehr Übersicht."
 
 #. Default: "Your location - either city and country - or in a company setting, where your office is located."
 #: plone.app.users/plone/app/users/profiles/default/userschema.xml
@@ -8861,7 +8857,7 @@ msgstr "Bitte geben Sie die zu sendende Nachricht ein."
 #: plone.app.discussion/plone/app/discussion/interfaces.py:255
 #, fuzzy
 msgid "help_moderation_enabled"
-msgstr "Falls ausgewählt werden Kommentare in einem für die Öffentlichkeit unsichtbaren Schwebezustand gehalten, bis sie ein Benutzer mit der 'Review comments' Berechtigung ('Reviewer' or 'Manager') genehmigt und damit für die Öffentlichkeit sichtbar macht. Wenn Sie einen angepassten Arbeitsablauf für Kommentare einstellen wollen, so geht das mit dem Menu unter Artikeltypen."
+msgstr "Falls ausgewählt werden Kommentare in einem für die Öffentlichkeit unsichtbaren Schwebezustand gehalten, bis sie ein Benutzer mit der 'Review comments' Berechtigung ('Reviewer' or 'Manager') genehmigt und damit für die Öffentlichkeit sichtbar macht. Wenn Sie einen angepassten Arbeitsablauf für Kommentare einstellen wollen, so geht das mit dem Menu unter Inhaltstypen."
 
 #. Default: "Address to which moderator notifications will be sent."
 #: plone.app.discussion/plone/app/discussion/interfaces.py:352
@@ -8959,12 +8955,12 @@ msgstr "Ordner, in denen gesucht werden soll."
 #. Default: "The timezone setting of the portal. Users can set their own timezone, if available timezones are defined."
 #: CMFPlone/interfaces/controlpanel.py:1344
 msgid "help_portal_timezone"
-msgstr ""
+msgstr "Die Zeitzonen Einstellungen des Portals. Benutzer können ihre eigene Zeitzone setzen, sofern verfügbare Zeitzonen konfiguriert wurden."
 
 #. Default: "One of the available content types."
 #: widget description of MultiSelectionWidget for label Value
 msgid "help_portal_type_criteria_value"
-msgstr "Einer der registrierten Artikeltypen."
+msgstr "Einer der registrierten Inhaltstypen."
 
 #. Default: "To add or change the portrait: click the \"Browse\" button; select a picture of yourself. Recommended image size is 75 pixels wide by 100 pixels tall."
 #: plone.app.users/plone/app/users/profiles/default/userschema.xml
@@ -9049,7 +9045,7 @@ msgstr "Findet Benutzer, deren Benutzername diesen Wert enthält."
 #. Default: "Select what content type you wish to create."
 #: Archetypes/skins/archetypes/widgets/addable_support.pt:45
 msgid "help_select_content_to_create"
-msgstr "Wählen Sie den Artikeltypen aus, den Sie erstellen möchten."
+msgstr "Wählen Sie den Inhaltstypen aus, den Sie erstellen möchten."
 
 #. Default: "Select where you want to create that."
 #: Archetypes/skins/archetypes/widgets/addable_support.pt:62
@@ -9764,7 +9760,7 @@ msgstr "Aktiviert"
 #. Default: "Active content rules in this ${content_type}"
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/manage-assignments.pt:137
 msgid "label_contentrules_active_assignments"
-msgstr "Aktive Regeln für diesen Artikeltypen (${content_type})"
+msgstr "Aktive Regeln für diesen Inhaltstypen (${content_type})"
 
 #. Default: "Enabled here?"
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/manage-assignments.pt:146
@@ -10308,7 +10304,7 @@ msgstr "Bildtitel"
 #. Default: "Allowed types"
 #: plone.app.content/plone/app/content/browser/constraintypes.py:72
 msgid "label_immediately_addable_types"
-msgstr "Erlaubte Artikeltypen"
+msgstr "Erlaubte Inhaltstypen"
 
 #. Default: "Include contained items"
 #: plone.app.content/plone/app/content/browser/contents/templates/properties.pt:60
@@ -10356,7 +10352,7 @@ msgstr "Artikel: ${contentitem}"
 #. Default: "Item type"
 #: CMFPlone/browser/templates/search.pt:74
 msgid "label_item_type"
-msgstr "Artikeltyp"
+msgstr "Inhaltstyp"
 
 #. Default: "Keywords"
 #: widget label of KeywordWidget - description ""
@@ -10394,7 +10390,7 @@ msgstr "Eingrenzung der Suchresultate"
 #. Default: "Secondary types"
 #: plone.app.content/plone/app/content/browser/constraintypes.py:82
 msgid "label_locally_allowed_types"
-msgstr "Selten benutzte Artikeltypen"
+msgstr "Selten benutzte Inhaltstypen"
 
 #. Default: "Location"
 #: Archetypes/ExtensibleMetadata.py:102
@@ -10725,7 +10721,7 @@ msgstr "Website der Plone-Community"
 #. Default: "Value"
 #: widget label of MultiSelectionWidget - description "One of the available content types."
 msgid "label_portal_type_criteria_value"
-msgstr "Artikeltyp"
+msgstr "Inhaltstyp"
 
 #. Default: "(Blocked)"
 #: plone.app.portlets/plone/app/portlets/browser/templates/edit-manager-contextual.pt:57
@@ -11007,7 +11003,7 @@ msgstr "Empfängeradresse (E-Mail)"
 #: CMFPlone/browser/interfaces.py:332
 #, fuzzy
 msgid "label_sender_from_address"
-msgstr "E-Mail"
+msgstr "Absenderadresse (E-Mail)"
 
 #. Default: "Name"
 #: CMFPlone/browser/interfaces.py:324
@@ -11267,7 +11263,7 @@ msgstr "Zeige Fehlerbericht als Text"
 #. Default: "Type restrictions"
 #: plone.app.content/plone/app/content/browser/constraintypes.py:63
 msgid "label_type_restrictions"
-msgstr "Artikeltypenbeschränkungen"
+msgstr "Inhaltstypenbeschränkungen"
 
 #. Default: "Unassign"
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/manage-assignments.pt:239
@@ -12131,7 +12127,7 @@ msgstr ""
 #. Default: "Will export the entire registry into a single XML file."
 #: plone.app.registry/plone/app/registry/browser/templates/records.pt:129
 msgid "registry_export_text"
-msgstr ""
+msgstr "Exportiert die gesamte Registry in eine XML Datei."
 
 #. Default: "reject"
 #: workflow transition defined in plone_workflow - title Reviewer rejects submission new state visible
@@ -12196,7 +12192,7 @@ msgstr "Wähle einen Prefix"
 #. Default: "Number of selected, non-empty folders: <strong>${refs}</strong>"
 #: plone.app.linkintegrity/plone/app/linkintegrity/browser/delete_confirmation_info.pt:58
 msgid "selected_folders_with_content"
-msgstr ""
+msgstr "Anzahl ausgewählter, nicht-leerer Ordner: <strong>${refs}</strong>"
 
 #. Default: "This link is sent to you from ${portal_url} You are receiving this mail because someone read a page at ${portal_title} and thought it might interest you. It is sent by ${from_address} with the following comment: \"${comment}\" ${document_title} ${document_description} ${document_url}"
 #: CMFPlone/browser/templates/sendto_template.pt:25
@@ -12265,7 +12261,7 @@ msgstr "Momentan zugewiesene Funktionen"
 #. Default: "Lists content written by an author grouped by content type"
 #: CMFPlone/browser/templates/author.pt:195
 msgid "summary_author_content_list"
-msgstr "Listet Artikel eines Autors gruppiert nach Artikeltyp auf."
+msgstr "Listet Artikel eines Autors gruppiert nach Inhaltstyp auf."
 
 #. Default: "Content listing"
 #: plone.app.content/plone/app/content/browser/table.pt:29
@@ -12383,7 +12379,7 @@ msgstr "Website"
 #. Default: "Types control panel"
 #: plone.app.discussion/plone/app/discussion/browser/controlpanel.pt:43
 msgid "text_discussion_type_control_panel_link"
-msgstr ""
+msgstr "Inhaltsypen"
 
 #. Default: "The specified log entry was not found. It may have expired. If you are using a load-balanced ZEO (cluster) setup, try reloading until you get the right server in the cluster."
 #: CMFPlone/skins/plone_prefs/prefs_error_log_showEntry.pt:35
@@ -12457,7 +12453,7 @@ msgstr ""
 #. Default: "Date and Time Settings control panel"
 #: CMFPlone/controlpanel/browser/overview.pt:73
 msgid "text_no_timezone_configured_control_panel_link"
-msgstr ""
+msgstr "Datum und Zeit Einstellungen"
 
 #. Default: "No user by that name."
 #: CMFPlone/browser/templates/author.pt:39
@@ -12700,7 +12696,7 @@ msgstr "&middot; Vergleiche mit aktueller Version"
 #: plone.app.content/plone/app/content/browser/folderfactories.pt:29
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:613
 msgid "title_configure_addable_content_types"
-msgstr "Konfiguration der hinzufügbaren Artikeltypen"
+msgstr "Konfiguration der hinzufügbaren Inhaltstypen"
 
 #. Default: "this rule has not been assigned"
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/controlpanel.pt:146
@@ -12757,7 +12753,7 @@ msgstr "Regeln"
 #. Default: "${contenttype_icon} Manage content type portlets for ${contenttype_name}"
 #: plone.app.portlets/plone/app/portlets/browser/templates/manage-content-type.pt:17
 msgid "title_manage_contenttype_portlets"
-msgstr "${contenttype_icon} Portlets für den Artikeltyp ${contenttype_name} verwalten"
+msgstr "${contenttype_icon} Portlets für den Inhaltstyp ${contenttype_name} verwalten"
 
 #. Default: "Manage portlets for ${context_title}"
 #: plone.app.portlets/plone/app/portlets/browser/templates/manage-contextual.pt:14
@@ -12800,7 +12796,7 @@ msgstr "Zum vorherigen"
 #. Default: "Password Reset Tool"
 #: CMFPlone/browser/templates/explainPWResetTool.pt:7
 msgid "title_pw_reset_tool"
-msgstr ""
+msgstr "Password Reset Funktion"
 
 #. Default: "Delete or rename the index_html item to gain full control over how this folder is displayed."
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:154
@@ -12854,7 +12850,7 @@ msgstr "Sende diesem Benutzer eine E-Mail"
 #. Default: "Expiration Interval"
 #: CMFPlone/browser/templates/explainPWResetTool.pt:11
 msgid "title_set_exp_interval"
-msgstr ""
+msgstr "Ablauf-Intervall"
 
 #. Default: "Static text portlet"
 #: plone.portlet.static/plone/portlet/static/static.py:104
@@ -12869,7 +12865,7 @@ msgstr "RSS Feed abonnieren"
 #. Default: "Other portlet managers"
 #: plone.app.portlets/plone/app/portlets/browser/templates/topbar-manage-portlets.pt:18
 msgid "title_switch_portlet_managers"
-msgstr ""
+msgstr "Andere Portlet-Manager"
 
 #. Default: "User registration fields"
 #: plone.app.users/plone/app/users/schema.py:170
@@ -12879,7 +12875,7 @@ msgstr "Felder für die Benutzerregistrierung"
 #. Default: "Username Check"
 #: CMFPlone/browser/templates/explainPWResetTool.pt:26
 msgid "title_username_check"
-msgstr ""
+msgstr "Benutzernamen Überprüfung"
 
 #. Default: "View"
 #: plone.app.layout/plone/app/layout/viewlets/content_history.pt:58
@@ -12923,7 +12919,7 @@ msgstr "Kann als Standardseite verwendet werden"
 #. Default: "Manage portlets assigned to this content type"
 #: CMFPlone/controlpanel/browser/types.pt:135
 msgid "types_controlpanel_manage_portlets"
-msgstr "Portlets verwalten, die diesem Artikeltypen zugeordnet sind"
+msgstr "Portlets verwalten, die diesem Inhaltstypen zugeordnet sind"
 
 #. Default: "New State"
 #: CMFPlone/controlpanel/browser/types.pt:220
@@ -12973,7 +12969,7 @@ msgstr "Versionierungsrichtlinie"
 #. Default: "Changing the workflow of a type will take a while, and may slow down the site significantly while the content is updated to the new setting."
 #: CMFPlone/controlpanel/browser/types.pt:253
 msgid "types_controlpanel_warn_remap"
-msgstr "Das Ändern des Arbeitsablaufs eines Artikeltypen kann einige Zeit dauern und Ihre Website in dieser Zeit deutlich verlangsamen."
+msgstr "Das Ändern des Arbeitsablaufs eines Inhaltstypen kann einige Zeit dauern und Ihre Website in dieser Zeit deutlich verlangsamen."
 
 #: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:119
 msgid "unsupported_features"
@@ -13127,3 +13123,4 @@ msgstr "Ja"
 #: plone.app.layout/plone/app/layout/viewlets/path_bar.pt:5
 msgid "you_are_here"
 msgstr "Sie sind hier:"
+


### PR DESCRIPTION
Ein paar Fehlen noch, einige greifen noch nicht. Aber das kann schonmal reviewed werden.

Ich habe auch _Artikeltypen_ in _Inhaltstypen_ umbenamst, und auch _Objekt*_ in _Inhalt*_ umbenannt.

Typos die ich gefunden habe, sind raus. 

Sicher hab ich auch neue gemacht. Wer die Kommaregeln besser als ich beherrscht (vor allemso spät am Abend) darf mich gerne korrigieren.