### PR TITLE
Fix Dutch translation in mailtemplate_reset_information

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 - Update Traditional Chinese translations.
   [l34marr]
+- Fix small typo in Dutch translation.
+  [huubbouma]
 
 
 5.1.10 (2018-10-02)

--- a/plone/app/locales/locales/nl/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/nl/LC_MESSAGES/plone.po
@@ -15,6 +15,7 @@
 # Reinout van Rees <reinout@zestsoftware.nl>, 2008
 # Roel Bruggink <roel@fourdigits.nl>, 2009
 # Wietze Helmantel <helmantel@goldmund-wyldebeast-wunderliebe.com>, 2007
+# Huub Bouma <huub@pythonunited.com>, 2018
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone CMS\n"
@@ -13199,7 +13200,7 @@ msgstr "Welkom ${fullname}, uw gebruikersaccount is aangemaakt. U moet uw accoun
 #. Default: "The site administrator asks you to reset your password for '${userid}' userid. Your old password doesn't work anymore."
 #: CMFPlone/browser/templates/mail_password_template.pt:14
 msgid "mailtemplate_reset_information"
-msgstr "De sitebeheerder vraagt u om uw wachtwoord voor '$ {userid}' opnieuw in te stellen. Uw oude wachtwoord is vervallen."
+msgstr "De sitebeheerder vraagt u om uw wachtwoord voor '${userid}' opnieuw in te stellen. Uw oude wachtwoord is vervallen."
 
 #. Default: "Password reset request"
 #: CMFPlone/browser/password_reset.py:54


### PR DESCRIPTION
Small typo in the translation that is used to ceate password reset email.
There was a space between the $ and the {userid} which has been removed