### PR TITLE
[new] Add .gitattributes file to avoid most CHANGES merge conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGES.rst merge=union

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 5.1.13 (unreleased)
 -------------------
 
+- Add .gitattributes file to avoid most CHANGES merge conflicts
+  [@arsenico13]
 - Update Traditional Chinese translations.
   [l34marr]
 


### PR DESCRIPTION
I've seen merge conflicts in Changes files in pull requests and I figured we might as well use the same strategy we use with other plone packages: setting gitattributes to use the union style for merging the Changelog file. What do you think about it?

Quick article for reference: http://krlmlr.github.io/using-gitattributes-to-avoid-merge-conflicts/