### PR TITLE
Update widgets.po

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 5.1.22 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Structure pattern: Change message from misleading "Cannot order items while querying" to "Drag and drop reordering is disabled while filters are applied.".
+  Fixes: https://github.com/collective/plone.app.locales/issues/173
+  [thet]
 
 
 5.1.21 (2020-01-06)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 5.1.22 (unreleased)
 -------------------
 
+- Synchronize with latest mockup.
 - Structure pattern: Change message from misleading "Cannot order items while querying" to "Drag and drop reordering is disabled while filters are applied.".
   Fixes: https://github.com/collective/plone.app.locales/issues/173
   [thet]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 5.1.22 (unreleased)
 -------------------
 
+- German translations for widgets.po.
 - Synchronize with latest mockup.
 - Structure pattern: Change message from misleading "Cannot order items while querying" to "Drag and drop reordering is disabled while filters are applied.".
   Fixes: https://github.com/collective/plone.app.locales/issues/173

--- a/plone/app/locales/locales/af/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/af/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/af/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/af/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/ar/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/ar/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/ar/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/ar/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/bg/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/bg/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/bg/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/bg/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/bn/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/bn/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/bn/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/bn/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/ca/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/ca/LC_MESSAGES/widgets.po
@@ -150,7 +150,7 @@ msgid "Cancel"
 msgstr "Cancel·la"
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr "Els elements no es poden reordenar mentre hi ha un filtre aplicat"
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/ca/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/ca/LC_MESSAGES/widgets.po
@@ -149,10 +149,6 @@ msgstr "CSS/LESS"
 msgid "Cancel"
 msgstr "Cancel·la"
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr "Els elements no es poden reordenar mentre hi ha un filtre aplicat"
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr "Seleccioneu un fitxer"
@@ -277,6 +273,10 @@ msgstr "El paquet conté fitxers RequireJS o LESS?"
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr "Arrossegueu fitxers des de l'ordinador i deixeu-los anar en aquesta àrea o bé cliqueu el botó Navega."
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr "Els elements no es poden reordenar mentre hi ha un filtre aplicat"
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr "Podeu arrossegar fitxers aquí..."
@@ -378,6 +378,14 @@ msgid "Expression"
 msgstr "Expressió"
 
 #: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
 msgid "External Image URL (can be relative within this site or absolute if it starts with http:// or https://)"
 msgstr "URL externa de la imatge (pot ser relativa a aquest portal o absoluta si comença amb http:// o https://)"
 
@@ -403,7 +411,7 @@ msgstr "El nom del fitxer ha de començar amb ++plone++static/"
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
-msgstr "Filtreu"
+msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Filter..."
@@ -645,10 +653,6 @@ msgstr "Anterior"
 msgid "Previous month"
 msgstr "Mes anterior"
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr "Cerca"
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr "Organitza"
@@ -824,6 +828,10 @@ msgstr "S'ha produït un error en la cerca…"
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
 msgstr "S'ha produït un error en enviar el formulari."
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
+msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js
 msgid "This permanently changes the order of items in this folder. This operation may take a long time depending on the size of the folder."

--- a/plone/app/locales/locales/cs/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/cs/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/cs/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/cs/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/cy/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/cy/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/cy/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/cy/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/da/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/da/LC_MESSAGES/widgets.po
@@ -149,7 +149,7 @@ msgid "Cancel"
 msgstr "Afbryd"
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/da/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/da/LC_MESSAGES/widgets.po
@@ -148,10 +148,6 @@ msgstr "CSS/LESS"
 msgid "Cancel"
 msgstr "Afbryd"
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr "Vælg fil"
@@ -276,6 +272,10 @@ msgstr "Indeholder din bundle RequireJS- eller LESS-filer?"
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr "Slip filer her..."
@@ -377,6 +377,14 @@ msgid "Expression"
 msgstr "Udtryk"
 
 #: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
 msgid "External Image URL (can be relative within this site or absolute if it starts with http:// or https://)"
 msgstr ""
 
@@ -402,7 +410,7 @@ msgstr "Filnavn skal starte med ++plone++static/"
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
-msgstr "Filtrér"
+msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Filter..."
@@ -644,10 +652,6 @@ msgstr "Foregående"
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr "Søg"
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr "Sortér"
@@ -823,6 +827,10 @@ msgstr "Søgningen kunne ikke udføres…"
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
 msgstr "Formularen kunne ikke indsendes."
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
+msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js
 msgid "This permanently changes the order of items in this folder. This operation may take a long time depending on the size of the folder."

--- a/plone/app/locales/locales/de/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/widgets.po
@@ -381,11 +381,11 @@ msgstr "Ausdruck"
 
 #: ./patterns/tinymce/pattern.js
 msgid "External"
-msgstr ""
+msgstr "Extern"
 
 #: ./patterns/tinymce/pattern.js
 msgid "External Image"
-msgstr ""
+msgstr "Externes Bild"
 
 #: ./patterns/tinymce/pattern.js
 msgid "External Image URL (can be relative within this site or absolute if it starts with http:// or https://)"
@@ -413,7 +413,7 @@ msgstr "Der Dateiname muss mit ++plone++static/ anfangen"
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
-msgstr ""
+msgstr "Filter"
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Filter..."
@@ -457,7 +457,7 @@ msgstr "Vollbild"
 
 #: ./patterns/relateditems/pattern.js
 msgid "Go one level up"
-msgstr ""
+msgstr "Eine Ebene höher"
 
 #: ./patterns/thememapper/pattern.js
 msgid "HTML mockup"
@@ -473,7 +473,7 @@ msgstr "Bild"
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "In production, the bundle is merged together with others. Select which one here."
-msgstr ""
+msgstr "Im Produktions-Modus wird das Bundle mit anderen zusammengefügt. Wählen Sie hier mit welchen."
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Init"
@@ -485,7 +485,7 @@ msgstr "Initialisierungs-Anweisung für RequireJS Shim"
 
 #: ./patterns/tinymce/pattern.js
 msgid "Inline"
-msgstr ""
+msgstr "Inline"
 
 #: ./patterns/tinymce/pattern.js
 msgid "Insert"
@@ -505,7 +505,7 @@ msgstr "Intern"
 
 #: ./patterns/tinymce/pattern.js
 msgid "Internal Image"
-msgstr ""
+msgstr "Internes Bild"
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Internet Explorer conditional comment"
@@ -525,7 +525,7 @@ msgstr "Zeitpunkt der letzten Kompilierung"
 
 #: ./patterns/tinymce/pattern.js
 msgid "Left"
-msgstr ""
+msgstr "Links"
 
 #: ./patterns/resourceregistry/pattern.js
 msgid "Less Variables"
@@ -537,11 +537,11 @@ msgstr "Liste der CSS/LESS-Dateien für diese Ressource"
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Load JavaScript asynchronously?"
-msgstr ""
+msgstr "JavaScript asynchron laden?"
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Load JavaScript deferred?"
-msgstr ""
+msgstr "JavaScript deferred laden?"
 
 #: ./patterns/structure/js/views/generic-popover.js
 msgid "Loading..."
@@ -557,11 +557,11 @@ msgstr "Auswahl ändern"
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Merge with"
-msgstr ""
+msgstr "Mergen mit"
 
 #: ./patterns/toolbar/pattern.js
 msgid "More"
-msgstr ""
+msgstr "Mehr"
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Name"
@@ -709,7 +709,7 @@ msgstr "Basis-URL der Ressource"
 
 #: ./patterns/tinymce/pattern.js
 msgid "Responsive"
-msgstr ""
+msgstr "Responsiv"
 
 #: ./patterns/structure/js/views/rearrange.js
 msgid "Reverse"
@@ -721,7 +721,7 @@ msgstr "Umgekehrte Reihenfolge"
 
 #: ./patterns/tinymce/pattern.js
 msgid "Right"
-msgstr ""
+msgstr "Rechts"
 
 #: ./patterns/thememapper/js/rulebuilderview.js
 msgid "Rule Builder"
@@ -797,11 +797,11 @@ msgstr "Sortieren nach"
 
 #: ./patterns/tinymce/pattern.js
 msgid "Specify an image. It can be on this site already (Internal Image), an image you upload (Upload), or from an external site (External Image)."
-msgstr ""
+msgstr "Wählen Sie ein Bild. Es kann bereits auf der Seite sein (Internes Bild), ein Bild sein, dass Sie hochladen (Hochladen) oder ein Bild auf einer externen Seite sein (Externes Bild)."
 
 #: ./patterns/tinymce/pattern.js
 msgid "Specify the object to link to. It can be on this site already (Internal), an object you upload (Upload), from an external site (External), an email address (Email), or an anchor on this page (Anchor)."
-msgstr ""
+msgstr "Wählen sie einen Inhalt zum verlinken aus. Der Inhalt kann bereits auf der Seite sein (Intern), ein Inhalt sein, den Sie hochladen (Hochladen), ein Inhalt auf einer externen Seite sein (Extern), eine E-Mail Adresse (E-Mail) oder ein Anker auf dieser Seite (Anker)."
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Stop Developing CSS"
@@ -833,7 +833,7 @@ msgstr "Beim Absenden des Formulars ist ein Fehler aufgetreten."
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "This listing has filters applied. Not all items are shown."
-msgstr ""
+msgstr "Diese Liste ist gefiltert. Nicht alle Inhalte werden angezeigt."
 
 #: ./patterns/structure/js/views/rearrange.js
 msgid "This permanently changes the order of items in this folder. This operation may take a long time depending on the size of the folder."
@@ -909,7 +909,7 @@ msgstr "kopiere"
 
 #: ./patterns/relateditems/pattern.js
 msgid "current directory:"
-msgstr ""
+msgstr "aktuelles Verzeichnis:"
 
 #: ./patterns/resourceregistry/js/overrides.js
 msgid "customized"

--- a/plone/app/locales/locales/de/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/widgets.po
@@ -151,10 +151,6 @@ msgstr "CSS/LESS"
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr "Sortieren ist während einer Abfrage nicht möglich"
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr "Datei wählen"
@@ -279,6 +275,10 @@ msgstr "Enthält das Bundle RequireJS oder LESS?"
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr "Ziehen Sie Dateien von Ihrem Computer in den Bereich unten oder klicken Sie auf die Durchsuchen Schaltfläche."
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr "Sortieren ist während einer Abfrage nicht möglich"
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr "Dateien hierher ziehen..."
@@ -380,6 +380,14 @@ msgid "Expression"
 msgstr "Ausdruck"
 
 #: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
 msgid "External Image URL (can be relative within this site or absolute if it starts with http:// or https://)"
 msgstr "URL des externen Bildes (kann relativ innerhalb dieser Seite sein oder absolut, wenn sie mit http:// or https:// beginnt)"
 
@@ -405,7 +413,7 @@ msgstr "Der Dateiname muss mit ++plone++static/ anfangen"
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
-msgstr "Filter"
+msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Filter..."
@@ -647,10 +655,6 @@ msgstr "Zurück"
 msgid "Previous month"
 msgstr "Vorheriger Monat"
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr "Abfrage"
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr "Neu ordnen"
@@ -826,6 +830,10 @@ msgstr "Beim Suchen ist ein Fehler aufgetreten…"
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
 msgstr "Beim Absenden des Formulars ist ein Fehler aufgetreten."
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
+msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js
 msgid "This permanently changes the order of items in this folder. This operation may take a long time depending on the size of the folder."

--- a/plone/app/locales/locales/de/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/de/LC_MESSAGES/widgets.po
@@ -152,7 +152,7 @@ msgid "Cancel"
 msgstr "Abbrechen"
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr "Sortieren ist während einer Abfrage nicht möglich"
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/el/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/el/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/el/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/el/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/en/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/en/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/en/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/en/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/en_AU/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/en_AU/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/en_AU/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/en_AU/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/en_GB/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/en_GB/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/en_GB/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/en_GB/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/eo/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/eo/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/eo/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/eo/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/es/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/es/LC_MESSAGES/widgets.po
@@ -152,10 +152,6 @@ msgstr "CSS/LESS"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr "No se pueden ordenar los elementos mientras se hace la búsqueda"
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr "Seleccionar Archivo"
@@ -280,6 +276,10 @@ msgstr "¿Contiene su paquete algún archivo RequireJS o LESS?"
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr "Arrastre archivos desde el ordenador o haga click en el botón Examinar"
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr "No se pueden ordenar los elementos mientras se hace la búsqueda"
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr "Soltar archivos aquí..."
@@ -381,6 +381,14 @@ msgid "Expression"
 msgstr "Expresión"
 
 #: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
 msgid "External Image URL (can be relative within this site or absolute if it starts with http:// or https://)"
 msgstr "Imágen externa (puede ser relativa al sitio o absoluta si comienza por http:// o https://)"
 
@@ -406,7 +414,7 @@ msgstr "El nombre de archivo debe empezar con ++plone++static/"
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
-msgstr "Filtro"
+msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Filter..."
@@ -648,10 +656,6 @@ msgstr "Anterior"
 msgid "Previous month"
 msgstr "Mes anterior"
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr "Consultar"
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr "Reorganizar"
@@ -827,6 +831,10 @@ msgstr "Ha ocurrido un error buscando…"
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
 msgstr "Ha ocurrido un error al enviar el formulario."
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
+msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js
 msgid "This permanently changes the order of items in this folder. This operation may take a long time depending on the size of the folder."

--- a/plone/app/locales/locales/es/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/es/LC_MESSAGES/widgets.po
@@ -153,7 +153,7 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr "No se pueden ordenar los elementos mientras se hace la búsqueda"
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/et/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/et/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/et/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/et/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/eu/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/eu/LC_MESSAGES/widgets.po
@@ -149,10 +149,6 @@ msgstr "CSS/LESS"
 msgid "Cancel"
 msgstr "Utzi"
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr "Ezin dira elementuak ordenatu bilaketa egiten den artean"
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr "Fitxategia aukeratu"
@@ -277,6 +273,10 @@ msgstr "Zure bildumak RequireJS edo LESS fitxategirik ba al du?"
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr "Arrastatu fitxategiak hona edo erabili Arakatu botoia."
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr "Ezin dira elementuak ordenatu bilaketa egiten den artean"
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr "Arrastatu fitxategiak hona..."
@@ -378,6 +378,14 @@ msgid "Expression"
 msgstr "Espresioa"
 
 #: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
 msgid "External Image URL (can be relative within this site or absolute if it starts with http:// or https://)"
 msgstr "Kanpoko irudi baten URLa (atariarekiko edo absolutua izan daiteke, kasu honetan http:// edo https://-rekin hasten bada)"
 
@@ -403,7 +411,7 @@ msgstr "Fitxategi izena ++plone++static/ -ekin hasi behar da"
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
-msgstr "Filtroa"
+msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Filter..."
@@ -645,10 +653,6 @@ msgstr "Aurrekoa"
 msgid "Previous month"
 msgstr "Aurreko hilabetea"
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr "Bilaketa"
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr "Birordenatu"
@@ -824,6 +828,10 @@ msgstr "Errorea gertatu da bilaketa egitean..."
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
 msgstr "Errorea gertatu da formularioa bidaltzean."
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
+msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js
 msgid "This permanently changes the order of items in this folder. This operation may take a long time depending on the size of the folder."

--- a/plone/app/locales/locales/eu/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/eu/LC_MESSAGES/widgets.po
@@ -150,7 +150,7 @@ msgid "Cancel"
 msgstr "Utzi"
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr "Ezin dira elementuak ordenatu bilaketa egiten den artean"
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/fa/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/fa/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/fa/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/fa/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/fi/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/fi/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/fi/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/fi/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/fr/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/fr/LC_MESSAGES/widgets.po
@@ -150,10 +150,6 @@ msgstr "CSS/LESS"
 msgid "Cancel"
 msgstr "Annuler"
 
-#: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
-msgstr "Impossible d'ordonner des éléments lors d'une requête"
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr "Choisir un fichier"
@@ -278,6 +274,10 @@ msgstr "Votre bundle contient-il des fichiers RequireJS ou LESS ?"
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr "Glissez-déposez des fichiers de votre ordinateur dans la zone ci-dessous ou cliquez sur le bouton Parcourir."
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr "Déposer les fichiers ici..."
@@ -379,6 +379,14 @@ msgid "Expression"
 msgstr "Expression"
 
 #: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
 msgid "External Image URL (can be relative within this site or absolute if it starts with http:// or https://)"
 msgstr "URL de l'image externe (peut être un chemin relatif dans ce site ou absolu s'il commence par http:// ou https://)"
 
@@ -404,7 +412,7 @@ msgstr "Le nom de fichier doit commencer par ++plone++static/"
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
-msgstr "Filtre"
+msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Filter..."
@@ -646,10 +654,6 @@ msgstr "Précédent"
 msgid "Previous month"
 msgstr "Mois précédent"
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr "Requête"
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr "Réordonner"
@@ -825,6 +829,10 @@ msgstr "Il y a eu une erreur en cherchant…"
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
 msgstr "Il y a eu une erreur pendant la soumission du formulaire"
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
+msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js
 msgid "This permanently changes the order of items in this folder. This operation may take a long time depending on the size of the folder."

--- a/plone/app/locales/locales/fu/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/fu/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/fu/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/fu/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/gl/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/gl/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/gl/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/gl/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/he/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/he/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/he/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/he/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/hi/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/hi/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/hi/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/hi/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/hr/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/hr/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/hr/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/hr/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/hu/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/hu/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/hu/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/hu/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/hy/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/hy/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/hy/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/hy/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/id/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/id/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/id/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/id/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/it/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/it/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr "CSS/LESS"
 msgid "Cancel"
 msgstr "Annulla"
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr "Non è possibile ordinare gli elementi durante l’interrogazione"
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr "Scegli file"
@@ -275,6 +271,10 @@ msgstr "Questo bundle contiene file RequireJS o LESS?"
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr "Trascina i file dal tuo computer nell'area sottostante o clicca sul pulsante Esplora."
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr "Non è possibile ordinare gli elementi durante l’interrogazione"
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr "Trascina i file qua..."
@@ -376,6 +376,14 @@ msgid "Expression"
 msgstr "Espressione"
 
 #: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
 msgid "External Image URL (can be relative within this site or absolute if it starts with http:// or https://)"
 msgstr "URL immagine esterna (può essere relativa a questo sito oppure assoluta se inizia per http:// o https://)"
 
@@ -401,7 +409,7 @@ msgstr "Il nome del file deve iniziare con ++plone++static/"
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
-msgstr "Filtro"
+msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Filter..."
@@ -643,10 +651,6 @@ msgstr "Precedente"
 msgid "Previous month"
 msgstr "Mese precedente"
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr "Filtra"
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr "Riordina"
@@ -822,6 +826,10 @@ msgstr "Errore in fase di ricerca…"
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
 msgstr "Errore in fase di sottomissione del modulo."
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
+msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js
 msgid "This permanently changes the order of items in this folder. This operation may take a long time depending on the size of the folder."

--- a/plone/app/locales/locales/it/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/it/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr "Annulla"
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr "Non è possibile ordinare gli elementi durante l’interrogazione"
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/ja/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/ja/LC_MESSAGES/widgets.po
@@ -148,10 +148,6 @@ msgstr ""
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr "ファイルを選択"
@@ -276,6 +272,10 @@ msgstr "バンドルにはRequireJSあるいはLESSのファイルが含まれ�
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr "コンピュータから以下の領域にファイルをドラッグ＆ドロップするか、[参照]ボタンをクリックします。"
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr "ここにファイルをドラッグ&ドロップ..."
@@ -377,6 +377,14 @@ msgid "Expression"
 msgstr "条件式"
 
 #: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
 msgid "External Image URL (can be relative within this site or absolute if it starts with http:// or https://)"
 msgstr "サイト外画像のURL（http://またはhttps://から始まる絶対パス）"
 
@@ -402,7 +410,7 @@ msgstr "ファイル名は ++plone++static/ から必ず始める"
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
-msgstr "フィルター"
+msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Filter..."
@@ -644,10 +652,6 @@ msgstr "前へ"
 msgid "Previous month"
 msgstr "前月"
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr "クエリー"
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr "並び替え"
@@ -823,6 +827,10 @@ msgstr "検索でエラーが発生しました..."
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
 msgstr "フォームの投稿でエラーが発生しました"
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
+msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js
 msgid "This permanently changes the order of items in this folder. This operation may take a long time depending on the size of the folder."

--- a/plone/app/locales/locales/ka/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/ka/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/ka/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/ka/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/kn/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/kn/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/kn/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/kn/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/ko/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/ko/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/ko/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/ko/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/lt/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/lt/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/lt/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/lt/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/lv/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/lv/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/lv/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/lv/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/mi/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/mi/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/mi/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/mi/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/mk_MK/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/mk_MK/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/mk_MK/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/mk_MK/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/my/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/my/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/my/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/my/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/nl/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/nl/LC_MESSAGES/widgets.po
@@ -149,10 +149,6 @@ msgstr ""
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr "Kies bestand"
@@ -277,6 +273,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr "Drop hier uw bestanden..."
@@ -376,6 +376,14 @@ msgstr ""
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
 msgstr "Expressie"
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
+msgstr ""
 
 #: ./patterns/tinymce/pattern.js
 msgid "External Image URL (can be relative within this site or absolute if it starts with http:// or https://)"
@@ -645,10 +653,6 @@ msgstr "Vorige"
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr "Zoek"
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr "Sorteren"
@@ -824,6 +828,10 @@ msgstr "Fout tijdens het zoeken…"
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
 msgstr "Er was een fout bij het verzenden van het formulier."
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
+msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js
 msgid "This permanently changes the order of items in this folder. This operation may take a long time depending on the size of the folder."

--- a/plone/app/locales/locales/nl/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/nl/LC_MESSAGES/widgets.po
@@ -150,7 +150,7 @@ msgid "Cancel"
 msgstr "Annuleren"
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/nn/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/nn/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/nn/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/nn/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/no/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/no/LC_MESSAGES/widgets.po
@@ -152,10 +152,6 @@ msgstr "CSS/LESS"
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr "Velg fil"
@@ -282,6 +278,10 @@ msgstr "Indeholder din bundle RequireJS- eller LESS-filer?"
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr "Dra og slipp filer fra datamaskinen til området under eller klikk på Bla gjennom-knappen."
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr "Slip filer her..."
@@ -386,6 +386,14 @@ msgid "Expression"
 msgstr "Uttryk"
 
 #: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
 msgid "External Image URL (can be relative within this site or absolute if it starts with http:// or https://)"
 msgstr "Ekstern bildeadresse (kan være relativt innenfor dette nettstedet eller absolutt hvis det starter med http: // eller https: //)"
 
@@ -411,7 +419,7 @@ msgstr "Filnavn må starte med ++plone++static/"
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
-msgstr "Filtrer"
+msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Filter..."
@@ -659,10 +667,6 @@ msgstr "Forrige"
 msgid "Previous month"
 msgstr "Forrige måned"
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr "Søk"
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr "Sorter"
@@ -845,6 +849,10 @@ msgstr "Søgningen kunne ikke udføres…"
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
 msgstr "Formularen kunne ikke indsendes."
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
+msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js
 msgid "This permanently changes the order of items in this folder. This operation may take a long time depending on the size of the folder."

--- a/plone/app/locales/locales/no/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/no/LC_MESSAGES/widgets.po
@@ -153,7 +153,7 @@ msgid "Cancel"
 msgstr "Avbryt"
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/pl/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/pl/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/pl/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/pl/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/pt/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/pt/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/pt/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/pt/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/pt_BR/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/pt_BR/LC_MESSAGES/widgets.po
@@ -151,10 +151,6 @@ msgstr "CSS/LESS"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr "Escolher arquivo"
@@ -279,6 +275,10 @@ msgstr "Seu pacote contém algum arquivo LESS ou RequireJS?"
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr "Arraste e solte arquivos do seu computador na área em baixo o selecione o botão Procurar."
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr "Arrasta arquivos aqui..."
@@ -380,6 +380,14 @@ msgid "Expression"
 msgstr "Expressão"
 
 #: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
 msgid "External Image URL (can be relative within this site or absolute if it starts with http:// or https://)"
 msgstr "URL da imagem externa (pode ser relativa com respeito ao site ou absoluta se inicia com http:// ou https://)"
 
@@ -405,7 +413,7 @@ msgstr "Nome do arquivo deve começar com ++plone++static/"
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
-msgstr "Filtrar"
+msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Filter..."
@@ -647,10 +655,6 @@ msgstr "Anterior"
 msgid "Previous month"
 msgstr "Mês anterior"
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr "Consultar"
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr "Reorganizar"
@@ -826,6 +830,10 @@ msgstr "Houve um erro durante a busca…"
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
 msgstr "Houve um erro durante o envio do formulário."
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
+msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js
 msgid "This permanently changes the order of items in this folder. This operation may take a long time depending on the size of the folder."

--- a/plone/app/locales/locales/pt_BR/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/pt_BR/LC_MESSAGES/widgets.po
@@ -152,7 +152,7 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/rm/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/rm/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/rm/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/rm/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/ro/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/ro/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/ro/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/ro/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/ru/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/ru/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr "Отмена"
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/ru/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/ru/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr "Отмена"
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr "Выбрать файл"
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr "Перетащите сюда файл..."
@@ -376,6 +376,14 @@ msgid "Expression"
 msgstr "Выражение"
 
 #: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
 msgid "External Image URL (can be relative within this site or absolute if it starts with http:// or https://)"
 msgstr ""
 
@@ -401,7 +409,7 @@ msgstr ""
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
-msgstr "Фильтр"
+msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Filter..."
@@ -643,10 +651,6 @@ msgstr "Предыдущий"
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr "Запрос"
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr "Пересроить"
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/sk/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/sk/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/sk/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/sk/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/sl/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/sl/LC_MESSAGES/widgets.po
@@ -4,10 +4,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: mockup\n"
-"POT-Creation-Date: 2019-09-09 13:10+0000\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "PO-Revision-Date: 2019-09-19 12:08+0200\n"
 "Last-Translator: Matjaž Jeran <matjaz.jeran@amis.net>\n"
-"Translator: Robert Kuzma <robert@balavec.com>\n"
 "Language-Team: Slovenian <lugos-slo@lugos.si>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,6 +16,7 @@ msgstr ""
 "Language-Name: Slovenian\n"
 "Preferred-Encodings: utf-8\n"
 "Domain: widgets\n"
+"Translator: Robert Kuzma <robert@balavec.com>\n"
 "Language: sl\n"
 "X-Generator: Poedit 2.2.3\n"
 
@@ -152,10 +152,6 @@ msgstr "CSS/LESS"
 msgid "Cancel"
 msgstr "Prekliči"
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr "Ne morem urediti prispevkov ob sočasni poizvedbi"
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr "Izberite datoteko"
@@ -280,6 +276,10 @@ msgstr "Ali vaš sveženj vsebuje datoteke RequireJS ali LESS?"
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr "Zgrabite in povlecite datoteke z vašega računalnika na spodnjo površino ali kliknite na gumb Brskaj."
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr "Ne morem urediti prispevkov ob sočasni poizvedbi"
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr "Spusti datoteke tu..."
@@ -381,6 +381,14 @@ msgid "Expression"
 msgstr "Izraz"
 
 #: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
 msgid "External Image URL (can be relative within this site or absolute if it starts with http:// or https://)"
 msgstr "Eksterni naslov slike (lahko je relativni naslov glede na to spletišč ali absolutni naslov, če se začne z http:// or https://)"
 
@@ -406,7 +414,7 @@ msgstr "Ime datoteke se mora pričeti s ++plone++static/"
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
-msgstr "Filter"
+msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Filter..."
@@ -648,10 +656,6 @@ msgstr "Prejšnji"
 msgid "Previous month"
 msgstr "Prejšnji mesec"
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr "Iskanje"
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr "Prestavi"
@@ -827,6 +831,10 @@ msgstr "Napaka pri iskanju..."
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
 msgstr "Prišlo je do napake pri predaji obrazca."
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
+msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js
 msgid "This permanently changes the order of items in this folder. This operation may take a long time depending on the size of the folder."

--- a/plone/app/locales/locales/sl/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/sl/LC_MESSAGES/widgets.po
@@ -153,7 +153,7 @@ msgid "Cancel"
 msgstr "Prekliči"
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr "Ne morem urediti prispevkov ob sočasni poizvedbi"
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/sm/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/sm/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/sm/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/sm/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/sq/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/sq/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/sq/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/sq/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/sr/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/sr/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/sr/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/sr/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/sr_Latn/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/sr_Latn/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/sr_Latn/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/sr_Latn/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/sv/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/sv/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/sv/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/sv/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/ta/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/ta/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/ta/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/ta/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/te/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/te/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/te/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/te/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/th/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/th/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/th/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/th/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/to/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/to/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/to/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/to/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/tr/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/tr/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/tr/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/tr/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/uk/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/uk/LC_MESSAGES/widgets.po
@@ -151,7 +151,7 @@ msgid "Cancel"
 msgstr "Скасувати"
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/uk/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/uk/LC_MESSAGES/widgets.po
@@ -150,10 +150,6 @@ msgstr "CSS/LESS"
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr "Вибрати файл"
@@ -278,6 +274,10 @@ msgstr "Ваш пакунок містить RequireJS чи LESS файли?"
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr "Закиньте файли сюди"
@@ -379,6 +379,14 @@ msgid "Expression"
 msgstr "Вираз"
 
 #: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
 msgid "External Image URL (can be relative within this site or absolute if it starts with http:// or https://)"
 msgstr ""
 
@@ -404,7 +412,7 @@ msgstr "Назва файлу повинна починатись з ++plone++st
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
-msgstr "Фільтрувати"
+msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Filter..."
@@ -646,10 +654,6 @@ msgstr "Попередня"
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr "Запит"
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr "Впорядкувати"
@@ -825,6 +829,10 @@ msgstr "Виникла помилка при пошуку..."
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
 msgstr "Виникла помилка при поданні форми."
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
+msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js
 msgid "This permanently changes the order of items in this folder. This operation may take a long time depending on the size of the folder."

--- a/plone/app/locales/locales/vi/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/vi/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/vi/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/vi/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/widgets.pot
+++ b/plone/app/locales/locales/widgets.pot
@@ -713,16 +713,16 @@ msgstr ""
 msgid "Notice: Drag and drop reordering is disabled when viewing the contents sorted by a column."
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
 msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
-msgstr ""
-
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
 msgstr ""
 
 #: ./patterns/structure/templates/paging.xml
@@ -862,6 +862,10 @@ msgid "Internal"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
 msgid "External URL (can be relative within this site or absolute if it starts with http:// or https://)"
 msgstr ""
 
@@ -899,6 +903,10 @@ msgstr ""
 
 #: ./patterns/tinymce/pattern.js
 msgid "Internal Image"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js

--- a/plone/app/locales/locales/widgets.pot
+++ b/plone/app/locales/locales/widgets.pot
@@ -714,7 +714,7 @@ msgid "Notice: Drag and drop reordering is disabled when viewing the contents so
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/structure/js/views/textfilter.js

--- a/plone/app/locales/locales/zh_CN/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/zh_CN/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr "CSS/LESS"
 msgid "Cancel"
 msgstr "取消"
 
-#: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr "选择文件"
@@ -275,6 +271,10 @@ msgstr "此包是否包含任何RequireJS或LESS文件？"
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr "将文件拖至此处..."
@@ -376,6 +376,14 @@ msgid "Expression"
 msgstr "表达式"
 
 #: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
 msgid "External Image URL (can be relative within this site or absolute if it starts with http:// or https://)"
 msgstr ""
 
@@ -401,7 +409,7 @@ msgstr "文件名必须以 ++plone++static/ 开头"
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
-msgstr "筛选器"
+msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Filter..."
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr "查询"
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr "重排"
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/zh_HK/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/zh_HK/LC_MESSAGES/widgets.po
@@ -148,7 +148,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
+msgid "Drag and drop reordering is disabled while filters are applied."
 msgstr ""
 
 #: ./patterns/upload/templates/upload.xml

--- a/plone/app/locales/locales/zh_HK/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/zh_HK/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./patterns/structure/js/views/table.js
-msgid "Drag and drop reordering is disabled while filters are applied."
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr ""
@@ -275,6 +271,10 @@ msgstr ""
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr ""
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr ""
@@ -373,6 +373,14 @@ msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Expression"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
 msgstr ""
 
 #: ./patterns/tinymce/pattern.js
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr ""
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr ""
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr ""
@@ -821,6 +825,10 @@ msgstr ""
 
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
+msgstr ""
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
 msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js

--- a/plone/app/locales/locales/zh_TW/LC_MESSAGES/widgets.po
+++ b/plone/app/locales/locales/zh_TW/LC_MESSAGES/widgets.po
@@ -147,10 +147,6 @@ msgstr "CSS/LESS"
 msgid "Cancel"
 msgstr "取消"
 
-#: ./patterns/structure/js/views/table.js
-msgid "Cannot order items while querying"
-msgstr ""
-
 #: ./patterns/upload/templates/upload.xml
 msgid "Choose File"
 msgstr "選擇檔案"
@@ -275,6 +271,10 @@ msgstr "Bundle 是否包含 RequireJS 或 LESS 檔案?"
 msgid "Drag and drop files from your computer onto the area below or click the Browse button."
 msgstr "從電腦拖拉檔案至此或點選瀏覽按鈕"
 
+#: ./patterns/structure/js/views/textfilter.js
+msgid "Drag and drop reordering is disabled while filters are applied."
+msgstr ""
+
 #: ./patterns/upload/templates/upload.xml
 msgid "Drop files here..."
 msgstr "拖拉檔案至此..."
@@ -376,6 +376,14 @@ msgid "Expression"
 msgstr "表示式"
 
 #: ./patterns/tinymce/pattern.js
+msgid "External"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
+msgid "External Image"
+msgstr ""
+
+#: ./patterns/tinymce/pattern.js
 msgid "External Image URL (can be relative within this site or absolute if it starts with http:// or https://)"
 msgstr "外部圖檔網址 (可以是站內的相對路徑或 http:// 之類的站外絕對路徑)"
 
@@ -401,7 +409,7 @@ msgstr "檔名要以 ++plone++static/ 開頭"
 
 #: ./patterns/structure/js/views/textfilter.js
 msgid "Filter"
-msgstr "過濾"
+msgstr ""
 
 #: ./patterns/resourceregistry/js/registry.js
 msgid "Filter..."
@@ -643,10 +651,6 @@ msgstr ""
 msgid "Previous month"
 msgstr "上個月"
 
-#: ./patterns/structure/js/views/textfilter.js
-msgid "Query"
-msgstr "查詢"
-
 #: ./patterns/structure/js/views/app.js
 msgid "Rearrange"
 msgstr "確認排序"
@@ -822,6 +826,10 @@ msgstr "搜尋時發生錯誤..."
 #: ./patterns/modal/pattern.js
 msgid "There was an error submitting the form."
 msgstr "送出表單時發生錯誤。"
+
+#: ./patterns/structure/js/views/textfilter.js
+msgid "This listing has filters applied. Not all items are shown."
+msgstr ""
 
 #: ./patterns/structure/js/views/rearrange.js
 msgid "This permanently changes the order of items in this folder. This operation may take a long time depending on the size of the folder."


### PR DESCRIPTION
- Synchronize with latest mockup.
- Structure pattern: Change message from misleading "Cannot order items while querying" to "Drag and drop reordering is disabled while filters are applied.".
  Fixes: https://github.com/collective/plone.app.locales/issues/173

Merge together:
https://github.com/plone/mockup/pull/937
https://github.com/collective/plone.app.locales/pull/286