### PR TITLE
Adresses plone/Products.CMFPlone#890

### DIFF
--- a/docs/terms-de.txt
+++ b/docs/terms-de.txt
@@ -107,7 +107,7 @@ Wenn wichtige Begriffe fehlen, bitte ersetzen.
      skin           =
      sub...         =
      subfolder      =
-     subject        =
+     subject        = Schlagwort/ Schlagwörter
      submit         =
      syndication    =
      title          =

--- a/plone/app/locales/locales/de/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/plone.po
@@ -229,7 +229,7 @@ msgstr "Mit dieser Bedingung legen Sie fest, dass eine Aktion nur ausgeführt wi
 
 #: CMFPlone/interfaces/controlpanel.py:367
 msgid "A list of valid tags which will be not filtered out."
-msgstr "Eine Liste gültiger Stichworte, die nicht herausgefiltert werden sollen."
+msgstr "Eine Liste gültiger Schlagwörter, die nicht herausgefiltert werden sollen."
 
 #: plone.app.contentrules/plone/app/contentrules/actions/logger.py:119
 msgid "A logger action can output a message to the system log."
@@ -2572,7 +2572,7 @@ msgstr "Änderung der Inhalte ist fehlgeschlagen"
 
 #: plone.app.content/plone/app/content/browser/contents/tags.py:40
 msgid "Failed to modify tags on items"
-msgstr "Änderung der Stichworte von Inhalten ist fehlgeschlagen"
+msgstr "Änderung der Schlagwörter von Inhalten ist fehlgeschlagen"
 
 #: plone.app.content/plone/app/content/browser/contents/paste.py:32
 msgid "Failed to paste items"
@@ -3358,11 +3358,11 @@ msgstr "Suchresultate eingrenzen"
 
 #: CMFPlone/interfaces/controlpanel.py:144
 msgid "Limit tags aka keywords vocabulary used for Tags field and in searches to the terms used inside the subtree of the current navigation root. This can be used together with Plone's multilingual extension plone.app.multilingual to only offer keywords of the current selected language. Other addons may utilize this feature for its specific purposes."
-msgstr "Schränke das Stichworte-Vokabular für das Stichworte-Feld und in Suchanfragen auf die Stichworte ein, die im Unterbaum der aktuellen Navigationsbasis vorkommen. Dies kann zusammen mir der Erweiterung 'plone.app.multilingual' verwendet werden um nur Stichworte der aktuell ausgewählten Sprache zu verwenden. Andere Erweiterungen können diese Fähigkeit für ihre spezifischen Anwendungsfälle nutzen."
+msgstr "Schränke das Schlagwörter-Vokabular für das Schlagwörter-Feld und in Suchanfragen auf die Schlagwörter ein, die im Unterbaum der aktuellen Navigationsbasis vorkommen. Dies kann zusammen mir der Erweiterung 'plone.app.multilingual' verwendet werden um nur Schlagwörter der aktuell ausgewählten Sprache zu verwenden. Andere Erweiterungen können diese Fähigkeit für ihre spezifischen Anwendungsfälle nutzen."
 
 #: CMFPlone/interfaces/controlpanel.py:143
 msgid "Limit tags/keywords to the current navigation root"
-msgstr "Stichworte auf aktuelle Navigationsbasis einschränken"
+msgstr "Schlagwörter auf aktuelle Navigationsbasis einschränken"
 
 #. Default: "Link"
 #: plone.app.contenttypes/plone/app/contenttypes/profiles/default/types/Link.xml
@@ -5049,7 +5049,7 @@ msgstr "Rollen: ${names}"
 
 #: CMFPlone/interfaces/controlpanel.py:1323
 msgid "Roles that can add keywords"
-msgstr "Rollen, die Stichworten hinzufügen dürfen"
+msgstr "Rollen, die Schlagwörter hinzufügen dürfen"
 
 #: CMFPlone/interfaces/controlpanel.py:997
 msgid "Root"
@@ -5676,7 +5676,7 @@ msgstr "Metadaten erfolgreich aktualisiert"
 
 #: plone.app.content/plone/app/content/browser/contents/tags.py:39
 msgid "Successfully updated tags on items"
-msgstr "Stichworte wurden erfolgreich aktualisiert"
+msgstr "Schlagwörter wurden erfolgreich aktualisiert"
 
 #. Default: "Summary view"
 #: plone.app.collection/plone/app/collection/browser/configure.zcml:62
@@ -5768,7 +5768,7 @@ msgstr "Tabelle"
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 #: plone.app.querystring/plone/app/querystring/profiles/upgrades/to_8/registry.xml
 msgid "Tag"
-msgstr "Stichwort"
+msgstr "Schlagwort"
 
 #: plone.app.content/plone/app/content/browser/contents/__init__.py:215
 #: plone.app.content/plone/app/content/browser/contents/tags.py:24
@@ -9451,7 +9451,7 @@ msgstr "Sollen Benutzer diesen Artikel kommentieren können?"
 #. Default: "Only the following roles can add new keywords "
 #: CMFPlone/interfaces/controlpanel.py:1324
 msgid "help_allow_roles_to_add_keywords"
-msgstr "Nur die folgende Rollen können neue Stichworte hinzufügen "
+msgstr "Nur die folgende Rollen können neue Schlagwörter hinzufügen "
 
 #. Default: "If selected, anonymous users are able to post comments without logging in. It is highly recommended to use a captcha solution to prevent spam if this setting is enabled."
 #: plone.app.discussion/plone/app/discussion/interfaces.py:228
@@ -11078,7 +11078,7 @@ msgstr "Urheberrechte"
 #. Default: "Create and apply new tags."
 #: Archetypes/skins/archetypes/widgets/keyword.pt:127
 msgid "label_create_new_tags"
-msgstr "Neues Stichwort anlegen und benutzen."
+msgstr "Neues Schlagwort anlegen und benutzen."
 
 #. Default: "Creation Date"
 #: Archetypes/ExtensibleMetadata.py:189
@@ -11423,7 +11423,7 @@ msgstr "Von Navigation ausschließen"
 #. Default: "Use Control/Command/Shift keys to select multiple tags."
 #: Archetypes/skins/archetypes/widgets/keyword.pt:48
 msgid "label_existingTagsHelp"
-msgstr "Benutzen Sie die Steuerungs- oder Kommandotaste bzw. die Hochstelltaste, um mehrere Stichworte auszuwählen"
+msgstr "Benutzen Sie die Steuerungs- oder Kommandotaste bzw. die Hochstelltaste, um mehrere Schlagwörter auszuwählen"
 
 #. Default: "Expiration Date"
 #: Archetypes/ExtensibleMetadata.py:147
@@ -11881,7 +11881,7 @@ msgstr "Navigationsbaumtiefe"
 #. Default: "Enter one tag per line, multiple words allowed."
 #: Archetypes/skins/archetypes/widgets/keyword.pt:131
 msgid "label_newTagsHelp"
-msgstr "Ein Stichwort pro Zeile eingeben, mehrere Worte sind erlaubt."
+msgstr "Ein Schlagwort pro Zeile eingeben, mehrere Worte sind erlaubt."
 
 #. Default: "New items since"
 #: CMFPlone/browser/templates/search.pt:101
@@ -11938,7 +11938,7 @@ msgstr "vor/zurück-Navigation"
 #. Default: "No tags currently selected."
 #: Archetypes/skins/archetypes/widgets/keyword.pt:81
 msgid "label_noTagsSelected"
-msgstr "Zur Zeit ist kein Stichwort ausgewählt."
+msgstr "Zur Zeit ist kein Schlagwort ausgewählt."
 
 #. Default: "No change"
 #: plone.app.content/plone/app/content/browser/contents/properties.py:69
@@ -11989,7 +11989,7 @@ msgstr "OK"
 #. Default: "% tags currently selected."
 #: Archetypes/skins/archetypes/widgets/keyword.pt:82
 msgid "label_oneOrMoreTagsSelected"
-msgstr "Zurzeit sind % Stichworte ausgewählt."
+msgstr "Zurzeit sind % Schlagwörter ausgewählt."
 
 #. Default: "Operation parameters"
 #: plone.app.caching/plone/app/caching/browser/controlpanel.pt:562
@@ -12365,7 +12365,7 @@ msgstr "Wählen Sie einen Artikel…"
 #. Default: "Select from existing tags."
 #: Archetypes/skins/archetypes/widgets/keyword.pt:44
 msgid "label_select_existing_tags"
-msgstr "Bestehendes Stichwort auswählen."
+msgstr "Bestehendes Schlagwort auswählen."
 
 #. Default: "Value"
 #: widget label of MultiSelectionWidget - description "Existing values."
@@ -12565,7 +12565,7 @@ msgstr "Inhaltsverzeichnis"
 #: Archetypes/ExtensibleMetadata.py:77
 #: plone.app.dexterity/plone/app/dexterity/behaviors/metadata.py:104
 msgid "label_tags"
-msgstr "Stichworte"
+msgstr "Schlagwörter"
 
 #. Default: "Legacy template mappings"
 #: plone.app.caching/plone/app/caching/browser/controlpanel.pt:448


### PR DESCRIPTION
see https://github.com/plone/Products.CMFPlone/issues/890

"Subject" ([Wikipedia](https://en.wikipedia.org/wiki/Subject_(documents))) im Englischen meint eigentlich nicht das Stichwort. Stichwort [(Duden)](https://www.duden.de/rechtschreibung/Schlagwort) hat zwei Bedeutungen hat im deutschen, und es hat im Plural mit "Stichworte" eine andere Bedeutung als die Form "Stichwörter".

"**Schlagwort**" ([Duden](https://www.duden.de/rechtschreibung/Schlagwort)) (pl. Schlagworte) passt defintionsgemäß wesentlich besser.

Alternativ, nahe am englischen Original, könnten man Thema (pl. Themen) nehmen. Das ist aber wiederum mehrdeutig und meiner Meinung nach nicht optimal.

cc @pbauer @agitator Meinungen?