### PR TITLE
accessibility-info: fix german translation

### DIFF
--- a/plone/app/locales/locales/de/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/plone.po
@@ -8213,20 +8213,18 @@ msgstr "Sie können für bestimmte Inhalte im Betreff, dem Absenderfeld, dem Emp
 
 #. Default: "This site uses the open source Content Management System ${plone}. It meets the Web Content Accessibility Guidelines (<a href=\"https://www.w3.org/TR/WCAG20/\">${wcag} v2.0</a>) level 'AA' for people with disabilities, including blindness and low vision, deafness and hearing loss, learning disabilities, cognitive limitations, limited movement, speech disabilities, photosensitivity, and combinations of these."
 #: CMFPlone/browser/templates/accessibility-info.pt:21
-#, fuzzy
 msgid "description_accessibility_info"
 msgstr "Diese Seite verwendet das Opensource Content Management System ${plone}. Es entspricht den \"Web Content Accessibility Guidelines\" (<a target='_blank' href=\"http://www.w3.org/TR/WCAG20/\">${wcag} v2.0</a>) level 'AA' für Menschen mit Behinderung, einschließlich Blindheit und Sehbehinderung, Taubheit und eingeschränktem Hörvermögen, Lernbeschränkungen, kognitive Einschränkungen, Bewegungseinschränkungen, Sprachbehinderung, Lichtempfindlichkeit, sowie Kombination von diesen."
 
 #. Default: "It is also accessible to content authors with disabilities per the level 'AA' Authoring Tool Accessibility Guidelines (<a href=\"https://www.w3.org/TR/ATAG20/\">${atag} 2.0</a>)."
 #: CMFPlone/browser/templates/accessibility-info.pt:29
-#, fuzzy
 msgid "description_accessibility_info2"
 msgstr "Es ist auch verwendbar für Content-Autoren mit Einschränkungen entsprechend dem Level 'AA' Authoring Tool Accessibility Guidelines (<a target='_blank' href=\"http://www.w3.org/TR/ATAG20/\">${atag} 2.0</a>)."
 
 #. Default: "This site was designed to accommodate the different ways people access and use the Internet."
 #: CMFPlone/browser/templates/accessibility-info.pt:37
 msgid "description_accessibility_statement"
-msgstr "Diese Seite wurde so designed, dass Personen auf unterschiedlichen Wegen auf das Internet zugreifen können."
+msgstr "Diese Seite wurde so entwickelt, dass unterschiedliche Arten des Zugriffs und der Nutzung berücksichtigt werden."
 
 #. Default: "Select the type of item you want to add to your folder."
 #: plone.app.content/plone/app/content/browser/folderfactories.pt:22
@@ -8932,17 +8930,17 @@ msgstr "Wählen Sie die Felder für das Registrierungsformular aus. Die Felder i
 #. Default: "The site uses assistive technology like WAI-ARIA roles to the current best practices; however, site standards and content vary over time. If this web site does not validate correctly, please contact the ${site_admin}."
 #: CMFPlone/browser/templates/accessibility-info.pt:48
 msgid "description_validation"
-msgstr "Wir haben ${xhtml} 1.0 und ${css} benutzt, das der Spezifikation des ${w3c} folgt, da wir glauben, dass Benutzbarkeit und Barrierefreiheit eine solide Basis benötigen. Sollte etwas in dieser Website nicht standardkonform sein, kontaktieren Sie bitte den ${site_admin} und nicht das Plone-Team."
+msgstr "Diese Website verwendet unterstützende Technologien wie WAI-ARIA-Rollen nach den aktuellen Vorgaben. Die Standards und die Inhalte der Website sind jedoch im Laufe der Zeit Veränderungen unterworfen. Wenn die Website nicht mehr korrekt validiert, wenden Sie sich bitte an den ${site_admin}."
 
 #. Default: "View <a title=\"x\" href=\"https://plone.org/plone-vpat.pdf/view\"> Plone's VPAT </a> <a href=\"https://www.state.gov/m/irm/impact/126340.htm\"> ${vpat} </a>"
 #: CMFPlone/browser/templates/accessibility-info.pt:72
 msgid "description_vpat"
-msgstr "Anzeigen des Dokumentes <a title=\"x\" href=\"https://plone.org/plone-vpat.pdf/view\"> Plone VPAT </a> <a href=\"https://www.state.gov/m/irm/impact/126340.htm\"> ${vpat} "
+msgstr "Das Dokument <a title=\"x\" href=\"https://plone.org/plone-vpat.pdf/view\"> Plone VPAT </a> ansehen <a href=\"https://www.state.gov/m/irm/impact/126340.htm\"> ${vpat} </a>"
 
 #. Default: "A number of checkpoints in ${wcag} 2.0 and ${atag} 2.0 guidelines are subjective; there may be instances where interpretations vary."
 #: CMFPlone/browser/templates/accessibility-info.pt:57
 msgid "description_wcag_aa_rating"
-msgstr "Wir haben uns ebenfalls bemüht, nach den Barrierefreiheitsrichtlinien der ${wcag} 1.0 den Status AA zu erreichen, sind uns jedoch bewusst, dass eine Reihe von Punkten der ${wcag2} verschieden auslegbar sind. Auch wenn wir meinen, diese Punkte alle erfüllt zu haben, ist es möglich, dass unterschiedliche Meinungen existieren."
+msgstr "Eine Reihe von Punkten der ${wcag} 2.0 und ${atag} 2.0 Richtlinien sind unterschiedlich auslegbar. Es mag Fälle geben in denen unterschiedliche Interpretationen existieren."
 
 #. Default: "This item was locked by ${author} ${time} ago."
 #: plone.locking/plone/locking/browser/info.pt:17


### PR DESCRIPTION
The page accessibility-info did not show some of the german text (removed fuzzy..)
also the text was outdated and not correct.