### PR TITLE
Review all italian translations for Plone core

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 5.1.26 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Update Italian translations
+  [lelit]
 
 
 5.1.25 (2020-09-22)

--- a/plone/app/locales/locales/it/LC_MESSAGES/cmfplacefulworkflow.po
+++ b/plone/app/locales/locales/it/LC_MESSAGES/cmfplacefulworkflow.po
@@ -1,13 +1,14 @@
 # Translation of cmfplacefulworkflow.pot to Italian
-# Lele Gaifax, 2007, 2017
+# Lele Gaifax, 2007, 2017, 2020
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: CMFPlacefulWorkflow\n"
 "POT-Creation-Date: 2019-03-27 18:18+0000\n"
-"PO-Revision-Date: 2017-04-07 12:57+0200\n"
+"PO-Revision-Date: 2020-10-04 16:56+0200\n"
 "Last-Translator: Giorgio Borelli <giorgio@giorgioborelli.it>\n"
-"Language-Team: Plone italian translation project <plone-italian-translation-discussion@lists.coactivate.org>\n"
+"Language-Team: Plone italian translation project "
+"<plone-italian-translation-discussion@lists.coactivate.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -17,6 +18,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: cmfplacefulworkflow\n"
 "X-Is-Fallback-For: it-ch it-it\n"
+"Language: it\n"
 
 #: ./profiles.zcml
 msgid "Add in Plone the capability to change workflow chains for types in every object."
@@ -56,7 +58,7 @@ msgstr "Politica di workflow locale aggiunta."
 
 #: CMFPlacefulWorkflow/browser/views.py:108
 msgid "No Policy selected."
-msgstr ""
+msgstr "Nessuna politica selezionata."
 
 #: CMFPlacefulWorkflow/browser/views.py:43
 msgid "No config in this folder."
@@ -96,7 +98,7 @@ msgstr "Supporto per le politiche di workflow (CMFPlacefulWorkflow) - senza alcu
 
 #: CMFPlacefulWorkflow/profiles.zcml:29
 msgid "Workflow Policy Support (CMFPlacefulWorkflow) [uninstall]"
-msgstr ""
+msgstr "Supporto per le politiche di workflow (CMFPlacefulWorkflow) [disinstalla]"
 
 #: CMFPlacefulWorkflow/browser/views.py:25
 msgid "Workflow policy configuration added."

--- a/plone/app/locales/locales/it/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/it/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 #
 # Giancarlo & Lele Gaifas, 2002-2009.
 # Alessandro Pisa <alessandro.pisa@gmail.com>, 2015-2020.
-# Lele Gaifas, 2017.
+# Lele Gaifas, 2017, 2020.
 # Andrea Cecchi, 2018-2020.
 # Giacomo Monari, 2017-2020.
 #
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI +ZONE\n"
-"PO-Revision-Date: 2017-04-07 15:05+0200\n"
-"Last-Translator: Alessandro Pisa <alessandro.pisa@gmail.com>\n"
+"PO-Revision-Date: 2020-10-04 17:07+0200\n"
+"Last-Translator: Lele Gaifax <lele@metapensiero.it>\n"
 "Language-Team: Italian <Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -308,7 +308,7 @@ msgstr "Un portlet per l'inserimento dei termini da ricercare."
 
 #: plone.app.caching/plone/app/caching/browser/controlpanel.py:282
 msgid "A positive number is required."
-msgstr "E' richiesto un numero positivo."
+msgstr "È richiesto un numero positivo."
 
 #: plone.app.caching/plone/app/caching/caching.zcml:69
 msgid "A public-facing view for a content item that is a folder or container for other items"
@@ -439,15 +439,15 @@ msgstr "Aggiungi ${name}"
 
 #: plone.app.event/plone/app/event/portlets/portlet_calendar.py:303
 msgid "Add Calendar Portlet"
-msgstr "Aggiungi una portlet Calendario"
+msgstr "Aggiungi portlet Calendario"
 
 #: plone.app.portlets/plone/app/portlets/portlets/classic.py:60
 msgid "Add Classic Portlet"
-msgstr "Aggiungi un portlet classico"
+msgstr "Aggiungi portlet Classico"
 
 #: plone.portlet.collection/plone/portlet/collection/collection.py:308
 msgid "Add Collection Portlet"
-msgstr "Aggiungi un portlet sulle collezioni"
+msgstr "Aggiungi portlet Collezioni"
 
 #: plone.app.dexterity/plone/app/dexterity/browser/add_type.py:31
 msgid "Add Content Type"
@@ -463,7 +463,7 @@ msgstr "Aggiungi azione di copia"
 
 #: plone.app.event/plone/app/event/portlets/portlet_events.py:223
 msgid "Add Events Portlet"
-msgstr "Aggiungi una portlet Eventi"
+msgstr "Aggiungi portlet Eventi"
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/fileextension.py:90
 msgid "Add File Extension Condition"
@@ -487,7 +487,7 @@ msgstr "Aggiungi azione sposta"
 
 #: plone.app.portlets/plone/app/portlets/portlets/navigation.py:376
 msgid "Add Navigation Portlet"
-msgstr "Aggiungi il portlet di navigazione"
+msgstr "Aggiungi portlet Navigazione"
 
 #: plone.app.dexterity/plone/app/dexterity/browser/types_listing.pt:25
 msgid "Add New Content Type&hellip;"
@@ -499,7 +499,7 @@ msgstr "Aggiunta di un nuovo elemento: operazione cancellata"
 
 #: plone.app.portlets/plone/app/portlets/portlets/news.py:143
 msgid "Add News Portlet"
-msgstr "Aggiungi il portlet delle notizie"
+msgstr "Aggiungi portlet Notizie"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/notify.py:80
 msgid "Add Notify Action"
@@ -507,15 +507,15 @@ msgstr "Aggiungi azione di notifica"
 
 #: plone.app.portlets/plone/app/portlets/portlets/rss.py:346
 msgid "Add RSS Portlet"
-msgstr "Aggiungi un portlet RSS"
+msgstr "Aggiungi portlet RSS"
 
 #: plone.app.portlets/plone/app/portlets/portlets/recent.py:158
 msgid "Add Recent Portlet"
-msgstr "Aggiungi portlet modifiche recenti"
+msgstr "Aggiungi portlet Modifiche recenti"
 
 #: plone.app.portlets/plone/app/portlets/portlets/review.py:157
 msgid "Add Review Portlet"
-msgstr "Aggiungi portlet di revisione"
+msgstr "Aggiungi portlet Revisione"
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/role.py:81
 msgid "Add Role Condition"
@@ -527,7 +527,7 @@ msgstr "Aggiungi regola"
 
 #: plone.app.portlets/plone/app/portlets/portlets/search.py:61
 msgid "Add Search Portlet"
-msgstr "Aggiungi portlet di ricerca"
+msgstr "Aggiungi portlet Ricerca"
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/talesexpression.py:74
 msgid "Add TALES Expression Condition"
@@ -563,11 +563,11 @@ msgstr "Aggiungi nuova azione"
 
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/add_field.py:28
 msgid "Add new field"
-msgstr "Aggiungi un nuovo campo"
+msgstr "Aggiungi nuovo campo"
 
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/add_fieldset.py:21
 msgid "Add new fieldset"
-msgstr "Aggiungi un nuovo insieme di campi"
+msgstr "Aggiungi nuovo insieme di campi"
 
 #: CMFPlone/PloneControlPanel.py:76
 msgid "Add-on Configuration"
@@ -591,7 +591,7 @@ msgstr "File aggiunti"
 
 #: plone.app.versioningbehavior/plone/app/versioningbehavior/configure.zcml:59
 msgid "Adds CMFEditions support for Dexterity."
-msgstr "Aggiungi il versionamento per Dexterity (CMFEditions)."
+msgstr "Aggiungi supporto CMFEditions per Dexterity."
 
 #: plone.app.dexterity/plone/app/dexterity/configure.zcml:36
 msgid "Adds Dexterity-based Folder and Document types for testing."
@@ -599,39 +599,41 @@ msgstr "Aggiunge i tipi di contenuto Cartelle e Documenti, basati su Dexterity, 
 
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/configure.zcml:37
 msgid "Adds a table of contents"
-msgstr "Aggiunge una tabella dei contenuti"
+msgstr "Aggiunge tabella dei contenuti"
 
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/configure.zcml:47
 msgid "Adds collection behavior"
-msgstr "Aggiunge un comportamento collezione"
+msgstr "Aggiunge comportamento collezione"
 
 #: plone.app.dexterity/plone/app/dexterity/behaviors/configure.zcml:44
 msgid "Adds creator, contributor, and rights fields."
-msgstr "Aggiunge i campi creatore, collaboratore e diritti di utilizzo"
+msgstr "Aggiunge campi creatore, collaboratore e diritti di utilizzo."
 
 #: plone.app.dexterity/plone/app/dexterity/behaviors/configure.zcml:36
 msgid "Adds effective date and expiration date fields."
-msgstr "Aggiunge i campi data di pubblicazione e data di scadenza."
+msgstr "Aggiunge campi data di pubblicazione e data di scadenza."
 
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/configure.zcml:19
 msgid "Adds image and image caption fields"
-msgstr "Aggiunge i campi immagine e didascalia dell'immagine"
+msgstr "Aggiunge campi immagine e didascalia dell'immagine"
 
 #: plone.app.dexterity/plone/app/dexterity/behaviors/configure.zcml:28
 msgid "Adds keywords and language fields."
-msgstr "Aggiunge i campi parole chiave e linguaggio."
+msgstr "Aggiunge campi parole chiave e linguaggio."
 
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/configure.zcml:58
 msgid "Adds richtext behavior"
-msgstr "Aggiunge il comportamento testo formattato"
+msgstr "Aggiunge comportamento testo formattato"
 
 #: plone.app.dexterity/plone/app/dexterity/behaviors/configure.zcml:56
 msgid "Adds standard metadata fields (equals Basic metadata + Categorization + Effective range + Ownership)"
-msgstr "Aggiunge i campi metadata standard (equivale a selezionare Metadata di Base + Categorizzazione + Intervallo di efficacia + Proprietà)"
+msgstr ""
+"Aggiunge campi metadata standard (equivale a selezionare Metadata di Base + "
+"Categorizzazione + Intervallo di efficacia + Proprietà)"
 
 #: plone.app.z3cform/plone/app/z3cform/profiles.zcml:15
 msgid "Adds support for rendering z3c.form forms in Plone"
-msgstr "Aggiunge il supporto a z3cform in Plone"
+msgstr "Aggiunge supporto per rendere moduli z3c.form in Plone"
 
 #: plone.app.referenceablebehavior/plone/app/referenceablebehavior/configure.zcml:17
 msgid "Adds the ability to be referenced by Archetypes items"
@@ -639,7 +641,7 @@ msgstr "Aggiunge la possibilità di essere referenziato da oggetti Archetype"
 
 #: plone.app.dexterity/plone/app/dexterity/behaviors/configure.zcml:20
 msgid "Adds title and description fields."
-msgstr "Aggiunge i campi titolo e descrizione."
+msgstr "Aggiunge campi titolo e descrizione."
 
 #: plone.app.iterate/plone/app/iterate/configure.zcml:34
 msgid "Adds working copy support (aka. in-place staging) to Plone."
@@ -766,7 +768,7 @@ msgstr "Tipi MIME permessi"
 
 #: CMFPlone/interfaces/controlpanel.py:1473
 msgid "Allowed image sizes"
-msgstr "dimensioni consentite"
+msgstr "Dimensioni consentite"
 
 #: CMFPlone/interfaces/controlpanel.py:964
 msgid "Allows users to login with their email address instead of specifying a separate login name. This also updates the login name of existing users, which may take a while on large sites. The login name is saved as lower case, but to be userfriendly it does not matter which case you use to login. When duplicates are found, saving this form will fail. You can use the @@migrate-to-emaillogin page to show the duplicates."
@@ -814,11 +816,15 @@ msgstr "URL alternativi rimossi."
 
 #: CMFPlone/controlpanel/browser/redirects.py:350
 msgid "Alternative urls that point to themselves will cause an endless cycle of redirects."
-msgstr "URL alternativi che puntano a loro stessi, causeranno un ciclo infinito di redirezioni."
+msgstr ""
+"URL alternativi che puntano a loro stessi causano un ciclo infinito di "
+"redirezioni."
 
 #: CMFPlone/controlpanel/browser/redirects.py:434
 msgid "Alternative urls that point to themselves will causean endless cycle of redirects."
-msgstr "URL alternativi che puntano a loro stessi, causeranno un ciclo infinito di redirezioni."
+msgstr ""
+"URL alternativi che puntano a loro stessi causano un ciclo infinito di "
+"redirezioni."
 
 #: CMFPlone/interfaces/controlpanel.py:1054
 msgid "Always"
@@ -838,7 +844,7 @@ msgstr "Un profilo di esempio per la configurazione di un proxy di caching con l
 
 #: plone.app.caching/plone/app/caching/browser/controlpanel.py:279
 msgid "An integer is required."
-msgstr "E' richiesto un numero intero."
+msgstr "È richiesto un numero intero."
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 msgid "An item's description"
@@ -891,7 +897,7 @@ msgstr "Applica solo quando il risultato dell'espressione TALES è vero"
 
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/manage-elements.pt:217
 msgid "Apply rule on the whole site"
-msgstr "Applica la regola all'intero sito."
+msgstr "Applica la regola all'intero sito"
 
 #: plone.app.discussion/plone/app/discussion/browser/moderation.py:29
 msgid "Approve"
@@ -903,7 +909,7 @@ msgstr "L'approvazione rende il commento visibile agli altri utenti."
 
 #: Archetypes/profiles.zcml:12
 msgid "Archetypes"
-msgstr "Archetype"
+msgstr "Archetypes"
 
 #: Archetypes/profiles.zcml:19
 msgid "Archetypes uninstall"
@@ -911,7 +917,7 @@ msgstr "Disinstalla Archetypes"
 
 #: plone.app.collection/plone/app/collection/configure.zcml:19
 msgid "Archetypes-based collections"
-msgstr "Collezioni basate su Archetype"
+msgstr "Collezioni basate su Archetypes"
 
 #: plone.schemaeditor/plone/schemaeditor/browser/schema/schema_listing.pt:130
 msgid "Are you sure you want to delete this field?"
@@ -963,11 +969,13 @@ msgstr "Automaticamente"
 
 #: plone.app.dexterity/plone/app/dexterity/behaviors/configure.zcml:64
 msgid "Automatically generate short URL name for content based on its initial title"
-msgstr "Generazione automatica del nome breve URL per il contenuto in base al suo titolo iniziale"
+msgstr "Genera automaticamente il nome breve URL del contenuto dal suo titolo iniziale"
 
 #: plone.app.dexterity/plone/app/dexterity/behaviors/configure.zcml:72
 msgid "Automatically generate short URL name for content based on its primary field file name"
-msgstr "Generazione automatica del nome breve URL per il contenuto in base al nome del suo campo primario"
+msgstr ""
+"Genera automaticamente il nome breve URL del contenuto dal nome del file "
+"primario"
 
 #: CMFPlone/interfaces/controlpanel.py:745
 msgid "Automatically generate tabs"
@@ -1277,7 +1285,7 @@ msgstr "Scegli i CSS da usare nell'area dell'editor visuale"
 
 #: CMFPlone/profiles/dependencies/portlets.xml
 msgid "Classic portlet"
-msgstr "Portlet classico"
+msgstr "Portlet Classico"
 
 #: plone/app/multilingual/browser/templates/cleanup.pt:79
 #: plone/app/multilingual/browser/templates/migration.pt:250
@@ -1472,7 +1480,7 @@ msgstr "Richiesta di conferma dell'azione utente."
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator_results.pt:20
 msgid "Congratulations! You migrated from Archetypes to Dexterity."
-msgstr "Complimenti! Migrazione da Archetype a Dexterity completata."
+msgstr "Complimenti! Migrazione da Archetypes a Dexterity completata."
 
 #. Default: "Contact"
 #: CMFPlone/profiles/default/actions.xml
@@ -1581,7 +1589,7 @@ msgid "Contents"
 msgstr "Contenuti"
 
 msgid "Contributor"
-msgstr "Contributore"
+msgstr "Collaboratore"
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
 msgid "Contributor withdraws submitted content"
@@ -1936,7 +1944,10 @@ msgstr "Dipendenze per lo shim"
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:44
 #: plone.app.contenttypes/plone/app/contenttypes/migration/custom_migration.pt:38
 msgid "Depending of the number of archetypes in your portal, it may take a <strong>really</strong> long time for the migration to be done. Stay calm, be patient and check your logs for progress-information."
-msgstr "In funzione del numero di oggetti archetype nel portale, la migrazione potrebbe impiegare <span class=\"strong\">davvero</span> molto tempo. Mantieni la calma, sii paziente e controlla lo stato di avanzamento nei log."
+msgstr ""
+"In funzione del numero di oggetti Archetypes nel portale, la migrazione "
+"potrebbe impiegare <strong>davvero</strong> molto tempo. Mantieni la calma, "
+"sii paziente e controlla lo stato di avanzamento nei log."
 
 #: CMFPlone/interfaces/resources.py:97
 msgid "Depends on another bundle"
@@ -2012,7 +2023,10 @@ msgstr "Disabilitato"
 
 #: CMFPlone/interfaces/controlpanel.py:146
 msgid "Disabling locking here will only affect users editing content through the Plone web UI.  Content edited via WebDAV clients will still be subject to locking."
-msgstr "Disabilitare il locking avrà effetto solo per gli utent i che modificano contenuti attraverso l'interfaccia di Plone. I contenuti modificati tramite client WebDAV saranno ancora soggetti al locking."
+msgstr ""
+"Disabilitare il locking avrà effetto solo per gli utenti che modificano "
+"contenuti attraverso l'interfaccia di Plone. I contenuti modificati tramite "
+"client WebDAV saranno ancora soggetti al locking."
 
 #: plone.app.content/plone/app/content/browser/contents/paste.py:57
 msgid "Disallowed subobject type \"${type}\""
@@ -2150,15 +2164,15 @@ msgstr "Modifica ${title} (${name})"
 
 #: plone.app.event/plone/app/event/portlets/portlet_calendar.py:315
 msgid "Edit Calendar Portlet"
-msgstr "Modifica la portlet Calendario"
+msgstr "Modifica portlet Calendario"
 
 #: plone.app.portlets/plone/app/portlets/portlets/classic.py:71
 msgid "Edit Classic Portlet"
-msgstr "Modifica portlet classico"
+msgstr "Modifica portlet Classico"
 
 #: plone.portlet.collection/plone/portlet/collection/collection.py:318
 msgid "Edit Collection Portlet"
-msgstr "Modifica portlet collezioni"
+msgstr "Modifica portlet Collezioni"
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/portaltype.py:116
 msgid "Edit Content Type Condition"
@@ -2170,11 +2184,11 @@ msgstr "Modifica azione di copia"
 
 #: plone.app.event/plone/app/event/portlets/portlet_events.py:234
 msgid "Edit Events Portlet"
-msgstr "Modifica la portlet Eventi"
+msgstr "Modifica portlet Eventi"
 
 #: plone.schemaeditor/plone/schemaeditor/browser/field/edit.py:134
 msgid "Edit Field '${fieldname}'"
-msgstr "Modifica il campo '${fieldname}'"
+msgstr "Modifica il campo \"${fieldname}\""
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/fileextension.py:113
 msgid "Edit File Extension Condition"
@@ -2215,7 +2229,7 @@ msgstr "Modifica azione di notifica"
 
 #: plone.app.portlets/plone/app/portlets/portlets/rss.py:359
 msgid "Edit RSS Portlet"
-msgstr "Modifica il portlet RSS"
+msgstr "Modifica portlet RSS"
 
 #: plone.app.portlets/plone/app/portlets/portlets/recent.py:167
 msgid "Edit Recent Portlet"
@@ -2223,7 +2237,7 @@ msgstr "Modifica portlet delle modifiche recenti"
 
 #: plone.app.portlets/plone/app/portlets/portlets/review.py:166
 msgid "Edit Review Portlet"
-msgstr "Modifica la Portlet di Revisione"
+msgstr "Modifica portlet delle revisioni"
 
 #: plone.app.contentrules/plone/app/contentrules/browser/rule.py:50
 msgid "Edit Rule"
@@ -2416,7 +2430,11 @@ msgstr "Data di termine"
 
 #: CMFPlone/interfaces/controlpanel.py:421
 msgid "Enter a JSON-formatted style format configuration. A format is for example the style that get applied when you press the bold button inside the editor. See https://www.tinymce.com/docs/configure/content-formatting/#formats"
-msgstr "Inserisci una configurazione in JSON. Un esempio può essere lo stile da applicare quando si clicca sul bottone per il grassetto. Per maggiori dettagli, vai qui: https://www.tinymce.com/docs/configure/content-formatting/#formats"
+msgstr ""
+"Inserisci una configurazione in JSON. Un esempio può essere lo stile da "
+"applicare quando si clicca sul pulsante per il grassetto. Per maggiori "
+"dettagli, vai qui: "
+"https://www.tinymce.com/docs/configure/content-formatting/#formats"
 
 #: CMFPlone/interfaces/controlpanel.py:668
 msgid "Enter a list of content types which can be used as images. Format is one contenttype per line."
@@ -2438,7 +2456,11 @@ msgstr "Inserisci una lista di plugin personalizzati che saranno caricati nell'e
 #: plone.app.event/plone/app/event/portlets/portlet_events.py:66
 #: plone.app.portlets/plone/app/portlets/portlets/navigation.py:117
 msgid "Enter a valid scale name (see 'Image Handling' control panel) to override (e.g. icon, tile, thumb, mini, preview, ... ). Leave empty to use default (see 'Site' control panel)."
-msgstr "Inserisci il nome di una miniatura (vedi il pannello di configurazione 'Gestione immagini') da personalizzare (per esempio icon, tile, thumb, mini, preview, ...). Lascia vuoto per usare il default (impostato nel pannello di controllo 'Sito')."
+msgstr ""
+"Inserisci il nome di una miniatura (vedi il pannello di configurazione "
+"\"Gestione immagini\") da personalizzare (per esempio icon, tile, thumb, "
+"mini, preview, ...). Lascia vuoto per usare il default (impostato nel "
+"pannello di controllo \"Sito\")."
 
 #: plone.schemaeditor/plone/schemaeditor/schema.py:78
 msgid "Enter allowed choices one per line."
@@ -2570,11 +2592,11 @@ msgstr "Gli eventi possono essere visualizzati nel calendario."
 
 #: CMFPlone/browser/templates/plone-addsite.pt:119
 msgid "Example content"
-msgstr "Contenuti d'esempio"
+msgstr "Contenuti di esempio"
 
 #: plone.formwidget.recurrence/plone/formwidget/recurrence/tests/at_example/configure.zcml:14
 msgid "Example content type for Recurrence Widget"
-msgstr "Tipo di contenuto d'esempio per il Recurrence Widget"
+msgstr "Tipo di contenuto di esempio per il Recurrence Widget"
 
 msgid "Excel spreadsheet"
 msgstr "Foglio di calcolo Excel"
@@ -2690,7 +2712,7 @@ msgstr "Nome utente Facebook"
 
 #: plone.app.content/plone/app/content/browser/contents/copy.py:32
 msgid "Failed to copy items"
-msgstr "Errore in fase di copia degli elementi"
+msgstr "Errore nel copiare gli elementi"
 
 #: plone.app.content/plone/app/content/browser/contents/cut.py:32
 msgid "Failed to cut items"
@@ -2698,7 +2720,7 @@ msgstr "Errore nel tagliare gli elementi"
 
 #: plone.app.content/plone/app/content/browser/contents/delete.py:48
 msgid "Failed to delete items"
-msgstr "Errore in fase di eliminazione degli elementi"
+msgstr "Errore nell'eliminare gli elementi"
 
 #: CMFPlone/controlpanel/browser/quickinstaller.py:698
 msgid "Failed to install ${product}."
@@ -2706,23 +2728,23 @@ msgstr "Non è stato possibile installare ${product}."
 
 #: plone.app.content/plone/app/content/browser/contents/workflow.py:42
 msgid "Failed to modify items"
-msgstr "Errore in fase di modifica degli elementi"
+msgstr "Errore nel modificare gli elementi"
 
 #: plone.app.content/plone/app/content/browser/contents/tags.py:40
 msgid "Failed to modify tags on items"
-msgstr "Errore in fase di modifica delle etichette degli elementi"
+msgstr "Errore nel modificare le etichette degli elementi"
 
 #: plone.app.content/plone/app/content/browser/contents/paste.py:32
 msgid "Failed to paste items"
-msgstr "Errore in fase di incolla degli elementi"
+msgstr "Errore nell'incollare gli elementi"
 
 #: plone.app.content/plone/app/content/browser/contents/rename.py:51
 msgid "Failed to rename all items"
-msgstr "Errore in fase di rinominazione degli elementi"
+msgstr "Errore nel rinominare gli elementi"
 
 #: plone.app.content/plone/app/content/browser/contents/defaultpage.py:8
 msgid "Failed to set default page"
-msgstr "Errore in fase di impostazione della vista predefinita"
+msgstr "Errore nell'impostare la vista predefinita"
 
 #: CMFPlone/browser/login/templates/login_failsafe.pt:12
 msgid "Failsafe Login"
@@ -2734,7 +2756,7 @@ msgstr "Errore"
 
 #: plone.app.content/plone/app/content/browser/contents/properties.py:48
 msgid "Failure updating metadata"
-msgstr "Errore in fase di aggiornamento dei metadati"
+msgstr "Errore nell'aggiornamento dei metadati"
 
 #: CMFPlone/interfaces/syndication.py:231
 msgid "Feed Types"
@@ -3017,7 +3039,7 @@ msgstr "Nascondi i contenuti per questi tipi"
 
 #: CMFPlone/interfaces/controlpanel.py:863
 msgid "Hide content inside the following types in Navigation."
-msgstr "Nascondi nella navigazione i contenuti dei seguenti elementi."
+msgstr "Nascondi nella navigazione i contenuti dei seguenti tipi."
 
 #: CMFPlone/interfaces/controlpanel.py:1503
 msgid "High pixel density mode"
@@ -3085,11 +3107,17 @@ msgstr "Identificatore del contenitore o login dell'utente considerato"
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:312
 msgid "Identifier, actually URL of the content"
-msgstr "Identificatore, attualmente URL del contenuto."
+msgstr "Identificatore, effettivamente l'URL del contenuto."
 
 #: CMFPlone/browser/login/templates/explainPWResetTool.pt:27
 msgid "If \"username check\" is on, users following the confirmation link from their email will be required to re-enter their username. This is to combat anonymous email sniffing attacks and it is <strong>highly recommended</strong> that you leave this <strong>ON</strong> if the portal is publicly accesible."
-msgstr "Se \"Controllo username\" è selezionato, agli utenti che utilizzano il link di conferma arrivato via e-mail, sarà chiesto di reinserire il loro username. Questo è un meccanismo di difesa contro un tipo di attacco informatico che cercano di indovinare gli indirizzi e-mail degli utenti. È <strong>altamente raccomandato</strong> mantenere <strong>attiva</strong> questa protezione se il portale è accesibile pubblicamente."
+msgstr ""
+"Se \"Controllo nome utente\" è attivo, agli utenti che utilizzano il link di "
+"conferma arrivato via e-mail, sarà chiesto di reinserire il loro nome utente. "
+"Questo è un meccanismo di difesa contro un tipo di attacco informatico che "
+"cerca di indovinare gli indirizzi e-mail degli utenti. È <strong>caldamente "
+"raccomandato</strong> mantenere <strong>attiva</strong> questa protezione se "
+"il portale è accessibile pubblicamente."
 
 #: CMFPlone/interfaces/controlpanel.py:836
 msgid "If an item has been excluded from navigation should it be shown in navigation when viewing content contained within it or within a subfolder."
@@ -3113,27 +3141,29 @@ msgstr "Se abilitato, gli elementi verranno estratti dalla collezione in ordine 
 
 #: plone.portlet.collection/plone/portlet/collection/collection.py:99
 msgid "If enabled, the listing will not include the current item the portlet is rendered for if it otherwise would be."
-msgstr "Se abilitato, l'elenco non includerà l'elemento nel quale per il quale la portlet è mostrata."
+msgstr ""
+"Se abilitato, l'elenco non includerà l'elemento corrente per cui è mostrato "
+"il portlet."
 
 #: plone.app.portlets/plone/app/portlets/portlets/recent.py:34
 #: plone.app.portlets/plone/app/portlets/portlets/review.py:25
 msgid "If enabled, the portlet will not show document type icons"
-msgstr "Se abilitato, la portlet non mostrerà le icone del tipo di contenuto."
+msgstr "Se abilitato, il portlet non mostrerà le icone del tipo di contenuto."
 
 #: plone.app.portlets/plone/app/portlets/portlets/navigation.py:110
 #: plone.portlet.collection/plone/portlet/collection/collection.py:107
 msgid "If enabled, the portlet will not show document type icons."
-msgstr "Se abilitato, la portlet non mostrerà le icone del tipo di contenuto."
+msgstr "Se abilitato, il portlet non mostrerà le icone del tipo di contenuto."
 
 #: plone.app.portlets/plone/app/portlets/portlets/news.py:54
 msgid "If enabled, the portlet will not show thumbs"
-msgstr "Se abilitato, la portlet non mostrerà le immagini."
+msgstr "Se abilitato, il portlet non mostrerà le immagini."
 
 #: plone.app.event/plone/app/event/portlets/portlet_events.py:77
 #: plone.app.portlets/plone/app/portlets/portlets/navigation.py:128
 #: plone.app.portlets/plone/app/portlets/portlets/recent.py:52
 msgid "If enabled, the portlet will not show thumbs."
-msgstr "Se abilitato, la portlet non mostrerà le immagini."
+msgstr "Se abilitato, il portlet non mostrerà le immagini."
 
 #: plone.portlet.static/plone/portlet/static/static.py:92
 msgid "If given, the header and footer will link to this URL."
@@ -3161,7 +3191,10 @@ msgstr "Se la distribuzione RSS deve essere abilitata globalmente su tutte le ca
 
 #: CMFPlone/controlpanel/browser/resourceregistry.pt:35
 msgid "If you see this, it is because there was an error rendering the resource registry configuration. It's possible you saved a bundle that gives a JavaScript error and it is preventing the resource registry from loading."
-msgstr "Se vedi questa pagina, è perché c'è stato un errore nel renderizzare la configurazione del registro delle risorse. E' possibile che ci sia un bundle con errori JavaScript che impedisono al registro delle risorse di caricarsi."
+msgstr ""
+"Se vedi questa pagina, è perché c'è stato un errore nella resa della "
+"configurazione del registro delle risorse. È possibile che ci sia un bundle "
+"con errori JavaScript che impediscono al registro delle risorse di caricarsi."
 
 #. Default: "If you submitted the item by mistake or want to perform additional edits, this will take it back."
 #: CMFPlone/profiles/default/workflows/folder_workflow/definition.xml
@@ -3229,7 +3262,9 @@ msgstr "Importazione riuscita."
 
 #: CMFPlone/interfaces/resources.py:65
 msgid "In case its a bundle we can have a condition to render it (it does not apply if the bundle is merged)."
-msgstr "Inserisci una condizione per renderizzare questo bundle (non viene considerata nel caso il bundle sia mergeato)."
+msgstr ""
+"Inserisci una condizione per la resa di questo bundle (non viene considerata "
+"nel caso il bundle sia unito)."
 
 #: CMFPlone/interfaces/resources.py:98
 msgid "In case you want to be the last: *, in case its the first should be empty"
@@ -3241,15 +3276,24 @@ msgstr "Nel caso tu volessi migrare da Products.LinguaPlone accedi alla ${url}"
 
 #: CMFPlone/interfaces/resources.py:72
 msgid "In case you want to render this resource on conditional comment (it does not apply if the bundle is merged)."
-msgstr "Inserisci un commento condizionale per renderizzare questo bundle (non viene considerata nel caso il bundle sia mergeato)."
+msgstr ""
+"Inserisci un commento condizionale per la resa di questo bundle (non viene "
+"considerata nel caso il bundle sia unito)."
 
 #: CMFPlone/interfaces/resources.py:121
 msgid "In production mode, bundles are merged together to reduce the quantity of JS and CSS resources loaded by the browser. Choose 'default' if this bundle must be available for all the visitors, choose 'logged-in' if it must be available for logged-in users only, or leave it empty if it must not be merged."
-msgstr "In modalità produzione, i bundle vengono uniti per ridurre la quantità di risorse JS e CSS scaricate dal browser. Seleziona 'default' per rendere il bundle visibile a tutti, 'logged-in' se deve essere visibile solo agli utenti autenticati, mentre lascialo vuoto se vuoi che il bundle non venga unito con nessun altro."
+msgstr ""
+"In modalità produzione, i bundle vengono uniti per ridurre la quantità di "
+"risorse JS e CSS scaricate dal browser. Seleziona \"default\" per rendere il "
+"bundle visibile a tutti, \"logged-in\" se deve essere visibile solo agli "
+"utenti autenticati, oppure lascialo vuoto se vuoi che il bundle non venga "
+"unito con nessun altro."
 
 #: CMFPlone/interfaces/controlpanel.py:1441
 msgid "Include meta tags on pages to give hints to social media on how to better render your pages when shared"
-msgstr "Includi nella pagina i meta tag che servono ai social media per renderizzare al meglio le pagine che condividi."
+msgstr ""
+"Includi nella pagina i meta tag che servono ai social media per rendere al "
+"meglio le pagine che condividi."
 
 #: plone.app.caching/plone/app/caching/caching.zcml:57
 msgid "Includes files and images in content space."
@@ -3373,7 +3417,7 @@ msgstr "Regole non valide"
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 #: plone.app.querystring/plone/app/querystring/profiles/upgrades/to_6/registry.xml
 msgid "Is"
-msgstr "uguale a"
+msgstr "Uguale a"
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 msgid "Is within"
@@ -3513,7 +3557,12 @@ msgstr "Permetti agli utenti di scegliere la propria password"
 
 #: CMFPlone/controlpanel/browser/navigation.py:12
 msgid "Lets you control how navigation is constructed in your site. Note that to control how the navigation tree is displayed, you should go to 'Manage portlets' at the root of the site (or wherever a navigation tree portlet has been added) and change its settings directly."
-msgstr "Impostazioni per il controllo della costruzione della navigazione del sito. Nota che per controllare come viene visualizzato l'albero di navigazione devi modificare le impostazioni del portlet navigazione attraverso la 'Gestione portlet' nella radice del sito (o in qualunque punto sia stato abilitato tale portlet)."
+msgstr ""
+"Impostazioni per il controllo della costruzione della navigazione del sito. "
+"Nota che per controllare come viene visualizzato l'albero di navigazione devi "
+"modificare le impostazioni del portlet navigazione attraverso la \"Gestione "
+"portlet\" nella radice del sito (o in qualunque punto sia stato abilitato "
+"tale portlet)."
 
 #: plone.app.contenttypes/plone/app/contenttypes/profiles/default/types/File.xml
 msgid "Lets you upload a file to the site."
@@ -4967,7 +5016,7 @@ msgstr "Il purge è ancora abilitato, mentre il caching è disabilitato!"
 
 #: plone/app/theming/browser/controlpanel.pt:606
 msgid "Put your plain css..."
-msgstr ""
+msgstr "Inserisci il CSS..."
 
 #. Default: "Puts your item in a review queue, so it can be published externally or internally."
 #: CMFPlone/profiles/default/workflows/intranet_workflow/definition.xml
@@ -5045,11 +5094,11 @@ msgstr "Flusso RSS di questo elenco"
 
 #: CMFPlone/interfaces/controlpanel.py:688
 msgid "Raw"
-msgstr "Non modificato"
+msgstr "Grezzo"
 
 #: plone.app.textfield/plone/app/textfield/interfaces.py:51
 msgid "Raw value in the original MIME type"
-msgstr "Valore non modificato nel tipo MIME originale"
+msgstr "Valore grezzo nel tipo MIME originale"
 
 msgid "Reader"
 msgstr "Lettore"
@@ -5060,7 +5109,7 @@ msgstr "E-mail dei lettori"
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/browser.py:312
 msgid "Rebuild the catalog after the migration."
-msgstr "Rigenera il catalogo dopo le migrazioni."
+msgstr "Rigenera il catalogo dopo la migrazione."
 
 #: plone.app.discussion/plone/app/discussion/browser/moderation.py:28
 msgid "Recall"
@@ -5142,7 +5191,7 @@ msgstr "Path relativo"
 
 #: CMFPlone/controlpanel/browser/resourceregistry.pt:41
 msgid "Reload the page. There could be a intermittent issue."
-msgstr "Ricarica la pagina. Potrebbe esserci stato un problema."
+msgstr "Ricarica la pagina. Potrebbe esserci stato un problema temporaneo."
 
 #: plone/app/multilingual/browser/templates/migration.pt:174
 msgid "Relocate"
@@ -5188,7 +5237,7 @@ msgstr "Rinomina gli elementi"
 
 #: plone.app.content/plone/app/content/browser/actions.py:179
 msgid "Renamed '${oldid}' to '${newid}'."
-msgstr "Rinominato '${oldid}' a '${newid}'."
+msgstr "Rinominato \"${oldid}\" a \"${newid}\"."
 
 #: CMFPlone/interfaces/syndication.py:176
 msgid "Render Body"
@@ -5268,11 +5317,11 @@ msgstr "Ripristina"
 
 #: plone.app.iterate/plone/app/iterate/profiles/test/workflows/workingcopy_workflow/definition.xml
 msgid "Revert to draft."
-msgstr "Manda indietro"
+msgstr "Riporta allo stato bozza."
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:332
 msgid "Review State"
-msgstr "Stato del workflow"
+msgstr "Stato di revisione"
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:343
 msgid "Review State Title"
@@ -5287,7 +5336,7 @@ msgstr "Elenco di revisione"
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 #: plone.app.vocabularies/plone/app/vocabularies/metadatafields.py:24
 msgid "Review state"
-msgstr "Stato del workflow"
+msgstr "Stato di revisione"
 
 msgid "Reviewer"
 msgstr "Revisore"
@@ -5424,7 +5473,7 @@ msgstr "Risultati della ricerca"
 
 #: CMFPlone/browser/templates/search.pt:155
 msgid "Search results for ${term}"
-msgstr "Risultati per ${term}"
+msgstr "Risultati ricerca per ${term}"
 
 #: plone.app.collection/plone/app/collection/collection.py:31
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/collection.py:38
@@ -5433,7 +5482,7 @@ msgstr "Parametri di ricerca"
 
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 msgid "Searchable text"
-msgstr "Testo"
+msgstr "Testo ricercabile"
 
 #. Default: "Security"
 #: CMFPlone/PloneControlPanel.py:73
@@ -5503,7 +5552,9 @@ msgstr "Seleziona quali ID (nomi brevi) dei content-type possono comportarsi com
 #: plone.app.collection/plone/app/collection/collection.py:84
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/collection.py:79
 msgid "Select which fields to display when 'Tabular view' is selected in the display menu."
-msgstr "Seleziona quali campi devono essere mostrati quando 'Vista tabellare' è selezionato nel menù display"
+msgstr ""
+"Seleziona quali campi devono essere mostrati quando \"Vista tabellare\" è "
+"selezionato nel menù display"
 
 #: CMFPlone/interfaces/controlpanel.py:1370
 msgid "Select which formats are available for users as alternative to the default format. Note that if new formats are installed, they will be enabled for text fields by default unless explicitly turned off here or by the relevant installer."
@@ -5520,7 +5571,7 @@ msgstr "Manda le richieste di PURGE con i percorsi di virtual host"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/configure.zcml:207
 msgid "Send an email on the triggering object"
-msgstr "Manda un'e-mail all'oggetto scatenante"
+msgstr "Manda un'e-mail relativa all'oggetto scatenante"
 
 #. Default: "Send back"
 #: CMFPlone/profiles/default/workflows/intranet_workflow/definition.xml
@@ -5548,7 +5599,7 @@ msgstr "Rifiutando un elemento lo farai tornare all'autore originale invece che 
 
 #: CMFPlone/interfaces/syndication.py:192
 msgid "Separate view name and title by '|'"
-msgstr "Separa nome e titolo della vista con '|'"
+msgstr "Separa nome e titolo della vista con \"|\""
 
 #: CMFPlone/controlpanel/browser/overview.pt:149
 msgid "Server:"
@@ -5635,7 +5686,7 @@ msgstr "Se la distribuzione RSS deve includere informazioni sull'autore"
 
 #: CMFPlone/browser/templates/plone-addsite.pt:120
 msgid "Should the default example content be added to the site?"
-msgstr "Vuoi che vengano creati dei contenuti d'esempio nel sito?"
+msgstr "Vuoi che vengano creati dei contenuti di esempio nel sito?"
 
 #: CMFPlone/controlpanel/browser/actions.pt:41
 msgid "Show"
@@ -5734,7 +5785,11 @@ msgstr "Workflow Pubblicazione semplice"
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:39
 #: plone.app.contenttypes/plone/app/contenttypes/migration/custom_migration.pt:36
 msgid "Since LinguaPlone does not support Dexterity you need to migrate from LinguaPlone to ${multilingual}. The migration from Products.LinguaPlone to plone.app.multilingual should happen before the migration from Archetypes to plone.app.contenttypes. For details on the migration see the ${documentation}"
-msgstr "Dato che LinguaPlone non supporta Dexterity devi migrare a ${multilingual}. La migrazione da Products.LinguaPlone a plone.app.multilingual dovrebbe avvenire prima della migrazione da Archetypes aplone.app.contenttypes. Per i dettagli sulla migrazione consulta la ${documentation}"
+msgstr ""
+"Dato che LinguaPlone non supporta Dexterity devi migrare a ${multilingual}. "
+"La migrazione da Products.LinguaPlone a plone.app.multilingual dovrebbe "
+"avvenire prima della migrazione da Archetypes a plone.app.contenttypes. Per i "
+"dettagli sulla migrazione consulta la ${documentation}"
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:77
 msgid "Since you effectively have Products.LinguaPlone installed in your portal, you're not allowed to continue this migration."
@@ -6030,7 +6085,7 @@ msgstr "Disabilita le icone"
 
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/thumb_icon.py:61
 msgid "Suppress icons in list, table or summary view"
-msgstr "Disabilita le icone nelle viste standard, tabellare e riassuntiva"
+msgstr "Disabilita le icone nelle viste elenco, tabellare e riassuntiva"
 
 #: plone.app.event/plone/app/event/portlets/portlet_events.py:76
 #: plone.app.portlets/plone/app/portlets/portlets/navigation.py:127
@@ -6040,23 +6095,31 @@ msgstr "Disabilita le miniature"
 
 #: CMFPlone/interfaces/controlpanel.py:1081
 msgid "Suppress thumbs in all list views; this default can be overriden individually"
-msgstr "Disabilita le miniature nelle viste standard; questa impostazione può essere sovrascritta singolarmente nei vari contenuti."
+msgstr ""
+"Disabilita le miniature nelle viste elenco; questa impostazione può essere "
+"sovrascritta singolarmente nei vari contenuti."
 
 #: CMFPlone/interfaces/controlpanel.py:1072
 msgid "Suppress thumbs in all portlets; this default can be overridden individually in selected portlets"
-msgstr "Disabilita le miniature nelle portlet; questa impostazione può essere sovrascritta singolarmente nelle varie portlet."
+msgstr ""
+"Disabilita le miniature nei portlet; questa impostazione può essere "
+"sovrascritta singolarmente nei singoli portlet."
 
 #: CMFPlone/interfaces/controlpanel.py:1088
 msgid "Suppress thumbs in all summary views; this default can be overriden individually"
-msgstr "Disabilita le miniature nelle viste riassuntive; questa impostazione può essere sovrascritta singolarmente nei vari contenuti."
+msgstr ""
+"Disabilita le miniature nelle viste riassuntive; questa impostazione può "
+"essere sovrascritta singolarmente nei singoli contenuti."
 
 #: CMFPlone/interfaces/controlpanel.py:1094
 msgid "Suppress thumbs in all tableviews and in folder contents view; this default can be overriden individually"
-msgstr "Disabilita le miniature nelle viste tabellari; questa impostazione può essere sovrascritta singolarmente nei vari contenuti."
+msgstr ""
+"Disabilita le miniature nelle viste tabellari; questa impostazione può essere "
+"sovrascritta singolarmente nei singoli contenuti."
 
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/thumb_icon.py:68
 msgid "Suppress thumbs in list, table or summary view"
-msgstr "Disabilita le miniature nelle viste standard, tabellare e riassuntiva"
+msgstr "Disabilita le miniature nelle viste elenco, tabellare e riassuntiva"
 
 #. Default: "Syndication"
 #: CMFPlone/profiles/default/actions.xml
@@ -6113,19 +6176,19 @@ msgstr "Etichette"
 #: plone.app.querystring/plone/app/querystring/profiles/default/registry.xml
 #: plone.app.querystring/plone/app/querystring/profiles/upgrades/to_8/registry.xml
 msgid "Tags are used for organization of content"
-msgstr "Le categorie sono utilizzate per organizzare i contenuti"
+msgstr "Le etichette sono utilizzate per organizzare i contenuti"
 
 msgid "Tar archive"
 msgstr "Archivio TAR"
 
 #: plone.portlet.collection/plone/portlet/collection/collection.py:63
 msgid "Target collection"
-msgstr "Collezione di riferimento"
+msgstr "Collezione di destinazione"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/copy.py:33
 #: plone.app.contentrules/plone/app/contentrules/actions/move.py:35
 msgid "Target folder"
-msgstr "Cartella destinazione"
+msgstr "Cartella di destinazione"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/copy.py:83
 #: plone.app.contentrules/plone/app/contentrules/actions/move.py:88
@@ -6212,11 +6275,13 @@ msgstr "Menu \"aggiunta\" - consente all'utente di aggiungere nuovi contenuti in
 
 #: plone.schemaeditor/plone/schemaeditor/interfaces.py:207
 msgid "The 'description' field must be a Text field."
-msgstr "Il campo 'descrizione' deve essere un campo di testo."
+msgstr "Il campo \"descrizione\" deve essere un campo di testo."
 
 #: plone.app.contentmenu/plone/app/contentmenu/configure.zcml:25
 msgid "The 'display' menu - allows the user to select the view of an object"
-msgstr "Menu \"visualizzazione\" - conente all'utente di selezionare la vista di un elemento"
+msgstr ""
+"Menu \"visualizzazione\" - consente all'utente di selezionare la vista di un "
+"elemento"
 
 #: plone.app.contentmenu/plone/app/contentmenu/configure.zcml:43
 msgid "The 'portlet' menu - allows the user to manage portlets"
@@ -6224,7 +6289,7 @@ msgstr "Menu \"portlet\" - consente all'utente di gestire i portlet"
 
 #: plone.schemaeditor/plone/schemaeditor/interfaces.py:202
 msgid "The 'title' field must be a Text line (string) field."
-msgstr "Il campo 'titolo' deve essere un campo Linea di testo (stringa)"
+msgstr "Il campo \"titolo\" deve essere un campo Linea di testo (stringa)"
 
 #: plone.app.contentmenu/plone/app/contentmenu/configure.zcml:37
 msgid "The 'workflow' menu - allows the user to execute workflow transitions"
@@ -6232,7 +6297,9 @@ msgstr "Menu \"workflow\" - consente all'utente di effettuare delle transizioni 
 
 #: CMFPlone/browser/templates/plone-addsite.pt:48
 msgid "The ID of the site. This ends up as part of the URL.<br /> No special characters or spaces are allowed."
-msgstr "L'ID del sito. Questo sarà parte del suo URL.<br /> Non sono mamessi caratteri speciali."
+msgstr ""
+"L'ID del sito. Questo sarà parte del suo URL.<br /> Non sono ammessi "
+"caratteri speciali."
 
 #. Default: "The ID of the user who performed the last transition"
 #: CMFPlone/profiles/default/workflows/folder_workflow/definition.xml
@@ -6280,7 +6347,10 @@ msgstr "La data in cui un elemento è stato creato"
 
 #: CMFPlone/browser/templates/plone-addsite.pt:98
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
-msgstr "Impostazione del fuso orario predefinita del portale. Gli utenti potranno impostare il loro fuso orario se disponibile tra quelli definiti nel campo \"Fusi orari disponibili\""
+msgstr ""
+"Impostazione del fuso orario predefinita del portale. Gli utenti potranno "
+"impostare il loro fuso orario se disponibile tra quelli definiti nel campo "
+"\"Fusi orari disponibili\"."
 
 #: CMFPlone/RegistrationTool.py:372
 msgid "The email address did not validate."
@@ -6301,7 +6371,9 @@ msgstr "La data e l'ora di termine di un evento"
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:56
 msgid "The estimated time for the migration is around: <strong> ${hours} hours ${minutes} minutes ${seconds} seconds </strong>"
-msgstr "Il tempo stimato per la migrazione è di circa: <strong> ${hours} ore${minutes} minuti ${seconds} secondi </strong>"
+msgstr ""
+"Il tempo stimato per la migrazione è di circa: <strong>${hours} ore "
+"${minutes} minuti ${seconds} secondi</strong>"
 
 #: CMFPlone/interfaces/controlpanel.py:1607
 msgid "The expression \"${value}\" is invalid"
@@ -6317,7 +6389,11 @@ msgstr "I seguenti tipi di contenuto personalizzati sono disponibili per questo 
 
 #: CMFPlone/browser/templates/plone-upgrade.pt:127
 msgid "The following list shows which upgrade steps are going to be run. Upgrading sometimes performs a catalog/security update, which may take a long time on large sites. Be patient."
-msgstr "La seguente lista elenca i passi che devono essere seguiti per l'aggiornamento. A volte l'aggiornamento del sito richiede l'aggiornamento del catalogo o aggiornamenti di sicurezza; potrebbe volerci molto tempo. Sii paziente."
+msgstr ""
+"La seguente lista elenca i passi che devono essere eseguiti per "
+"l'aggiornamento. A volte l'aggiornamento del sito richiede l'aggiornamento "
+"del catalogo o aggiornamenti di sicurezza; potrebbe volerci molto tempo. Sii "
+"paziente."
 
 #: CMFPlone/controlpanel/browser/usergroups_groupdetails.py:48
 msgid "The group name you entered is not valid."
@@ -6347,7 +6423,7 @@ msgstr "Il nome di login che hai scelto è già stato usato oppure non è valido
 
 #: plone.app.portlets/plone/app/portlets/portlets/classic.py:21
 msgid "The macro containing the portlet. Leave blank if there is no macro."
-msgstr "La macro contenente la portlet. Lascia vuoto se non c'è nessuna macro."
+msgstr "La macro contenente il portlet. Lascia vuoto se non c'è nessuna macro."
 
 #: CMFPlone/browser/templates/plone-addsite.pt:72
 msgid "The main language of the site."
@@ -6550,19 +6626,25 @@ msgstr "Sono occorsi degli errori"
 #: plone.app.users/plone/app/users/browser/membersearch.py:94
 #: plone.app.users/plone/app/users/browser/register.py:67
 msgid "There were errors."
-msgstr "Ci sono stati errori."
+msgstr "Sono occorsi degli errori."
 
 #: plone.app.caching/plone/app/caching/caching.zcml:51
 msgid "These are resources which can be cached 'forever'. Normally this means that if the object does change, its URL changes too."
-msgstr "Queste risorse possono essere inserite nella cache 'per sempre'. Normalmente questo significa che l'oggetto dovesse cambiare allora cambierebbe anche il suo URL."
+msgstr ""
+"Queste risorse possono essere inserite nella cache \"per sempre\". "
+"Normalmente questo significa che l'oggetto dovesse cambiare allora "
+"cambierebbe anche il suo URL."
 
 #: CMFPlone/interfaces/controlpanel.py:300
 msgid "These attributes are additionally allowed."
-msgstr "Questi attributi non verranno filtrati."
+msgstr "Questi ulteriori attributi sono consentiti."
 
 #: CMFPlone/interfaces/controlpanel.py:195
 msgid "These tags and their content are completely blocked when a page is saved or rendered. They are only deleted if they are not marked as valid_tags"
-msgstr "Questi tag e il loro contenuto verranno completamente bloccati quando al salvataggio o visualizzazione di una pagina. Verranno cancellati solo se non fanno parte dei tag validi."
+msgstr ""
+"Questi tag e il loro contenuto verranno completamente bloccati quando la "
+"pagina viene salvata o visualizzata. Verranno cancellati solo se non fanno "
+"parte dei tag validi."
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:108
 msgid "These types are installed and have the image-behavior: ${types}"
@@ -6587,7 +6669,7 @@ msgstr "Questa impostazione può velocizzare parecchio la migrazione se ci sono 
 
 #: plone/app/multilingual/browser/templates/not_translated_yet.pt:23
 msgid "This content is not translated yet to the language requested."
-msgstr "Questo contenuto non è ancora stato tradotto nella lingua richiesta"
+msgstr "Questo contenuto non è ancora stato tradotto nella lingua richiesta."
 
 #: CMFPlone/interfaces/controlpanel.py:1102
 msgid "This default can be overriden individually."
@@ -6620,7 +6702,7 @@ msgstr "Questo nome verrà mostrato nell'URL."
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/browser.py:313
 msgid "This operation can take a very long time."
-msgstr "Questa operazione potrebbe essere molto lunga."
+msgstr "Questa operazione potrebbe richiedere molto tempo."
 
 #: CMFPlone/interfaces/controlpanel.py:578
 msgid "This option allows you to choose the spellchecker for TinyMCE."
@@ -6644,7 +6726,10 @@ msgstr "Questa opzione consente il ridimensionamento manuale della finestra dell
 
 #: CMFPlone/interfaces/controlpanel.py:336
 msgid "This option gives you the ability to specify the height of the editor in pixels. If auto resize is enabled this value is used as minimum height."
-msgstr "Questa opzione ti consente di specificare l'altezza (in pixel) dell'editor. Se l'opzione \"Abilità il ridimensionamento automatico dell'editor\" è abilitata, questo valore è utilizzato come altezza minima."
+msgstr ""
+"Questa opzione ti consente di specificare l'altezza (in pixel) dell'editor. "
+"Se l'opzione \"Abilita il ridimensionamento automatico dell'editor\" è "
+"abilitata, questo valore è utilizzato come altezza minima."
 
 #: CMFPlone/interfaces/controlpanel.py:328
 msgid "This option gives you the ability to specify the width of the editor (like 100% or 400px)."
@@ -6740,7 +6825,7 @@ msgstr "Miniatura da usare nelle liste"
 
 #: CMFPlone/interfaces/controlpanel.py:1101
 msgid "Thumb scale for portlets"
-msgstr "Miniature da usare nelle portlets"
+msgstr "Miniature da usare nei portlet"
 
 #: CMFPlone/interfaces/controlpanel.py:1124
 msgid "Thumb scale for summary view"
@@ -6752,7 +6837,7 @@ msgstr "Miniature da usare nelle viste tabellari"
 
 #: CMFPlone/interfaces/controlpanel.py:1060
 msgid "Thumb visibility"
-msgstr "Visiblità delle miniature"
+msgstr "Visibilità delle miniature"
 
 #. Default: "Thumbnail view"
 #: plone.app.collection/plone/app/collection/browser/configure.zcml:74
@@ -6773,7 +6858,9 @@ msgstr "Tempo in minuti passato il quale il flusso deve essere ricaricato."
 
 #: plone/app/theming/interfaces.py:201
 msgid "Time stamp when the custom CSS was changed. Used to generate custom.css with timestamp in URL."
-msgstr "Timestamp corrispondente alla modifica del CSS personalizzato. Usato per rompere eventuali cache nel browser o eventuali proxy."
+msgstr ""
+"Timestamp corrispondente alla modifica del CSS personalizzato. Usato generare "
+"custom.css con il timestamp negli URL."
 
 #: CMFPlone/profiles/default/controlpanel.xml
 msgid "TinyMCE"
@@ -6815,7 +6902,9 @@ msgstr "Da usare per integrazioni come Open Graph"
 
 #: CMFPlone/interfaces/controlpanel.py:1448
 msgid "To identify things like Twitter Cards. Do not include the \"@\" prefix character."
-msgstr "Per identificare cose come le Twitter Card. Nono inserire il caratter \"@\"."
+msgstr ""
+"Per identificare cose come le Twitter Card. Non inserire il carattere \"@\" "
+"come prefisso."
 
 #: CMFPlone/controlpanel/browser/quickinstaller.pt:34
 msgid "To make new add-ons show up here, add them to your buildout configuration, run buildout, and restart the server process. For detailed instructions see ${third_party_product}."
@@ -6907,7 +6996,7 @@ msgstr "Tipo di contenuto copiato con successo."
 
 #: plone.app.dexterity/plone/app/dexterity/browser/import_types.py:33
 msgid "Type profiles archive file"
-msgstr "File con i profili dei tipi"
+msgstr "File con i profili dei tipi di contenuto"
 
 #: CMFPlone/controlpanel/browser/types.py:53
 msgid "Types Settings"
@@ -6915,7 +7004,7 @@ msgstr "Impostazioni dei tipi di contenuto"
 
 #: plone.app.dexterity/plone/app/dexterity/browser/import_types.py:74
 msgid "Types in archive must be only Dexterity types."
-msgstr "I tipi nell'archivio posso essere solo tipi Dexterity."
+msgstr "I tipi di contenuto nell'archivio posso essere solo tipi Dexterity."
 
 #: CMFPlone/controlpanel/browser/types.py:55
 msgid "Types settings"
@@ -6923,11 +7012,11 @@ msgstr "Impostazioni dei tipi di contenuto"
 
 #: CMFPlone/interfaces/controlpanel.py:1260
 msgid "Types that can be set as a default page"
-msgstr "Tipi che possono essere selezionati come vista predefinita"
+msgstr "Tipi di contenuto che possono essere selezionati come vista predefinita"
 
 #: CMFPlone/interfaces/controlpanel.py:1235
 msgid "Types which use the view action in listing views."
-msgstr "Tipi che usano l'azione \"/view\" nelle viste elenco."
+msgstr "Tipi di contenuto che usano l'azione \"/view\" nelle viste elenco."
 
 #: CMFPlone/interfaces/resources.py:25
 #: plone.app.contenttypes/plone/app/contenttypes/schema/link.xml
@@ -6947,7 +7036,7 @@ msgstr "URL del flusso RSS"
 
 #: CMFPlone/interfaces/resources.py:55
 msgid "URL of the last css compilation"
-msgstr "URL dell'ultima compilazione CSS "
+msgstr "URL dell'ultima compilazione CSS"
 
 #: CMFPlone/interfaces/resources.py:51
 msgid "URL of the last js compilation"
@@ -6955,11 +7044,15 @@ msgstr "URL dell'ultima compilazione JavaScript"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/workflow.py:82
 msgid "Unable to change state of ${name} as part of content rule 'workflow' action: ${error}"
-msgstr "Impossibile modificare lo stato di ${name} nell'azione 'workflow' specificata nelle regole di contenuto: ${error}"
+msgstr ""
+"Impossibile modificare lo stato di ${name} nell'azione \"workflow\" "
+"specificata nelle regole di contenuto: ${error}"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/copy.py:123
 msgid "Unable to copy ${name} as part of content rule 'copy' action: ${error}"
-msgstr "Impossibile copiare ${name} nell'esecuzione dell'azione \"copy\" specificata nelle regole di contenuto: ${error}"
+msgstr ""
+"Impossibile copiare ${name} nell'esecuzione dell'azione \"copy\" specificata "
+"nelle regole di contenuto: ${error}"
 
 #: plone.app.contentrules/plone/app/contentrules/actions/move.py:141
 msgid "Unable to move ${name} as part of content rule 'move' action: ${error}"
@@ -6967,7 +7060,9 @@ msgstr "Impossibile spostare ${name} nell'esecuzione dell'azione \"move\" specif
 
 #: plone.app.contentrules/plone/app/contentrules/actions/delete.py:64
 msgid "Unable to remove ${name} as part of content rule 'delete' action: ${error}"
-msgstr "Impossibile rimuovere ${name} attraverso una regola di contenuto: ${error}"
+msgstr ""
+"Impossibile rimuovere ${name} nell'esecuzione dell'azione \"move\" "
+"specificata nelle regole di contenuto: ${error}"
 
 #: CMFPlone/browser/author.py:123
 #: CMFPlone/browser/sendto.py:100
@@ -7001,7 +7096,7 @@ msgstr "Disinstalla"
 
 #: plone.app.collection/plone/app/collection/configure.zcml:27
 msgid "Uninstall Archetypes-based collections"
-msgstr "Disinstalla le collezioni Archetype-based"
+msgstr "Disinstalla le collezioni basate su Archetypes"
 
 #: plone/app/multilingual/configure.zcml:157
 msgid "Uninstall, removes multilingual content support with plone.app.multilingual"
@@ -7095,7 +7190,7 @@ msgstr "Usa l'indirizzo e-mail come nome utente"
 
 #: plone.app.caching/plone/app/caching/operations/default.py:320
 msgid "Use this operation to keep the response out of all caches."
-msgstr "Usa questa operazione per mantenere la reponse fuori da tutte le cache."
+msgstr "Usa questa operazione per mantenere la risposta fuori da tutte le cache."
 
 #: plone.schemaeditor/plone/schemaeditor/interfaces.py:167
 msgid "Used for programmatic access to the field."
@@ -7155,11 +7250,11 @@ msgstr "Immagine con il ritratto dell'utente"
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/configure.zcml:160
 msgid "User's group"
-msgstr "Gruppo dell'utente'"
+msgstr "Gruppo dell'utente"
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/configure.zcml:189
 msgid "User's role"
-msgstr "Ruolo dell'utente'"
+msgstr "Ruolo dell'utente"
 
 #: CMFPlone/controlpanel/browser/usergroups.py:28
 msgid "User/Groups settings"
@@ -7171,7 +7266,7 @@ msgstr "Controllo nome utente"
 
 #: plone.app.discussion/plone/app/discussion/interfaces.py:189
 msgid "Username of the commenter"
-msgstr "Username dell'autore del commento"
+msgstr "Nome utente dell'autore del commento"
 
 #: CMFPlone/PloneControlPanel.py:72
 msgid "Users"
@@ -7194,27 +7289,27 @@ msgstr "Tag validi"
 
 #: validation/validators/RegexValidator.py:47
 msgid "Validation failed($name): $value of type $type, expected 'string'"
-msgstr "Validazione fallita($name): '$value' di tipo $type invece che 'string'"
+msgstr "Validazione fallita($name): \"$value\" di tipo $type invece che \"string\""
 
 #: validation/validators/RegexValidator.py:65
 msgid "Validation failed($name): '$value' $errmsg"
-msgstr "Validazione fallita($name): '$value' $errmsg"
+msgstr "Validazione fallita($name): \"$value\" $errmsg"
 
 #: validation/validators/EmptyValidator.py:44
 msgid "Validation failed($name): '$value' is not empty."
-msgstr "Validazione fallita($name): '$value' non è vuoto"
+msgstr "Validazione fallita($name): \"$value\" non è vuoto"
 
 #: validation/validators/RangeValidator.py:38
 msgid "Validation failed($name): '$value' out of range($min, $max)"
-msgstr "Validazione fallita($name): '$value' fuori dai limiti($min, $max)"
+msgstr "Validazione fallita($name): \"$value\" fuori dall'intervallo ($min, $max)"
 
 #: validation/validators/SupplValidators.py:95
 msgid "Validation failed($name): could not convert $value to a date."
-msgstr "Validazione fallita($name): impossibile convertire '$value' in una data"
+msgstr "Validazione fallita($name): impossibile convertire \"$value\" in una data"
 
 #: validation/validators/RangeValidator.py:32
 msgid "Validation failed($name): could not convert '$value' to number"
-msgstr "Validazione fallita($name): impossibile convertire '$value' in un numero"
+msgstr "Validazione fallita($name): impossibile convertire \"$value\" in un numero"
 
 #: validation/validators/SupplValidators.py:88
 msgid "Validation failed($name): value is empty ($value)."
@@ -7257,31 +7352,31 @@ msgstr "Visualizza"
 
 #: plone.app.contenttypes/plone/app/contenttypes/browser/configure.zcml:153
 msgid "View Document"
-msgstr "Vista Pagina"
+msgstr "Visualizza Pagina"
 
 #: CMFPlone/skins/plone_content/event_view.pt.metadata
 msgid "View Event"
-msgstr "Vista Evento"
+msgstr "Visualizza Evento"
 
 #: plone.app.contenttypes/plone/app/contenttypes/browser/configure.zcml:163
 msgid "View File"
-msgstr "Vista File"
+msgstr "Visualizza File"
 
 #: plone.app.contenttypes/plone/app/contenttypes/browser/configure.zcml:172
 msgid "View Image"
-msgstr "Vista immagine"
+msgstr "Visualizza Immagine"
 
 #: plone.app.contenttypes/plone/app/contenttypes/browser/configure.zcml:181
 msgid "View Image Fullscreen"
-msgstr "Vista immagine a tutto schermo"
+msgstr "Visualizza Immagine a tutto schermo"
 
 #: plone.app.contenttypes/plone/app/contenttypes/browser/configure.zcml:190
 msgid "View Link"
-msgstr "Vista Collegamento"
+msgstr "Visualizza Collegamento"
 
 #: plone.app.contenttypes/plone/app/contenttypes/browser/configure.zcml:199
 msgid "View News Item"
-msgstr "Vista Notizia"
+msgstr "Visualizza Notizia"
 
 #: plone.app.content/plone/app/content/browser/selection.py:88
 msgid "View changed."
@@ -7387,8 +7482,8 @@ msgstr "Quando è stata effettuata l'ultima transizione"
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/controlpanel.pt:52
 msgid "Whether or not content rules should be disabled globally. If this is selected, no rules will be executed anywhere in the portal."
 msgstr ""
-"Se le regole di contenuto devono essere disabilitate globalmente o meno.\n"
-"Se selezionato, nessuna regola sarà eseguita in nessun punto del portale."
+"Se le regole di contenuto devono essere disabilitate globalmente o meno. Se "
+"selezionato, nessuna regola sarà eseguita in nessun punto del portale."
 
 #: plone.contentrules/plone/contentrules/rule/interfaces.py:119
 msgid "Whether or not execution of further rules should stop after this rule is executed"
@@ -7396,11 +7491,14 @@ msgstr "Controlla se l'esecuzione delle regole successive debba essere sospesa o
 
 #: plone.contentrules/plone/contentrules/rule/interfaces.py:123
 msgid "Whether or not other rules should be triggered by the actions launched by this rule. Activate this only if you are sure this won't create infinite loops."
-msgstr "Decidi se l'esecuzione di questa regola può attivare o no l'esecuzione di altre regole. Attiva questa opzione solo se sei sicuro di non creare una ricorsione infinita."
+msgstr ""
+"Se l'esecuzione di questa regola debba attivare o no l'esecuzione di altre "
+"regole. Attiva questa opzione solo se sei sicuro di non creare una ricorsione "
+"infinita."
 
 #: plone.contentrules/plone/contentrules/rule/interfaces.py:115
 msgid "Whether or not the rule is currently enabled"
-msgstr "Controlla se la regola è abilitata o meno"
+msgstr "Se la regola è attualmente abilitata o meno"
 
 #: CMFPlone/skins/plone_form_scripts/plone_change_password.py:40
 #: plone.app.users/plone/app/users/browser/passwordpanel.py:134
@@ -7475,7 +7573,7 @@ msgstr "Sì"
 
 #: plone.app.registry/plone/app/registry/browser/templates/delete_layout.pt:27
 msgid "Yes, delete"
-msgstr "Si, cancella"
+msgstr "Sì, cancella"
 
 #: plone.app.content/plone/app/content/browser/contents/delete.py:85
 msgid "You are not authorized to delete ${title}."
@@ -7511,7 +7609,9 @@ msgstr "Puoi selezionare quali tipi di contenuto Archetypes vuoi migrare ad un e
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:66
 msgid "You can select which content types you want to migrate and choose to migrate references or not."
-msgstr "Puoi selezionare quali tipi di contenuto vuoi migrare e per quali migrare i riferimenti."
+msgstr ""
+"Puoi selezionare quali tipi di contenuto vuoi migrare e scegliere se migrare "
+"i riferimenti o no."
 
 #: plone.app.contenttypes/plone/app/contenttypes/browser/templates/archetypes_warning_viewlet.pt:9
 msgid "You can't edit this content unless you ${migrate}"
@@ -7547,7 +7647,12 @@ msgstr "Devi inserire un URL alternativo."
 
 #: plone.app.dexterity/plone/app/dexterity/browser/import_types.py:100
 msgid "You may import types by uploading a zip archive containing type profiles. The import archive should contain a types.xml file and a types directory containing one or more Dexterity type information files. For a sample, create a content type and export it from the Dexterity Content Types page."
-msgstr "Puoi importare le definizioni dei tipi caricando un archivio zip con i vari profili. L'archivio deve contenere un file \"types.xml\" e una cartella \"types\" contenente uno o più file con le informazioni dei contenuti Dexterity. Per avere un esempio, crea un tipo manualmente, ed esportalo dal pannello di controllo."
+msgstr ""
+"Puoi importare le definizioni dei tipi caricando un archivio zip con i vari "
+"profili. L'archivio deve contenere un file \"types.xml\" e una cartella "
+"\"types\" contenente uno o più file con le informazioni dei contenuti "
+"Dexterity. Per avere un esempio, crea un tipo manualmente, ed esportalo dalla "
+"pagina \"Tipi di contenuto Dexterity\" nel pannello di controllo."
 
 #: CMFPlone/skins/plone_login/login_form_validate.vpy:22
 #: CMFPlone/skins/plone_login/login_password_validate.vpy:17
@@ -7586,7 +7691,9 @@ msgstr "Devi prima accedere al sito."
 
 #: CMFPlone/browser/templates/plone-addsite.pt:137
 msgid "You normally don't need to change anything here unless you have specific reasons and know what you are doing."
-msgstr "Normalmente non è necessario cambiare alcunché se non hai una ragione molto particolare e non conosci bene quello che stai modificando"
+msgstr ""
+"Normalmente non è necessario cambiare alcunché se non hai una ragione molto "
+"particolare e non conosci bene quello che stai facendo."
 
 #: CMFPlone/interfaces/controlpanel.py:722
 msgid "You should pack your database regularly. This number indicates how many days of undo history you want to keep. It is unrelated to versioning, so even if you pack the database, the history of the content changes will be kept. Recommended value is 7 days."
@@ -7598,7 +7705,7 @@ msgstr "Il tuo sito Plone non è stato ancora aggiunto:"
 
 #: plone.app.discussion/plone/app/discussion/browser/comments.py:293
 msgid "Your comment awaits moderator approval."
-msgstr "Il tuo commento è in attesa di approvazione"
+msgstr "Il tuo commento è in attesa di approvazione."
 
 #: CMFPlone/RegistrationTool.py:195
 msgid "Your password and confirmation did not match. Please try again."
@@ -7696,7 +7803,7 @@ msgstr "aggiungi"
 #. Default: "This object is going to be a translation to ${language} from:"
 #: plone/app/multilingual/browser/templates/add-form-is-translation.pt:8
 msgid "add-form-is-translation"
-msgstr "Questo oggetto sta per diventare la traduzione di ${language} da: "
+msgstr "Questo oggetto sta per diventare la traduzione in ${language} da: "
 
 #. Default: "Add a new alternative url"
 #: CMFPlone/controlpanel/browser/redirects-controlpanel.pt:54
@@ -7744,7 +7851,7 @@ msgstr "Questo elemento non può essere rimosso perché è al momento bloccato d
 #. Default: "(This will delete a total of ${number_of_items_to_delete} items.)"
 #: plone.app.content/plone/app/content/browser/templates/delete_confirmation.pt:31
 msgid "alert_deleting_x_number_of_items"
-msgstr "(Questa operazione eliminerà ${number_of_items_to_delete} elemento/i)"
+msgstr "(Questa operazione eliminerà ${number_of_items_to_delete} elemento/i.)"
 
 #. Default: "Disconnect translation"
 #: plone/app/multilingual/browser/templates/disconnect_translation.pt:15
@@ -7802,7 +7909,7 @@ msgstr "Hai ricevuto questa mail poiché ${from_address} ha inviato un commento 
 #. Default: "You have received a message from ${from_address}."
 #: CMFPlone/browser/templates/author_feedback_template.pt:22
 msgid "author_message_mailtemplate_body"
-msgstr "Hai ricevuto un messaggio da: ${from_address}."
+msgstr "Hai ricevuto un messaggio da ${from_address}."
 
 #. Default: "First item"
 #: plone.batching/plone/batching/batchnavigation_bootstrap.pt:18
@@ -7831,7 +7938,7 @@ msgstr "Precedenti ${number} elementi"
 #: plone.app.querystring/plone/app/querystring/querybuilder.py:185
 #: plone.app.querystring/plone/app/querystring/results.pt:15
 msgid "batch_x_items_matching_your_criteria"
-msgstr "${number} elementi soddisfano i criteri specificati"
+msgstr "${number} elementi soddisfano i criteri specificati."
 
 #. Default: "Error"
 #: plone.app.portlets/plone/app/portlets/browser/templates/error_message.pt:9
@@ -7888,7 +7995,7 @@ msgstr "Ultime notizie"
 #. Default: "Previous events…"
 #: plone.app.event/plone/app/event/portlets/portlet_events.pt:55
 msgid "box_previous_events"
-msgstr "Eventi passati…"
+msgstr "Eventi precedenti…"
 
 #. Default: "published"
 #: CMFPlone/browser/templates/search.pt:257
@@ -8121,7 +8228,7 @@ msgstr "Usa il ${controlpanel_link} per creare nuove regole o eliminare o modifi
 #. Default: "The actions executed by this rule can trigger other rules"
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/manage-elements.pt:288
 msgid "contentrules_description_cascading"
-msgstr "Le azioni eseguite da questa regola scateneranno altre regole"
+msgstr "Le azioni eseguite da questa regola possono scatenare altre regole"
 
 #. Default: "Enter a short description of the rule and its purpose."
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/manage-elements.pt:260
@@ -8280,7 +8387,10 @@ msgstr "Questo strumento aggiunge un meccanismo per resettare in sicurezza una p
 #. Default: "Specify the time until timeout of password reset requests in hours. This interval, added to the time a user makes a request, will decide the expiration of the request."
 #: CMFPlone/browser/login/templates/explainPWResetTool.pt:12
 msgid "desc_set_exp_interval"
-msgstr "Specifica il tempo di durata del token per il reset della password. In ore. Questo tempo, sommato all'orario in cui viene eseguita la richiesta dall'utente, determinerà la scadenza della richiesta di reset."
+msgstr ""
+"Specifica il tempo di durata, in ore, del token per il reset della password. "
+"Questo tempo, sommato all'orario in cui viene eseguita la richiesta "
+"dall'utente, determinerà la scadenza della richiesta di reset."
 
 #. Default: "Use the form below to define, change or remove content rules. Rules will automatically perform actions on content when certain triggers take place. After defining rules, you may want to go to a folder to assign them, using the \"rules\" item in the actions menu."
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/controlpanel.pt:24
@@ -8305,7 +8415,9 @@ msgstr "Risulta accessibile anche per gli autori di contenuti con disabilità pe
 #. Default: "This site was designed to accommodate the different ways people access and use the Internet."
 #: CMFPlone/browser/templates/accessibility-info.pt:37
 msgid "description_accessibility_statement"
-msgstr "Questo sito è stato progettato per adattarsi alle differenti modalità con cui gli utenti accedono e usano la rete internet."
+msgstr ""
+"Questo sito è stato progettato per adattarsi alle differenti modalità con cui "
+"gli utenti accedono e usano Internet."
 
 #. Default: "Select the type of item you want to add to your folder."
 #: plone.app.content/plone/app/content/browser/folderfactories.pt:22
@@ -8315,24 +8427,34 @@ msgstr "Seleziona il tipo di elemento che vuoi aggiungere alla tua cartella."
 #. Default: "Using this form, you can manage alternative urls for an item. This is an easy way to make an item available under two different URLs."
 #: CMFPlone/controlpanel/browser/redirects-manage.pt:38
 msgid "description_adding_aliases"
-msgstr "Utilizzando questo form puoi gestire URL alternativi per un contenuto del sito. E' un modo semplice per rendere disponibile un contenuto del sito con due URL differenti."
+msgstr ""
+"Utilizzando questo form puoi gestire URL alternativi per un contenuto del "
+"sito. È un modo semplice per rendere disponibile un contenuto del sito con "
+"due URL differenti."
 
 #. Default: "Use the fields below to configure the Diazo theme manually. Usually, these settings are applied by enabling a theme from the <strong>Themes</strong> tab."
 #: plone/app/theming/browser/controlpanel.pt:350
 msgid "description_advanced"
-msgstr "Usa i campi seguenti per configurare il tema Diazo manualmente. Di solito queste impostazioni sono applicate abilitando un tema dalla schema <strong>Temi</strong>."
+msgstr ""
+"Usa i campi seguenti per configurare manualmente il tema Diazo. Di solito "
+"queste impostazioni sono applicate abilitando un tema dalla scheda "
+"<strong>Temi</strong>."
 
 #. Default: "The settings below control the presentation of the <em>content</em> produced by Plone before a Diazo theme is applied. Note that these settings will have an effect even if no Diazo theme is currently enabled."
 #: plone/app/theming/browser/controlpanel.pt:525
 msgid "description_advanced_base"
 msgstr ""
-"Queste impostazioni controllano la presentazione del <em>contenuto</em> prodotto da Plone prima che un tema Diazo sia applicato.\n"
-"Nota che queste impostazioni avranno effetto anche se nessun tema Diazo è al momento attivo."
+"Queste impostazioni controllano la presentazione del <em>contenuto</em> "
+"prodotto da Plone prima che un tema Diazo sia applicato. Nota che queste "
+"impostazioni avranno effetto anche se nessun tema Diazo è al momento attivo."
 
 #. Default: "This step will fix some lost dependencies to the ITranslatable interface hidden in the relation catalog and it gets rid of them. It must be run only when LinguaPlone is already uninstalled."
 #: plone/app/multilingual/browser/templates/migration.pt:225
 msgid "description_after_migration_cleanup"
-msgstr "Questo step fissa alcune dipendenze mancanti per l'interfaccia ITranslatable, nascoste nel relation catalog e le rimuove. Deve essere eseguito solamente quando LinguaPlone è già stato disinstallato."
+msgstr ""
+"Questo step correggerà alcune dipendenze mancanti per l'interfaccia "
+"ITranslatable nascoste nel relation catalog, rimuovendole. Deve essere "
+"eseguito solamente quando LinguaPlone è già stato disinstallato."
 
 #. Default: "Related to: use cookie for manual override"
 #: plone.i18n/plone/i18n/interfaces.py:150
@@ -8372,7 +8494,11 @@ msgstr "Puoi aggiungere più URL alternativi insieme caricando un file CSV. La p
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
 #: plone/app/multilingual/interfaces.py:247
 msgid "description_buttons_babel_view_up_to_nr_translations"
-msgstr "Quando ci sono diverse traduzioni per un contenuto, il numero di bottoni mostrati potrebbe essere troppo grande. Seleziona a partire da quante traduzioni mostrare un menu a discesa al posto dei bottoni. Lascia a zero per mostrare sempre dei bottoni."
+msgstr ""
+"Quando ci sono diverse traduzioni per un contenuto, il numero di pulsanti "
+"mostrati potrebbe essere troppo grande. Seleziona a partire da quante "
+"traduzioni mostrare un menu a discesa al posto dei pulsanti. Lascia a zero "
+"per mostrare sempre dei pulsanti."
 
 #. Default: "When updating an object with language independent the field will be synced to all target languages. That can produce Unauthorized error messages because if the editor of the canonical object is not allowed to update the target language objects. Enabling this bypasses this permission check. This could also be dangerous, so think about possible security issues before enabling this."
 #: plone/app/multilingual/interfaces.py:228
@@ -8387,17 +8513,31 @@ msgstr "Se è stato abilitato un proxy di caching, questo potrebbe aggiungere al
 #. Default: "Control how pages, images, style sheets and other resources are cached."
 #: plone.app.caching/plone/app/caching/browser/controlpanel.pt:85
 msgid "description_cache_settings"
-msgstr "Configurazione delle politiche di caching di pagine, immagini e fogli di stile."
+msgstr ""
+"Configurazione delle politiche di caching di pagine, immagini, fogli di stile "
+"e altre risorse."
 
 #. Default: "Choose a profile below to import cache settings. Additional profiles may be installed by third party products. <strong>Warning:</strong> This may overwrite existing settings."
 #: plone.app.caching/plone/app/caching/browser/import.pt:54
 msgid "description_caching_ipmort"
-msgstr "Selezionare un profilo qui sotto per importare le configurazioni della cache. Possono essere installati dei profili aggiuntivi da prodotti di terze parti.<strong>Attenzione:</strong> questa operazione potrebbe sovrascrivere le configurazioni esistenti."
+msgstr ""
+"Selezionare un profilo qui sotto per importare le configurazioni della cache. "
+"Possono essere installati dei profili aggiuntivi da prodotti di terze parti. "
+"<strong>Attenzione:</strong> questa operazione potrebbe sovrascrivere le "
+"configurazioni esistenti."
 
 #. Default: "High-performance sites will often place a caching reverse proxy such as Varnish or Squid in front of Zope. The caching operations configured elsewhere on this screen can often take advantage of such a proxy by instructing it to cache certain content in a certain way, whilst passing requests for other content through to Plone always. Plone can also send so-called <code>PURGE</code> requests to a caching proxy when content changes, reducing the risk of a stale response from a cached copy."
 #: plone.app.caching/plone/app/caching/browser/controlpanel.pt:129
 msgid "description_caching_proxies"
-msgstr "I siti ad alte prestazioni mettono spesso davanti a Zope un reverse proxy per il caching come Varnish o Squid. Le operazioni di caching configurate in altre parti di questo pannello possono prendere il controllo del proxy forzando il tipo di memorizzazione di certi contenuti e quando passare le richieste di altri contenuti direttamente a Plone. Plone può anche mandare una richiesta cosiddetta <code>PURGE</code> ad un proxy quando il contenuto viene modificato, riducendo così il rischio di una risposta obsoleta da una copia memorizzata."
+msgstr ""
+"I siti ad alte prestazioni mettono spesso davanti a Zope un reverse proxy per "
+"il caching come Varnish o Squid. Le operazioni di caching configurate in "
+"altre parti di questo pannello possono prendere il controllo del proxy "
+"forzando il tipo di memorizzazione di certi contenuti, passando invece le "
+"richieste di altri contenuti direttamente a Plone. Plone può anche mandare "
+"una richiesta cosiddetta <code>PURGE</code> ad un proxy quando il contenuto "
+"viene modificato, riducendo così il rischio di una risposta obsoleta da una "
+"copia memorizzata."
 
 #. Default: "Canceling the check-out will delete this working copy, and any modifications made to it will be lost. The existing version of the content will become unlocked."
 #: plone.app.iterate/plone/app/iterate/browser/cancel.pt:22
@@ -8454,12 +8594,14 @@ msgstr "Al momento non ci sono regole di contenuto attive su questo ${type_name}
 #. Default: "This rule is assigned to the following locations:"
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/manage-elements.pt:229
 msgid "description_contentrules_rule_assignments"
-msgstr "Questa regola è assegnata nelle seguenti posizioni."
+msgstr "Questa regola è assegnata nelle seguenti posizioni:"
 
 #. Default: "Note that content type portlets are normally rendered below context portlets."
 #: plone.app.portlets/plone/app/portlets/browser/templates/manage-content-type.pt:34
 msgid "description_contenttype_portlets_below"
-msgstr "Nota che di norma i portlet associate ai tipi di contenuto vengono visualizzati sotto quelli contestuali."
+msgstr ""
+"Nota che di norma i portlet associati ai tipi di contenuto vengono "
+"visualizzati sotto quelli contestuali."
 
 #. Default: "Configuration area for Plone and add-on Products."
 #: CMFPlone/controlpanel/browser/overview.pt:20
@@ -8479,12 +8621,34 @@ msgstr "${plonecms} è ${copyright} 2000-${current_year} della ${plonefoundation
 #. Default: "You are running in \"debug mode\". This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process."
 #: CMFPlone/controlpanel/browser/overview.pt:169
 msgid "description_debug_mode"
-msgstr "La modalità di \"debug\" è attivata. Questa modalità è utile durante lo sviluppo del sito, dal momento che consente l'immediata attivazione delle modifiche apportate ma causa un generale rallentamento delle operazioni. Per disattivarla devi spegnere il server, impostare l'opzione 'debug-mode=off' nel file buildout.cfg, eseguire nuovamente il buildout ed infine riavviare il server Zope."
+msgstr ""
+"La modalità di \"debug\" è attivata. Questa modalità è utile durante lo "
+"sviluppo del sito, dal momento che consente l'immediata attivazione delle "
+"modifiche apportate ma causa un generale rallentamento delle operazioni. Per "
+"disattivarla devi spegnere il server, impostare l'opzione \"debug-mode=off\" "
+"nel file buildout.cfg, eseguire nuovamente il buildout ed infine riavviare il "
+"server Zope."
 
 #. Default: "<p> Many caching operations accept parameters to influence their behaviour. For example, an operation which returns a page cached in RAM may accept a parameter specifying the timeout period before pages are re-calculated. Most operations, however, will have \"sensible defaults\", so that they work acceptably even when no parameters have been set. Note also that not all operations support parameters. </p> <p> Parameters can be set at two levels. By default, parameters apply to all uses of particular operation. Thus, if you have assigned an operation to more than one ruleset, the <em>same</em> parameters will be used. However, you can also override the parameters for a particular ruleset. </p> <p> Use the table below to access parameters for a particular operation or ruleset. <strong>Warning:</strong> If you have made changes elsewhere in this form, you should save them before configuring any operation parameters. Otherwise, you will lose your changes. </p>"
 #: plone.app.caching/plone/app/caching/browser/controlpanel.pt:536
 msgid "description_detailed_settings"
-msgstr "<p> Molte operazioni di caching accettano dei parametri per modificare il proprio comportamento. Ad esempio, un'operazione che restituisce una pagina memorizzata in RAM potrebbe accettare un parametro che specifichi il periodo di timeout prima che la pagina venga ricalcolata. La maggior parte delle operazioni comunque avranno un comportamento predefinito ragionevole in modo da poter operare anche senza parametri. Notare inoltre che non tutte le operazione supportano dei parametri. </p><p> I parametri possono essere impostati a due livelli. Normalmente i parametri si applicano a tutti gli utilizzi di una particolare operazione. Quindi, se avete assegnato un'operazione a più di una regola, verranno utilizzati gli <em>stessi</em> parametri. È comunque possibile sovrascrivere i parametri per una certa regola.</p> <p> Utilizzare la tabella sottostante per accedere ai parametri di una particolare regola. <strong>Attenzione:</strong> se sono state fatte modifiche in altre parti di questo pannello, è necessario salvare le modifiche prima di configurare qualsiasi altro parametro delle operazioni, altrimenti le modifiche fatte andranno perse."
+msgstr ""
+"<p> Molte operazioni di caching accettano dei parametri per modificare il "
+"proprio comportamento. Ad esempio, un'operazione che restituisce una pagina "
+"memorizzata in RAM potrebbe accettare un parametro che specifichi il periodo "
+"di timeout prima che la pagina venga ricalcolata. La maggior parte delle "
+"operazioni comunque avranno un comportamento predefinito ragionevole in modo "
+"da poter operare anche senza parametri. Notare inoltre che non tutte le "
+"operazione supportano dei parametri. </p><p> I parametri possono essere "
+"impostati a due livelli. Normalmente i parametri si applicano a tutti gli "
+"utilizzi di una particolare operazione. Quindi, se avete assegnato "
+"un'operazione a più di una regola, verranno utilizzati gli <em>stessi</em> "
+"parametri. È comunque possibile sovrascrivere i parametri per una certa "
+"regola.</p> <p> Utilizzare la tabella sottostante per accedere ai parametri "
+"di una particolare regola. <strong>Attenzione:</strong> se sono state fatte "
+"modifiche in altre parti di questo pannello, è necessario salvare le "
+"modifiche prima di configurare qualsiasi altro parametro delle operazioni, "
+"altrimenti le modifiche fatte andranno perse.</p>"
 
 #. Default: "This information, also referred to as <em>metadata</em> is the collection of information that is used to categorize an object, assign effective dates and expiration dates, language, and keywords."
 #: Archetypes/skins/archetypes/metadata_macros.pt:32
@@ -8545,7 +8709,9 @@ msgstr "I gruppi sono insiemi logici di utenti che condividono una certa caratte
 #. Default: "The symbol ${image_link_icon} indicates a role inherited from membership in another group."
 #: CMFPlone/controlpanel/browser/usergroups_groupsoverview.pt:66
 msgid "description_groups_management2"
-msgstr "Il simbolo ${image_link_icon} indica un ruolo che eredita i permessi da un gruppo"
+msgstr ""
+"Il simbolo ${image_link_icon} indica un ruolo che eredita i permessi da un "
+"gruppo."
 
 #. Default: "You can import a Zip file containing an existing theme. This should contain a single top level directory, which will be used as the theme identifier. If no Diazo <code>rules.xml</code> or <code>manifest.cfg</code> file is found in this directory, a default <code>rules.xml</code> file will be created."
 #: plone/app/theming/browser/controlpanel.pt:730
@@ -8580,7 +8746,7 @@ msgstr "Impostazioni relative alle lingue e alle traduzioni dei contenuti."
 #. Default: "Distributed under the ${license}."
 #: CMFPlone/browser/templates/footer.pt:30
 msgid "description_license"
-msgstr "Distribuito sotto licenza ${license}."
+msgstr "Distribuito sotto ${license}."
 
 #. Default: "The link is used almost verbatim, relative links become absolute and the strings \"${navigation_root_url}\" and \"${portal_url}\" get replaced with the real navigation_root_url or portal_url. If in doubt which one to use, please use navigation_root_url."
 #: plone.app.contenttypes/plone/app/contenttypes/schema/link.xml
@@ -8635,7 +8801,17 @@ msgstr "Le colonne con i portlet a destra e sinistra mostreranno solo i portlet 
 #. Default: "<p> Caching can be controlled by mapping <em>rulesets</em> to <em>caching operations</em>. </p> <p> A <strong>ruleset</strong> is a name given to a resource published by Plone, such as a view. Rulesets are declared by the developers who write those views. You can think of them as a way to give hints about how something should be cached, without actually implementing the caching operations. </p> <p> The exact caching operations to use are mapped to rulesets in the table below. Caching operations will often set response headers to tell the users's web browser and/or a caching proxy how to cache content. They may also intercept a response to return a cached copy or instruct the browser to use its own cached copy, if it is considered to be current. </p>"
 #: plone.app.caching/plone/app/caching/browser/controlpanel.pt:384
 msgid "description_mappings"
-msgstr "<p> Il caching può essere controllato assegnando le <em>Regole</em> alle <em>Operazioni di caching</em>. </p><p> Una <strong>Regola</strong> è il nome dato ad una risorsa pubblicata da Plone, come ad esempio una vista. Le regole sono dichiarate dagli sviluppatori che scrivono queste viste. Si può pensare ad una regola come ad un'istruzione su come una risorsa debba essere aggiunta alla cache, senza implementare effettivamente le operazioni di caching. </p><p>Le specifiche operazioni di caching da usare sono assegnate alle regole nella tabella sottostante. Le operazioni di caching definiscono spesso le intestazioni delle risposte da inviare al browser dell'utente per utilizzare la sua copia di cache se questa è aggiornata."
+msgstr ""
+"<p> Il caching può essere controllato assegnando le <em>Regole</em> alle "
+"<em>Operazioni di caching</em>. </p><p> Una <strong>Regola</strong> è il nome "
+"dato ad una risorsa pubblicata da Plone, come ad esempio una vista. Le regole "
+"sono dichiarate dagli sviluppatori che scrivono queste viste. Si può pensare "
+"ad una regola come ad un'istruzione su come una risorsa debba essere aggiunta "
+"alla cache, senza implementare effettivamente le operazioni di caching. "
+"</p><p>Le specifiche operazioni di caching da usare sono assegnate alle "
+"regole nella tabella sottostante. Le operazioni di caching definiscono spesso "
+"le intestazioni delle risposte da inviare al browser dell'utente per "
+"utilizzare la sua copia di cache se questa è aggiornata.</p>"
 
 #. Default: "This search form enables you to find users by specifying one or more search criteria."
 #: plone.app.users/plone/app/users/browser/membersearch.py:89
@@ -8660,7 +8836,14 @@ msgstr "Qui potrai vedere i risultati del processo di migrazione"
 #. Default: "This form allows you to directly edit the XML representation of the field list. This makes it possible to add annotations for fieldsets, validation and widgets. See the <a href=\"https://docs.plone.org/external/plone.app.dexterity/docs/reference/dexterity-xml.html\">Dexterity XML</a> section of the <a href=\"https://docs.plone.org/external/plone.app.dexterity/docs/index.html\">Dexterity Developer Manual</a> for details."
 #: plone.app.dexterity/plone/app/dexterity/browser/modeleditor.pt:25
 msgid "description_model_edit"
-msgstr "Questo form ti permette di modificare direttamente la rappresentazione in XML dei campi. E' possibile aggiungere fieldsets, validazioni e widgets. Per dettagli, vedi il <a href=\"https://docs.plone.org/external/plone.app.dexterity/docs/reference/dexterity-xml.html\">Dexterity XML</a> section of the <a href=\"https://docs.plone.org/external/plone.app.dexterity/docs/index.html\">Dexterity Developer Manual</a>."
+msgstr ""
+"Questo form ti permette di modificare direttamente la rappresentazione in XML "
+"dei campi. È possibile aggiungere fieldsets, validazioni e widgets. Per "
+"dettagli, vedi la sezione <a "
+"href=\"https://docs.plone.org/external/plone.app.dexterity/docs/reference/dext"
+"erity-xml.html\">Dexterity XML</a> del <a "
+"href=\"https://docs.plone.org/external/plone.app.dexterity/docs/index.html\">D"
+"exterity Developer Manual</a>."
 
 #. Default: "Add or delete translations"
 #: plone/app/multilingual/browser/menu.py:220
@@ -8768,7 +8951,13 @@ msgstr "Impostazioni personali per $name"
 #. Default: "You are running in \"production mode\". This is the preferred mode of operation for a live Plone site, but means that some configuration changes will not take effect until your server is restarted or a product refreshed. If this is a development instance, and you want to enable debug mode, stop the server, set 'debug-mode=on' in your buildout.cfg, re-run bin/buildout and then restart the server process."
 #: CMFPlone/controlpanel/browser/overview.pt:157
 msgid "description_production_mode"
-msgstr "Modalità \"produzione\" attivata. Questa è la modalità preferibile per un sito Plone, ma implica che eventuali modifiche apportate alla configurazione non avranno effetto finché il server non venga riavviato o aggiornato un prodotto. Se questa è una istanza di sviluppo e volessi attivare la modalità di debug, ferma il server, imposta 'debug-mode=on' nel file buildout.cfg, esegui il buildout e riavvia il server."
+msgstr ""
+"Modalità \"produzione\" attivata. Questa è la modalità preferibile per un "
+"sito Plone, ma implica che eventuali modifiche apportate alla configurazione "
+"non avranno effetto finché il server non venga riavviato o aggiornato un "
+"prodotto. Se questa è una istanza di sviluppo e volessi attivare la modalità "
+"di debug, ferma il server, imposta \"debug-mode=on\" nel file buildout.cfg, "
+"esegui il buildout e riavvia il server."
 
 #. Default: "An item's status (also called its review state) determines who can see it. Another way to control the visibility of an item is with its <em class=\"discreet\">Publishing Date</em>. An item is not publicly searchable before its publishing date. This will prevent the item from showing up in portlets and folder listings, although the item will still be available if accessed directly via its URL."
 #: plone.app.content/plone/app/content/browser/templates/content_status_history.pt:53
@@ -8818,7 +9007,7 @@ msgstr "Usa il form seguente per modificare il valore di un particolare record."
 #. Default: "After creating a new translation redirecto to babel view"
 #: plone/app/multilingual/interfaces.py:216
 msgid "description_redirect_babel_view"
-msgstr "Dopo aver creato una nuova traduzione redirigi l'utente alla 'babel view'"
+msgstr "Dopo aver creato una nuova traduzione redirigi l'utente alla \"babel view\""
 
 #. Default: "The table below shows record currently managed by the configuration registry. Click on a record to edit it."
 #: plone.app.registry/plone/app/registry/browser/templates/records.pt:29
@@ -8833,7 +9022,13 @@ msgstr "Utilizza questo campo per definire i tipi di contenuto che non verranno 
 #. Default: "This step will move the site's content to its corresponding root language folder and previously will make a search for misplaced content through the site's content tree and will move them to its nearest translated parent. This step is destructive as it will alter your content tree structure. Make sure you have previously configured your site's languages properly in the 'Site Languages' tab of the 'Languages' control panel."
 #: plone/app/multilingual/browser/templates/migration.pt:149
 msgid "description_relocate_content"
-msgstr "Questo step sposta tutti i contenuti del sito nella rispettiva cartella radice di lingua ed effettua anche un ricerca per contenuti che si trovano in cartelle di lingua sbagliate e prova a spostarli in quella corretta. Questa operazione è distruttiva in quanto altera la struttura del sito. Assicutati di aver configurato correttamente le impostazioni di lingua del sito prima di eseguirla."
+msgstr ""
+"Questo step sposta tutti i contenuti del sito nella rispettiva cartella "
+"radice di lingua ed effettua anche un ricerca per contenuti che si trovano in "
+"cartelle di lingua sbagliate e prova a spostarli in quella corretta. Questa "
+"operazione è distruttiva in quanto altera la struttura del sito. Assicurati "
+"di aver configurato correttamente le impostazioni di lingua del sito prima di "
+"eseguirla."
 
 #. Default: "Each item has a Short Name and a Title, which you can change by entering the new details below."
 #: plone.app.content/plone/app/content/browser/actions.py:132
@@ -8954,7 +9149,7 @@ msgstr "Abilitando la Distribuzione consentirai ad altri siti web di sincronizza
 #. Default: "A test portlet"
 #: plone.app.portlets/plone/app/portlets/tests/profiles/testing/portlets.xml
 msgid "description_test_portlet"
-msgstr "Una portlet di test"
+msgstr "Un portlet di test"
 
 #. Default: "e.g.: www.plone.de"
 #: plone.i18n/plone/i18n/interfaces.py:185
@@ -8964,7 +9159,10 @@ msgstr "esempio: www.plone.it"
 #. Default: "This step will transfer the relations between translations stored by LinguaPlone to the PAM catalog. This step is not destructive and can be executed as many times as needed."
 #: plone/app/multilingual/browser/templates/migration.pt:195
 msgid "description_transfer_multilingual_catalog_info"
-msgstr "Questo step converte le relazioni tra traduzioni memorizzate da LinguaPlone nel PM catalog. Questo step non è distruttivo e può essere eseguito quante volte si vuole."
+msgstr ""
+"Questo step trasferirà le relazioni tra le traduzioni memorizzate da "
+"LinguaPlone al catalog PAM. Questo step non è distruttivo e può essere "
+"eseguito quante volte si vuole."
 
 #. Default: "Translate into ${lang_name}"
 #: plone/app/multilingual/browser/menu.py:167
@@ -8974,7 +9172,7 @@ msgstr "Traduci in ${lang_name}"
 #. Default: "Translation map."
 #: plone/app/multilingual/browser/templates/mmap.pt:70
 msgid "description_translation_map"
-msgstr "Mappa traduzioni"
+msgstr "Mappa traduzioni."
 
 #. Default: "Workflow, visibility and versioning settings for your content types."
 #: CMFPlone/controlpanel/browser/types.pt:16
@@ -8984,7 +9182,7 @@ msgstr "Impostazioni sul workflow, visibilità e sul versionamento dei tipi di c
 #. Default: "Universal link to the content in user's preferred language"
 #: plone/app/multilingual/browser/menu.py:241
 msgid "description_universal_link"
-msgstr "Link universale indipendente dalla lingua"
+msgstr "Link universale al contenuto nella lingua preferita dell'utente"
 
 #. Default: "Untranslated languages from the current content"
 #: plone/app/multilingual/browser/interfaces.py:63
@@ -9100,7 +9298,10 @@ msgstr "I cookie non sono abilitati. Devi abilitarli per poterti autenticare."
 #. Default: "Use this option to enable or disable the theme globally. Note that the options will also affect whether the theme is used when this option is enabled."
 #: plone/app/theming/interfaces.py:85
 msgid "enable_theme_globally"
-msgstr "Usa questa opzione per abilitare o disabilitare il tema globalmente. Nota che l'opzione avrà effetto se il temma viene utilizzato quando questa opzione è abilitata"
+msgstr ""
+"Usa questa opzione per abilitare o disabilitare il tema globalmente. Nota che "
+"l'opzione avrà effetto se il tema viene utilizzato quando questa opzione è "
+"abilitata"
 
 #. Default: "Enabled"
 #: plone/app/theming/interfaces.py:84
@@ -9115,7 +9316,9 @@ msgstr "Il Mimetype ${mimetype} non è permesso in ${name}, prego correggi."
 #. Default: "This theme is already installed. Select 'Replace existing theme' and re-upload to replace it."
 #: plone/app/theming/browser/controlpanel.py:276
 msgid "error_already_installed"
-msgstr "Questo tema è già applicato. Seleziona 'Sostituisci il tema corrente' e carica nuovamente il tema per sostituirlo."
+msgstr ""
+"Questo tema è già applicato. Seleziona \"Sostituisci il tema corrente\" e "
+"carica nuovamente il tema per sostituirlo."
 
 #. Default: "No alternative urls were added. Please correct these errors in your CSV file and try again:"
 #: CMFPlone/controlpanel/browser/redirects-controlpanel.pt:16
@@ -9243,7 +9446,7 @@ msgstr "Esempio:"
 
 #: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:139
 msgid "except"
-msgstr " eccetto"
+msgstr "eccetto"
 
 #: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:62
 msgid "exclude"
@@ -9277,7 +9480,7 @@ msgstr "Visita il sito"
 #. Default: "The '${value1}' vocabulary value conflicts with '${value2}'."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:193
 msgid "field_edit_error_conflicting_values"
-msgstr "Il valore '${value1}' nel vocabolario è in conflitto con '${value2}'."
+msgstr "Il valore \"${value1}\" nel vocabolario è in conflitto con \"${value2}\"."
 
 #. Default: "You can not set a vocabulary name AND vocabulary values. Please clear values field or set no value here."
 #: plone.schemaeditor/plone/schemaeditor/fields.py:225
@@ -9371,7 +9574,7 @@ msgstr "Vai a"
 #. Default: "All content created by ${user}…"
 #: CMFPlone/browser/templates/author.pt:225
 msgid "go_to_search_author_content"
-msgstr "Trova tutti contenuti creati da ${user}…"
+msgstr "Trova tutti i contenuti creati da ${user}…"
 
 #. Default: "With kind regards,"
 #: CMFPlone/browser/login/templates/registered_notify_template.pt:28
@@ -9417,7 +9620,7 @@ msgstr "Aggiungi l'evento al calendario"
 #. Default: "Add New User"
 #: plone.app.users/plone/app/users/browser/register.py:620
 msgid "heading_add_user_form"
-msgstr "Aggiungi utente"
+msgstr "Aggiungi nuovo utente"
 
 #. Default: "Approved by"
 #: plone.app.discussion/plone/app/discussion/browser/comments_approved.pt:65
@@ -9457,7 +9660,7 @@ msgstr "Usa la richiesta di negoziazione della lingua fatta dal browser"
 #. Default: "Use buttons in the bable view for up to how many translations?"
 #: plone/app/multilingual/interfaces.py:243
 msgid "heading_buttons_babel_view_up_to_nr_translations"
-msgstr "Utilizza i bottoni nella vista babel per vedere quante traduzioni ci sono?"
+msgstr "Fino a quante traduzioni devono essere usati dei pulsanti nella vista babel?"
 
 #. Default: "Bypass language independent field permission check"
 #: plone/app/multilingual/interfaces.py:225
@@ -9482,7 +9685,7 @@ msgstr "Impostazioni del caching"
 #. Default: "Time to change your password!"
 #: CMFPlone/browser/login/templates/forced_password_change.pt:9
 msgid "heading_change_password"
-msgstr "E' ora di cambiare la tua password!"
+msgstr "È ora di cambiare la tua password!"
 
 #. Default: "Change password for ${user}"
 #: CMFPlone/skins/plone_prefs/password_form.pt:15
@@ -9538,7 +9741,7 @@ msgstr "Condivisioni di ${folder}"
 #. Default: "${user_name}&#8217;s dashboard"
 #: plone.app.layout/plone/app/layout/dashboard/dashboard.pt:16
 msgid "heading_dashboard"
-msgstr "Dashboard di ${user_name}"
+msgstr "Bacheca di ${user_name}"
 
 #. Default: "Date"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:106
@@ -9584,7 +9787,7 @@ msgstr "Contenuto del file"
 #. Default: "Filter content by language."
 #: plone/app/multilingual/interfaces.py:202
 msgid "heading_filter_content"
-msgstr "Filtra i contenuti per lingua"
+msgstr "Filtra i contenuti per lingua."
 
 #. Default: "Find duplicate login names"
 #: CMFPlone/controlpanel/browser/emaillogin.pt:11
@@ -9774,7 +9977,7 @@ msgstr "Elementi pubblicati"
 #. Default: "Redirect on creation to babel view."
 #: plone/app/multilingual/interfaces.py:213
 msgid "heading_redirect_babel_view"
-msgstr "Alla creazione usa la vista 'babel'"
+msgstr "Alla creazione usa la vista babel"
 
 #. Default: "Registration form"
 #: plone.app.users/plone/app/users/browser/register.py:552
@@ -10002,7 +10205,7 @@ msgstr "Un portlet delle azioni mostra le azioni di una categoria"
 #. Default: "Select the restriction policy in this location"
 #: plone.app.content/plone/app/content/browser/constraintypes.py:67
 msgid "help_add_restriction_mode"
-msgstr "Seleziona la politica di restrizioni per questa posizione."
+msgstr "Seleziona la politica di restrizioni per questa posizione"
 
 #. Default: "Content types show up on Plone's \"Add Item\" menu and allow you to store custom data in your site. Click the \"Add Content Type\" button to begin creating a new content type with its own fields."
 #: plone.app.dexterity/plone/app/dexterity/browser/types.py:200
@@ -10043,7 +10246,10 @@ msgstr "Solo i ruoli qui elencati potranno aggiungere parole chiave "
 #. Default: "If selected, anonymous users are able to post comments without logging in. It is highly recommended to use a captcha solution to prevent spam if this setting is enabled."
 #: plone.app.discussion/plone/app/discussion/interfaces.py:229
 msgid "help_anonymous_comments"
-msgstr "Se selezionato, gli utenti anonimi saranno in grado di inserire commenti senza autenticazione. È altamente consigliato l'uso di captcha to prevenire spam se questa impostazione viene abilitata."
+msgstr ""
+"Se selezionato, gli utenti anonimi saranno in grado di inserire commenti "
+"senza autenticazione. È caldamente consigliato l'uso di captcha to prevenire "
+"spam se questa impostazione viene abilitata."
 
 #. Default: "If selected, anonymous user will have to give their email."
 #: plone.app.discussion/plone/app/discussion/interfaces.py:243
@@ -10058,7 +10264,10 @@ msgstr "URL del server di controllo ortografico \"After the Deadline\". Il valor
 #. Default: "A list of error types which the \"After the Deadline\" spellchecker should check for. By default, all the available error type will be listed here."
 #: CMFPlone/interfaces/controlpanel.py:608
 msgid "help_atderrortypes_to_show"
-msgstr "Un elenco di tipi di errore che il correttore ortografico \"After the Deadline\" dovrebbe controllare. Il comportamento predefinito è di controllare tutti quelli qui elencati. "
+msgstr ""
+"Un elenco di tipi di errore che il correttore ortografico \"After the "
+"Deadline\" dovrebbe controllare. Il comportamento predefinito è di "
+"controllare tutti quelli qui elencati."
 
 #. Default: "The timezones, which should be available for the portal. Can be set for users and events"
 #: CMFPlone/interfaces/controlpanel.py:1210
@@ -10127,7 +10336,7 @@ msgstr "Reinserisci la password. Assicurati che le password siano identiche."
 #. Default: "&e = the triggering event, &c = the context, &u = the user"
 #: plone.app.contentrules/plone/app/contentrules/actions/logger.py:42
 msgid "help_contentrules_logger_message"
-msgstr "&e = l'evento scatenante, &c = il contesto, &u = l'utente'"
+msgstr "&e = l'evento scatenante, &c = il contesto, &u = l'utente"
 
 #. Default: "The names of people that have contributed to this item. Each contributor should be on a separate line."
 #: Archetypes/ExtensibleMetadata.py:112
@@ -10172,7 +10381,12 @@ msgstr "Inserisci la tua password attuale."
 #: plone/app/theming/browser/controlpanel.pt:597
 #: plone/app/theming/interfaces.py:183
 msgid "help_custom_css"
-msgstr "Insersci delle regole CSS per personalizzare rapidamente l'aspetto del sito. Queste regole avranno la precedenza su quelle definite da Plone. È una buona idea limitare l'uso di questo campo a piccole personalizzazioni poiché è molto facile perdere traccia dei cambiamenti effettuati. Per cambioamenti più importanti è più indicato utilizzare un tema personalizzato."
+msgstr ""
+"Inserisci delle regole CSS per personalizzare rapidamente l'aspetto del sito. "
+"Queste regole avranno la precedenza su quelle definite da Plone. È una buona "
+"idea limitare l'uso di questo campo a piccole personalizzazioni poiché è "
+"molto facile perdere traccia dei cambiamenti effettuati. Per cambiamenti più "
+"importanti è più indicato utilizzare un tema personalizzato."
 
 #. Default: "Columns in the table are controlled by 'Table Columns' below."
 #: widget description of BooleanWidget for label Display as Table
@@ -10226,7 +10440,20 @@ msgstr "Puoi specificare un Doctype che verrà impostato nell'output del tema, a
 #. Default: "<p> If you have enabled <em>Virtual host rewriting takes place front of the caching proxy</em> above, and your site is reachable via multiple domains (e.g. <code>http://example.com:80</code> vs. <code>http://www.example.com:80</code>), enter all available domains here, one per line. This will ensure that purge requests are sent for all domains where applicable. Note that it is more efficient to configure the front-most web server to simply redirect all requests to a single domain, so that Zope only \"sees\" a single domain. </p> <p> It is safe to leave this list blank if you are not using a caching proxy, if you are not using virtual hosting, if virtual host rewriting takes place behind the caching proxy, or if you only have a single virtually hosted domain name. </p>"
 #: plone.app.caching/plone/app/caching/browser/controlpanel.pt:246
 msgid "help_domains"
-msgstr "<p> Se l'opzione \"<em>Le riscritture del Virtual Host avvengono prima del proxy di caching</em>\" è abilitata, e se il sito è raggiungibile da domini multipli (es. <code>http://example.com:80</code> e <code>http://www.example.com:80</code>), inserire qui tutti i domini disponibili, uno per linea. Questo assicura che le richieste di rimozione vengano inviate a tutti i domini, dove possibile. Notare che è più efficiente configurare il web server più esterno per redirigere semplicemente tutte le richieste verso un singolo dominio, così che Zope 'veda' un singolo dominio.</p><p> E' più sicuro lasciare questa lista vuota nei seguenti casi: non si sta utilizzando un proxy di caching, oppure non si sta utilizzando il virtual hosting, oppure le riscritture del virtual host avvengono <em>dopo</em> il proxy di caching oppure si utilizza un singolo nome di dominio con il virtual host."
+msgstr ""
+"<p> Se l'opzione \"<em>Le riscritture del Virtual Host avvengono prima del "
+"proxy di caching</em>\" è abilitata, e se il sito è raggiungibile da domini "
+"multipli (es. <code>http://example.com:80</code> e "
+"<code>http://www.example.com:80</code>), inserire qui tutti i domini "
+"disponibili, uno per linea. Questo assicura che le richieste di rimozione "
+"vengano inviate a tutti i domini, dove possibile. Notare che è più efficiente "
+"configurare il web server più esterno per redirigere semplicemente tutte le "
+"richieste verso un singolo dominio, così che Zope 'veda' un singolo "
+"dominio.</p><p>È più sicuro lasciare questa lista vuota nei seguenti casi: "
+"non si sta utilizzando un proxy di caching, oppure non si sta utilizzando il "
+"virtual hosting, oppure le riscritture del virtual host avvengono "
+"<em>dopo</em> il proxy di caching oppure si utilizza un singolo nome di "
+"dominio con il virtual host.</p>"
 
 #. Default: "Switching the email login setting in the ${link} on or off automatically changes the login name for existing users. This may fail when there are duplicates. On this page you can search for duplicates."
 #: CMFPlone/controlpanel/browser/emaillogin.pt:18
@@ -10236,7 +10463,9 @@ msgstr "Cambiando le impostazioni di autenticazione in ${link}, cambia automatic
 #. Default: "If selected, supports editing of comments for users with the \"Edit comments\" permission."
 #: plone.app.discussion/plone/app/discussion/interfaces.py:274
 msgid "help_edit_comment_enabled"
-msgstr "Se selezionato, verrà abilitato il supporto alla modifica dei commenti da parte degli utenti che hanno il permesso 'Edit comments'."
+msgstr ""
+"Se selezionato, verrà abilitato il supporto alla modifica dei commenti da "
+"parte degli utenti che hanno il permesso \"Edit comments\"."
 
 #. Default: "The date when the item will be published. If no date is selected the item will be published immediately."
 #: Archetypes/ExtensibleMetadata.py:137
@@ -10370,7 +10599,9 @@ msgstr "Se selezionato tutti i link esterni nell'area del contenuto si apriranno
 #. Default: "External URL (can be relative within this site or absolute if it starts with http:// or https://)"
 #: plone.app.z3cform/plone/app/z3cform/templates/link_input.pt:27
 msgid "help_external_url"
-msgstr "URL esterno (può essere relativo a questo sito or assoluto se inizia con http:// o https://)"
+msgstr ""
+"URL esterno (può essere relativo a questo sito o assoluto se inizia con "
+"http:// o https://)"
 
 #. Default: "First day in the week."
 #: CMFPlone/interfaces/controlpanel.py:1222
@@ -10407,7 +10638,13 @@ msgstr "L'indirizzo della tua pagina personale esterna, se ne hai una."
 #. Default: "If there are hostnames that you do not want to be themed, you can list them here, one per line. This is useful during theme development, so that you can compare the themed and unthemed sites. In some cases, you may also want to provided an unthemed host alias for content administrators to be able to use 'plain' Plone."
 #: plone/app/theming/browser/controlpanel.pt:467
 msgid "help_hostname_blacklist"
-msgstr "Se ci sono dei nomi di host ai quali non vuoi che venga applicato il tema, puoi inserirli qui sotto, uno per riga. Questo è utile durante lo sviluppo di un nuovo tema per confrontare il sito con il tema e quello senza. In alcuni casi potresti avere la necessità di fornire un alias del sito per l'amministrazione dei contenuti senza il tema applicato per essere in grado di usare un Plone 'puro'."
+msgstr ""
+"Se ci sono dei nomi di host ai quali non vuoi che venga applicato il tema, "
+"puoi inserirli qui sotto, uno per riga. Questo è utile durante lo sviluppo di "
+"un nuovo tema per confrontare il sito con il tema e quello senza. In alcuni "
+"casi potresti avere la necessità di fornire un alias del sito per "
+"l'amministrazione dei contenuti senza il tema applicato per essere in grado "
+"di usare un Plone \"puro\"."
 
 #. Default: "Import Events from icalendar files."
 #: plone.app.event/plone/app/event/profiles/default/actions.xml
@@ -10439,7 +10676,10 @@ msgstr "Se attivato, verrà modificato lo stato di tutti i contenuti nelle carte
 #. Default: "Whether or not to show the top, or 'root', node in the navigation tree. This is affected by the 'Start level' setting."
 #: plone.app.portlets/plone/app/portlets/portlets/navigation.py:66
 msgid "help_include_top_node"
-msgstr "Determina se mostrare o meno il link alla radice del portale nella prima posizione dell'albero di navigazione. Viene influenzato dall'impostazione 'Livello iniziale'."
+msgstr ""
+"Determina se mostrare o meno il link alla radice del portale nella prima "
+"posizione dell'albero di navigazione. Viene influenzato dall'impostazione "
+"\"Livello iniziale\"."
 
 #. Default: "Narrow down the search results from the parent Smart Folder(s) by using the criteria from this Smart Folder."
 #: widget description of BooleanWidget for label Inherit Criteria
@@ -10634,7 +10874,16 @@ msgstr "Un breve commento che sarà inserito nella cronologia della pubblicazion
 #. Default: "If you have enabled purging, Plone can automatically purge the views of content items when they are modified or removed. Select the types to automatically purge below. <strong>Note:</strong> although a content items's view can be purged easily, it is not always possible to purge every page where that item may appear. Items that appear in dynamic listings (such as <em>Collection</em> portlets), the navigation tree and other navigational aids may appear out of date if you have cached the pages where those items would appear."
 #: plone.app.caching/plone/app/caching/browser/controlpanel.pt:188
 msgid "help_purged_content_types"
-msgstr "Se l'opzione <em>Abilita il purge</em> è stata abilitata, Plone può svuotare automaticamente le viste dei contenuti quando vengono modificati o rimossi. Selezionare qui sotto i tipi da svuotare automaticamente. <strong>Nota:</strong> anche se la vista di un contenuto può essere svuotata facilmente, non è sempre possibile svuotare ogni pagina in cui quel contenuto potrebbe apparire. I contenuti che compaiono in liste dinamiche (come ad esempio le portlet <em>Collezione</em>), nel albero di navigazione o in altri aiuti alla navigazione potrebbero apparire scaduti se sono state aggiunte alla cache le pagine dove questi contenuti appaiono."
+msgstr ""
+"Se l'opzione <em>Abilita il purge</em> è stata abilitata, Plone può svuotare "
+"automaticamente le viste dei contenuti quando vengono modificati o rimossi. "
+"Selezionare qui sotto i tipi da svuotare automaticamente. "
+"<strong>Nota:</strong> anche se la vista di un contenuto può essere svuotata "
+"facilmente, non è sempre possibile svuotare ogni pagina in cui quel contenuto "
+"potrebbe apparire. I contenuti che compaiono in liste dinamiche (come ad "
+"esempio i portlet <em>Collezione</em>), nell'albero di navigazione o in altri "
+"aiuti alla navigazione potrebbero apparire scaduti se sono state aggiunte "
+"alla cache le pagine dove questi contenuti appaiono."
 
 #. Default: "Enable this option if you have configured a caching proxy in front of Plone, and the proxy supports HTTP <code>PURGE</code> requests."
 #: plone.app.caching/plone/app/caching/browser/controlpanel.pt:150
@@ -10659,7 +10908,9 @@ msgstr "Il tempo da attendere prima di tentare di svuotare la cache espresso in 
 #. Default: "Enter the maximum time, in seconds, that an item may remain in the cache before being purged."
 #: plone.app.caching/plone/app/caching/browser/controlpanel.pt:338
 msgid "help_ram_max_age"
-msgstr "Il tempo massimo in cui un elemento può rimanere nella cache prima di essere rimosso espresso in secondi."
+msgstr ""
+"Il tempo massimo, espresso in secondi, in cui un elemento può rimanere nella "
+"cache prima di essere rimosso."
 
 #. Default: "Use this to control how many items can be placed in the cache. The more items you allow, the higher the potential memory consumption."
 #: plone.app.caching/plone/app/caching/browser/controlpanel.pt:315
@@ -10684,7 +10935,11 @@ msgstr "La migrazione da LinguaPlone si basa su un indice Language aggiornato. U
 #. Default: "Enter a relative path e.g.: <br /> '..' for the parent folder <br /> '../..' for the parent's parent <br />'../somefolder' for a sibling folder"
 #: ATContentTypes/criteria/relativepath.py
 msgid "help_relativepath_criteria_customrelativepath"
-msgstr "Inserisci un percorso relativo all'attuale posizione, es.:<br/> '..' per la cartella superiore <br/> '../..' per salire di due posizioni <br/> '../cartella' per una cartella che si trova in una posizione superiore rispetto alla posizione corrente."
+msgstr ""
+"Inserisci un percorso relativo all'attuale posizione, es.:<br/> \"..\" per la "
+"cartella superiore <br/> \"../..\" per salire di due posizioni <br/> "
+"\"../cartella\" per una cartella che si trova in una posizione superiore "
+"rispetto alla posizione corrente."
 
 #. Default: "Check this to have your email address filled in automatically when you log in later."
 #: CMFPlone/skins/plone_login/login_form.cpt:179
@@ -10710,7 +10965,11 @@ msgstr "Seleziona questa opzione per sostituire il tema corrente con quello appe
 #. Default: "robots.txt is read by search engines to determine how to index your site. For details see <a href='http://www.robotstxt.org'>http://www.robotstxt.org</a>. Use '{portal_url}' for the site URL."
 #: CMFPlone/interfaces/controlpanel.py:1152
 msgid "help_robots_txt"
-msgstr "La pagina robots.txt viene letta dai motori di ricerca per capire come indicizzare il tuo sito. Consulta il link <a href='http://www.robotstxt.org'>http://www.robotstxt.org</a> per maggiori dettagli. La stringa \"{portal_url}\" sarà sostituita dall'URL del sito."
+msgstr ""
+"robots.txt viene letto dai motori di ricerca per capire come indicizzare il "
+"tuo sito. Consulta il link <a "
+"href=\"http://www.robotstxt.org\">http://www.robotstxt.org</a> per maggiori "
+"dettagli. La stringa \"{portal_url}\" sarà sostituita dall'URL del sito."
 
 #. Default: "Enter a path or URL for the theme rules file."
 #: plone/app/theming/browser/controlpanel.pt:379
@@ -10810,7 +11069,7 @@ msgstr "Password per l'account ESMTP."
 #. Default: "The port of your local SMTP (outgoing e-mail) server. Usually '25'."
 #: CMFPlone/interfaces/controlpanel.py:1294
 msgid "help_smtp_port"
-msgstr "La porta del server SMTP (per la posta in uscita). Di solito è la '25'."
+msgstr "La porta del server SMTP (per la posta in uscita). Di solito è la \"25\"."
 
 #. Default: "The address of your local SMTP (outgoing e-mail) server. Usually 'localhost', unless you use an external server to send e-mail."
 #: CMFPlone/interfaces/controlpanel.py:1282
@@ -10835,7 +11094,11 @@ msgstr "Una stringa."
 #. Default: "Select this option to wait while the purge completes. This allows you to see the results of the purges. Purging asynchronously will return immediately, but you will need to check your caching proxy's log files to see if the purge actually succeeded."
 #: plone.app.caching/plone/app/caching/browser/purge.pt:107
 msgid "help_synchronous"
-msgstr "Seleziona questa opzione per attendere per il completamento della rimozione. Questo permette di vedere i risultati delle rimozioni. Rimuovere in maniera asincrona finirà immediatamente, ma "
+msgstr ""
+"Seleziona questa opzione per attendere per il completamento della rimozione. "
+"Questo permette di vedere i risultati delle rimozioni. Rimuovere in maniera "
+"asincrona finirà immediatamente, ma per verificare se la rimozione è "
+"effettivamente riuscita dovrai controllare i log del proxy di caching."
 
 #. Default: "Maximum number of items that will be syndicated."
 #: CMFPlone/interfaces/syndication.py:185
@@ -10866,7 +11129,12 @@ msgstr "Scegli il modello che verrà usato per visualizzare questo elemento."
 #. Default: "Use this setting to choose if the comment text should be transformed in any way. You can choose between \"Plain text\" and \"Intelligent text\". \"Intelligent text\" converts plain text into HTML where line breaks and indentation is preserved, and web and email addresses are made into clickable links."
 #: plone.app.discussion/plone/app/discussion/interfaces.py:296
 msgid "help_text_transform"
-msgstr "Utilizzare questa impostazione per scegliere se il testo del commento deve essere trasformato in qualche modo. È possibile scegliere tra 'Plain text' e 'Testo intelligente'. 'Testo intelligente' converte il testo in HTML dove le interruzioni di linea e le indentazioni vengono preservate, e gli indirizzi web o e-mail vengono trasformati in collegamenti cliccabili."
+msgstr ""
+"Utilizzare questa impostazione per scegliere se il testo del commento deve "
+"essere trasformato in qualche modo. È possibile scegliere tra \"Plain text\" "
+"e \"Testo intelligente\". \"Testo intelligente\" converte il testo in HTML "
+"dove le interruzioni di linea e le indentazioni vengono preservate, e gli "
+"indirizzi web o e-mail vengono trasformati in collegamenti cliccabili."
 
 #. Default: "Select a file to upload."
 #: plone/app/theming/browser/controlpanel.pt:751
@@ -10903,7 +11171,9 @@ msgstr "Seleziona i plugin che verranno utilizzati da TinyMCE."
 #. Default: "Enter the list of templates in json format https://www.tinymce.com/docs/plugins/template/"
 #: CMFPlone/interfaces/controlpanel.py:529
 msgid "help_tinymce_templates"
-msgstr "Inserisci una lista di modelli in formato JSON (vedi https://www.tinymce.com/docs/plugins/template/."
+msgstr ""
+"Inserisci una lista di modelli in formato JSON (vedi "
+"https://www.tinymce.com/docs/plugins/template/)."
 
 #. Default: "Enter how you would like the toolbar items to list."
 #: CMFPlone/interfaces/controlpanel.py:542
@@ -11015,7 +11285,7 @@ msgstr "Dominio I18n"
 #. Default: "Content type of the event, which is created when importing icalendar resources."
 #: plone.app.event/plone/app/event/ical/importer.py:230
 msgid "ical_import_event_type_desc"
-msgstr "Tipo di contenuto degli eventi importati da icalendar."
+msgstr "Tipo di contenuto degli eventi creati importando una file icalendar."
 
 #. Default: "Event Type"
 #: plone.app.event/plone/app/event/ical/importer.py:229
@@ -11030,7 +11300,7 @@ msgstr "File icalendar, se nessun URL è stato inserito."
 #. Default: "Icalendar File"
 #: plone.app.event/plone/app/event/ical/importer.py:247
 msgid "ical_import_file_title"
-msgstr "File Icalendar"
+msgstr "File icalendar"
 
 #. Default: "${num} events imported from ${filename}"
 #: plone.app.event/plone/app/event/ical/importer.py:348
@@ -11047,10 +11317,12 @@ msgstr "Inserisci un file icalendar ics o un URL di un file."
 msgid "ical_import_sync_strategy_desc"
 msgstr ""
 "Definisce come sincronizzare:\n"
-"1)\"Tieni il più nuovo\": Importa se l'evento è stato modificato dopo quello esistente.\n"
-"\"Tieni il mio\": in caso di conflitti, non fare nulla.\n"
-"3 \"Tieni i loro\": in caso di conflitti, sovrascrivi l'evento esistente.\n"
-"4) \"Nessuna sincronizzazione\": Non sincronizzare ma importa gli eventi e creali nuovi, anche se esistono già. Per ognuno, crea un nuovo sync_uid."
+"1) \"Tieni il più nuovo\": importa se l'evento è stato modificato dopo quello "
+"esistente.\n"
+"2) \"Tieni il mio\": in caso di conflitti, non fare nulla.\n"
+"3) \"Tieni i loro\": in caso di conflitti, sovrascrivi l'evento esistente.\n"
+"4) \"Nessuna sincronizzazione\": Non sincronizzare ma importa gli eventi e "
+"creali nuovi, anche se esistono già. Per ognuno, crea un nuovo sync_uid."
 
 #. Default: "Synchronization Strategy"
 #: plone.app.event/plone/app/event/ical/importer.py:255
@@ -11065,7 +11337,7 @@ msgstr "URL ad un file icalendar esterno"
 #. Default: "Icalendar URL"
 #: plone.app.event/plone/app/event/ical/importer.py:239
 msgid "ical_import_url_title"
-msgstr "URL Icalendar"
+msgstr "URL icalendar"
 
 #. Default: "If all of the following conditions are met:"
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/manage-elements.pt:39
@@ -11122,7 +11394,7 @@ msgstr "includi"
 
 #: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:56
 msgid "including"
-msgstr " incluso"
+msgstr "incluso"
 
 #. Default: "Your dashboard is currently empty. Click the <em>edit</em> tab to assign some personal portlets."
 #: plone.app.layout/plone/app/layout/dashboard/dashboard.py:31
@@ -11438,7 +11710,7 @@ msgstr "Saltati"
 #. Default: "Size (bytes)"
 #: plone.app.caching/plone/app/caching/browser/ramcache.pt:71
 msgid "label_cache_size_bytes"
-msgstr "Dimensione (bytes)"
+msgstr "Dimensione (byte)"
 
 #. Default: "First time here? We recommend that you get started by ${link}."
 #: plone.app.caching/plone/app/caching/browser/controlpanel.pt:65
@@ -12074,7 +12346,7 @@ msgstr "Ometti dalla navigazione"
 #: Archetypes/skins/archetypes/widgets/keyword.pt:48
 #: Archetypes/skins/archetypes/widgets/tests/keywordtests.html:78
 msgid "label_existingTagsHelp"
-msgstr "Usa il tasto Control o Command o Shift per selezionare più elementi"
+msgstr "Usa il tasto Control o Command o Shift per selezionare più elementi."
 
 #. Default: "Select from existing tags."
 #: Archetypes/skins/archetypes/widgets/tests/keywordtests.html:72
@@ -12091,7 +12363,7 @@ msgstr "Data di scadenza"
 #. Default: "External links open in new window"
 #: plone/app/theming/browser/controlpanel.pt:579
 msgid "label_ext_links_open_new_window"
-msgstr "Collegamenti esterni aprono in una nuova finestra"
+msgstr "Collegamenti esterni vengono aperti in una nuova finestra"
 
 #. Default: "External"
 #: plone.app.z3cform/plone/app/z3cform/templates/link_input.pt:25
@@ -12181,7 +12453,7 @@ msgstr "Licenza GNU GPL"
 #: CMFPlone/controlpanel/browser/usergroups_groupmembership.pt:73
 #: plone.app.portlets/plone/app/portlets/browser/templates/manage-group-dashboard.pt:40
 msgid "label_group_dashboard"
-msgstr "Dashboard del gruppo"
+msgstr "Bacheca del gruppo"
 
 #. Default: "Group Members"
 #: CMFPlone/controlpanel/browser/usergroups_groupdetails.pt:68
@@ -12345,12 +12617,12 @@ msgstr "Lingue"
 #. Default: "Lead Image"
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/leadimage.py:22
 msgid "label_leadimage"
-msgstr "Immagine in testata"
+msgstr "Immagine di testata"
 
 #. Default: "Lead Image Caption"
 #: plone.app.contenttypes/plone/app/contenttypes/behaviors/leadimage.py:28
 msgid "label_leadimage_caption"
-msgstr "Didascalia dell'immagine in testata"
+msgstr "Didascalia dell'immagine di testata"
 
 # ATTopic
 #. Default: "Limit Search Results"
@@ -12368,7 +12640,7 @@ msgstr "Tipi supplementari"
 #: plone.app.users/plone/app/users/profiles/default/userschema.xml
 #: plone.app.users/plone/app/users/upgrades.py:63
 msgid "label_location"
-msgstr "Località:"
+msgstr "Località"
 
 #. Default: "Locked"
 #: plone.locking/plone/locking/browser/info.pt:8
@@ -12497,7 +12769,7 @@ msgstr "Scelta multipla"
 #: CMFPlone/browser/login/templates/mail_password_form.pt:47
 #: CMFPlone/browser/login/templates/pwreset_form.pt:52
 msgid "label_my_email_address_is"
-msgstr "La mia e-mail è:"
+msgstr "La mia e-mail è"
 
 #. Default: "My user name is"
 #: CMFPlone/browser/login/templates/mail_password_form.pt:42
@@ -12620,7 +12892,7 @@ msgstr "Non è stato specificato nessun gruppo."
 #. Default: "No preference panels available."
 #: CMFPlone/controlpanel/browser/overview.pt:124
 msgid "label_no_prefs_panels_available"
-msgstr "Non ci sono configurazioni specifiche per i moduli installati."
+msgstr "Non ci sono configurazioni specifiche."
 
 #. Default: "<no reference>"
 #: Archetypes/Field.py:2194
@@ -12699,7 +12971,7 @@ msgstr "Cartelle"
 #. Default: "Plone<sup>&reg;</sup> Open Source CMS/WCM"
 #: CMFPlone/browser/templates/footer.pt:14
 msgid "label_plone_cms"
-msgstr "Plone<sup>&reg;</sup> CMS — Open Source CMS/WCM"
+msgstr "Plone<sup>&reg;</sup> Open Source CMS/WCM"
 
 #. Default: "For an introduction to Plone, success stories, demos, providers, visit"
 #: CMFPlone/browser/templates/plone-overview.pt:145
@@ -12762,7 +13034,7 @@ msgstr "Ritratto"
 #: plone.app.layout/plone/app/layout/viewlets/colophon.pt:6
 #: plone.app.theming/resources/theme/theme1/overrides/plone.app.layout.viewlets.colophon.pt:8
 msgid "label_powered_by_plone"
-msgstr "Realizzato con Plone &amp; Python"
+msgstr "Realizzato con Plone & Python"
 
 #. Default: "Previous"
 #: Archetypes/skins/archetypes/edit_macros.pt:213
@@ -12782,12 +13054,12 @@ msgstr "Può essere rischioso, confermi di volerlo fare?"
 #. Default: "New profile version is ${version}."
 #: CMFPlone/controlpanel/browser/quickinstaller.pt:89
 msgid "label_product_upgrade_new_profile_version"
-msgstr "La versione del nuovo profilo è la ${version}."
+msgstr "La nuova versione del profilo è la ${version}."
 
 #. Default: "Old profile version was ${version}."
 #: CMFPlone/controlpanel/browser/quickinstaller.pt:86
 msgid "label_product_upgrade_old_profile_version"
-msgstr "La versione del profilo precedente era la ${version}."
+msgstr "La versione precedente del profilo era la ${version}."
 
 #. Default: "Old version was ${version}."
 #: CMFPlone/controlpanel/browser/quickinstaller.pt:82
@@ -13239,7 +13511,7 @@ msgstr "Categorie"
 #. Default: "Target Path"
 #: CMFPlone/controlpanel/browser/redirects-controlpanel.pt:98
 msgid "label_target_path"
-msgstr "URL originale"
+msgstr "Path di destinazione"
 
 #. Default: "Legacy template mappings"
 #: plone.app.caching/plone/app/caching/browser/controlpanel.pt:448
@@ -13427,7 +13699,7 @@ msgstr "URL"
 #. Default: "URLs to purge"
 #: plone.app.caching/plone/app/caching/browser/purge.pt:80
 msgid "label_urls"
-msgstr "Gli URLs da rimuovere"
+msgstr "Gli URL da rimuovere"
 
 #. Default: "User Name"
 #: CMFPlone/skins/plone_prefs/prefs_error_log_form.pt:91
@@ -13752,7 +14024,7 @@ msgstr "Rimuovi"
 #. Default: "Reset Password"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.pt:112
 msgid "listingheader_reset_password"
-msgstr "Azzera la password"
+msgstr "Reimposta la password"
 
 #. Default: "Size"
 #: plone.app.content/plone/app/content/browser/table.pt:74
@@ -13854,7 +14126,9 @@ msgstr "Benvenuta/o ${fullname}, il tuo account è stato creato e il tuo nome ut
 #. Default: "The site administrator asks you to reset your password for '${userid}' userid. Your old password doesn't work anymore."
 #: CMFPlone/browser/login/templates/mail_password_template.pt:14
 msgid "mailtemplate_reset_information"
-msgstr "L'amministratore del sito richiede di reimpostare la password per l'utente con identificativo '${userid}'. La tua vecchia password non funzionerà più."
+msgstr ""
+"L'amministratore del sito richiede di reimpostare la password per l'utente "
+"con identificativo \"${userid}\". La tua vecchia password non funzionerà più."
 
 #. Default: "Password reset request"
 #: CMFPlone/browser/login/password_reset.py:65
@@ -13869,7 +14143,9 @@ msgstr "(Questo link è valido per ${hours} ore)"
 #. Default: "The following link will take you to a page where you can reset your password for ${site_name} site: ${reset_url}"
 #: CMFPlone/browser/login/templates/mail_password_template.pt:23
 msgid "mailtemplate_text_linkreset"
-msgstr "Il seguente link ti porterà ad una pagina dove potrai reimpostare la tua password per ${site_name}: ${reset_url}"
+msgstr ""
+"Il seguente link ti porterà ad una pagina dove potrai reimpostare la tua "
+"password per il sito ${site_name}: ${reset_url}"
 
 #. Default: "If you didn't expect to receive this email, please ignore it. Your password has not been changed. Request made from IP address ${ipaddress}"
 #: CMFPlone/browser/login/templates/mail_password_template.pt:36
@@ -13939,7 +14215,7 @@ msgstr "L'indirizzo e-mail selezionato è già in uso o non è valido come nome 
 #. Default: "enable the 'Comment Review Workflow' for the Comment content type"
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:46
 msgid "message_enable_comment_workflow"
-msgstr "abilitare il 'Comment Review Workflow' per il tipo di contenuto Commento"
+msgstr "abilitare il \"Comment Review Workflow\" per il tipo di contenuto Commento"
 
 #. Default: "Moderation workflow is disabled. You have to ${enable_comment_workflow} before you can moderate comments here."
 #: plone.app.discussion/plone/app/discussion/browser/moderation.pt:46
@@ -13974,7 +14250,10 @@ msgstr "Spiacenti ma la richiesta non è valida. Assicurati di aver copiato esat
 #. Default: "Sorry, this appears to be an invalid request. Please make sure you copied the URL exactly as it appears in your email and that you entered your email address correctly."
 #: CMFPlone/browser/login/templates/pwreset_invalid.pt:26
 msgid "message_pwreset_invalid_with_email"
-msgstr "Spiacenti ma la richiesta non è valida. Assicurati di aver copiato esattamente l'indirizzo specificato nell'e-mail e di aver inserito correttamente il nome utente."
+msgstr ""
+"Spiacenti ma la richiesta non è valida. Assicurati di aver copiato "
+"esattamente l'indirizzo specificato nell'e-mail e di aver inserito "
+"correttamente il tuo indirizzo e-mail."
 
 #. Default: "Your password has been set successfully. You may now ${login_url} with your new password."
 #: CMFPlone/browser/login/templates/pwreset_finish.pt:23
@@ -13999,11 +14278,13 @@ msgstr "inviare una nuova richiesta"
 #. Default: "A mail has now been sent to the site administrator regarding your questions and/or comments."
 #: CMFPlone/browser/templates/send_feedback_confirm.pt:23
 msgid "message_send_feedback_confirm"
-msgstr "È stata spedita una mail all'amministratore relativa alla tua domanda e/o commenti."
+msgstr ""
+"È stata spedita una mail all'amministratore relativa alle tue domande e/o "
+"commenti."
 
 #: plone.app.contenttypes/plone/app/contenttypes/browser/templates/archetypes_warning_viewlet.pt:9
 msgid "migrate the default content-types to Dexterity."
-msgstr "Migra i contenuti di default a Dexterity."
+msgstr "Migra i tipi di contenuto di default a Dexterity."
 
 #: plone/app/multilingual/browser/templates/controlpanel.pt:39
 msgid "migration procedure."
@@ -14022,7 +14303,7 @@ msgstr "L'indice \"Language\" è stato reindicizzato correttamente. Prima conten
 #. Default: "Missing languages:"
 #: plone/app/multilingual/browser/templates/mmap.pt:111
 msgid "missing_languages"
-msgstr "Lingue mandcanti:"
+msgstr "Lingue mancanti:"
 
 #. Default: "Upcoming"
 #: plone.app.event/plone/app/event/browser/event_listing.pt:17
@@ -14137,7 +14418,7 @@ msgstr "nome"
 #. Default: "Filter the results"
 #: CMFPlone/browser/templates/search.pt:65
 msgid "narrow_search_options"
-msgstr "Filtra i risultati."
+msgstr "Filtra i risultati"
 
 #. Default: "Need an account?"
 #: CMFPlone/browser/login/templates/login.pt:91
@@ -14211,7 +14492,10 @@ msgstr "Mantieni l'immagine corrente"
 #. Default: "Your site is not configured with more than one allowed language, but the add-on that provides support for content in multiple language is installed. You can add one or more additional languages from the ${control-panel-link}."
 #: plone/app/multilingual/browser/templates/languages-notice.pt:11
 msgid "not_configured_for_multiple_languages"
-msgstr "Il tuo sito non è stato configurato con più di una lingua, ma il supporto per il multilinguismo è installato. Puoi aggiungere una o più lingue supportate dal ${control-panel-link}."
+msgstr ""
+"Il tuo sito non è stato configurato con più di una lingua, ma il supporto per "
+"il multilingue è installato. Puoi aggiungere una o più lingue supportate dal "
+"${control-panel-link}."
 
 #. Default: "Option 3 : hiver"
 #: Archetypes/tests/test_baseobject.py:46
@@ -14265,7 +14549,7 @@ msgstr "Puoi definire dei parametri aggiuntivi da passare al tema. All'interno d
 #. Default: "Password reset successful, you are logged in now!"
 #: CMFPlone/browser/login/password_reset.py:119
 msgid "password_reset_successful"
-msgstr "Password resettata correttamente, sei autenticato!"
+msgstr "Password reimpostata correttamente, sei autenticato!"
 
 #: plone.formwidget.recurrence/plone/formwidget/recurrence/browser/i18n.py:127
 msgid "past_end_date"
@@ -14303,7 +14587,7 @@ msgstr "plone.app.collection (disinstalla)"
 
 #: plone.app.collection/plone/app/collection/configure.zcml:19
 msgid "plone.app.collection, the new style Archetypes collections in Plone 4"
-msgstr "plone.app.collection, il nuovo tipo di collezioni per Archetype su Plone 4"
+msgstr "plone.app.collection, il nuovo tipo di collezioni Archetypes su Plone 4"
 
 #: plone.app.contentrules/plone/app/contentrules/tests/testing.zcml:13
 msgid "plone.app.contentrules testing"
@@ -14514,7 +14798,11 @@ msgstr "respingi"
 #. Default: "It's not possible to execute this step without uninstalling completely LinguaPlone: uninstall in the add-ons control panel, delete it from your buildout and re-run buildout. Then come here and try again."
 #: plone/app/multilingual/browser/templates/migration.pt:234
 msgid "relation_migration_with_lp_not_posible"
-msgstr "Non è possibile eseguire questo step senza disinstallare prima LinguaPlone. Disinstallalo nel pannello di controllo dei prodotti aggiuntivi, rimuovilo dal buildout e ri-lancia il buildout. A questo punto puoi tornare qui e continuare."
+msgstr ""
+"Non è possibile eseguire questo step senza disinstallare prima LinguaPlone. "
+"Disinstallalo nel pannello di controllo dei prodotti aggiuntivi, rimuovilo "
+"dal buildout e riesegui il buildout. A questo punto puoi tornare qui e "
+"continuare."
 
 #. Default: "Your site has no relation catalog, and therefore this migration step is not needed"
 #: plone/app/multilingual/browser/templates/migration.pt:242
@@ -14585,7 +14873,7 @@ msgstr "Numero di cartelle non vuote selezionate: <strong>${refs}</strong>"
 #: CMFPlone/browser/templates/sendto_template.pt:25
 msgid "sendto_mailtemplate_body"
 msgstr ""
-"Questo collegamento ti è stato spedito dall'indirizzo ${portal_url}\n"
+"Questo collegamento ti è stato spedito dall'indirizzo ${portal_url}.\n"
 "\n"
 "Ricevi questo messaggio poiché qualcuno, leggendo una pagina sul sito\n"
 "\"${portal_title}\", ha pensato ti potesse interessare.\n"
@@ -14602,7 +14890,7 @@ msgstr ""
 #. Default: "Open ${title} folder"
 #: plone/app/multilingual/browser/menu.py:443
 msgid "shared_folder"
-msgstr "Vai alla cartella condivisa"
+msgstr "Vai alla cartella ${title}"
 
 #. Default: "show"
 #: workflow transition defined in folder_workflow - title Member makes content visible new state visible
@@ -14638,7 +14926,7 @@ msgstr "Ti sei disconnesso."
 #. Default: "An email has been sent with instructions on how to reset your password."
 #: CMFPlone/browser/login/login_help.py:87
 msgid "statusmessage_pwreset_password_mail_sent"
-msgstr "È stata inviata una email con le istruzioni per fare il reset della password."
+msgstr "È stata inviata una email con le istruzioni per reimpostare la tua password."
 
 #. Default: "An email has been sent with your username."
 #: CMFPlone/browser/login/login_help.py:136
@@ -14812,7 +15100,12 @@ msgstr "da ${creator}, ultimo aggiornamento: ${date}"
 #. Default: "You have configured a custom workflow for the 'Discussion Item' content type. You can enable/disable the comment moderation in this control panel only if you use one of the default 'Discussion Item' workflows. Go to the ${label_discussion_control_panel_link} to choose a workflow for the 'Discussion Item' type."
 #: plone.app.discussion/plone/app/discussion/browser/controlpanel.pt:44
 msgid "text_custom_comment_workflow"
-msgstr "Hai configurato un workflow personalizzato per il tipo di contenuto 'Discussion Item'. Puoi abilitare/disabilitare la moderazione dei commenti in questo pannello di controllo solo se usi uno dei workdlow predefiniti. Vai nel ${label_discussion_control_panel_link} per selezionare un workflow per il tipo 'Discussion Item'."
+msgstr ""
+"Hai configurato un workflow personalizzato per il tipo di contenuto "
+"\"Commento\". Puoi abilitare/disabilitare la moderazione dei commenti in "
+"questo pannello di controllo solo se usi uno dei workdlow predefiniti. Vai "
+"nel ${label_discussion_control_panel_link} per selezionare un workflow per il "
+"tipo \"Commento\"."
 
 #. Default: "Site"
 #: CMFPlone/browser/templates/plone-addsite.pt:65
@@ -14880,7 +15173,9 @@ msgstr "Attenzione: il modulo PIL non risulta installato correttamente, pertanto
 #. Default: "Enter a group or user name to search for or click 'Show All'."
 #: CMFPlone/controlpanel/browser/usergroups_groupmembership.pt:274
 msgid "text_no_searchstring"
-msgstr "Inserisci il nome di un gruppo o di un utente da cercare o clicca su 'Mostra tutti'."
+msgstr ""
+"Inserisci il nome di un gruppo o di un utente da cercare o clicca su \"Mostra "
+"tutti\"."
 
 #. Default: "Enter a group or user name to search for."
 #: CMFPlone/controlpanel/browser/usergroups_groupmembership.pt:268
@@ -14890,7 +15185,11 @@ msgstr "Inserisci il nome di un gruppo o di un collaboratore da cercare."
 #. Default: "You have not set the portal timezone. Date/Time handling will not work properly for timezone aware date/time values. Go to the ${label_mail_event_settings_link} to fix this."
 #: CMFPlone/controlpanel/browser/overview.pt:75
 msgid "text_no_timezone_configured"
-msgstr "Non hai impostato il fuso orario del portale. La gestione di date e orari non funzionerà correttamente per valori che tengono in considerazione il fuso orario. Puoi il problema impostando i valori appropriati in ${label_mail_event_settings_link}."
+msgstr ""
+"Non hai impostato il fuso orario del portale. La gestione di date e orari non "
+"funzionerà correttamente per valori che tengono in considerazione il fuso "
+"orario. Puoi correggere il problema impostando i valori appropriati in "
+"${label_mail_event_settings_link}."
 
 #. Default: "Date and Time Settings control panel"
 #: CMFPlone/controlpanel/browser/overview.pt:76
@@ -14910,7 +15209,7 @@ msgstr "Inserisci il nome utente da cercare"
 #. Default: "Enter a username to search for, or click 'Show All'"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.pt:185
 msgid "text_no_user_searchstring_largesite"
-msgstr "Inserisci il nome di un collaboratore da cercare, o clicca su 'Mostra tutti'"
+msgstr "Inserisci il nome di un collaboratore da cercare, o clicca su \"Mostra tutti\""
 
 #. Default: "No matches"
 #: CMFPlone/controlpanel/browser/usergroups_groupmembership.pt:263
@@ -14990,7 +15289,7 @@ msgstr "Carica tema"
 #. Default: "This is a built-in theme, and cannot be edited."
 #: plone/app/theming/browser/mapper.pt:84
 msgid "theming_mapper_warning_cannot_edit"
-msgstr "Questo è un tema built-in, non può essere modificato"
+msgstr "Questo è un tema built-in, non può essere modificato."
 
 #. Default: "This theme is currently active. Any changes made will be immediately reflected on the live site."
 #: plone/app/theming/browser/mapper.pt:75
@@ -15120,7 +15419,7 @@ msgstr "Cambia l'elemento usato come vista predefinita di questa cartella"
 #. Default: "Change the portlets of this item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:867
 msgid "title_change_portlets"
-msgstr "Cambia le portlet di questo elemento"
+msgstr "Cambia i portlet di questo elemento"
 
 #. Default: "Change the state of this item"
 #: plone.app.contentmenu/plone/app/contentmenu/menu.py:698
@@ -15176,7 +15475,7 @@ msgstr "Sostituzioni"
 #. Default: "Copyright"
 #: CMFPlone/browser/templates/footer.pt:17
 msgid "title_copyright"
-msgstr "Copyright ©"
+msgstr "Copyright"
 
 #. Default: "Default view for this folder"
 #: plone.app.content/plone/app/content/browser/table.pt:141
@@ -15216,7 +15515,7 @@ msgstr "Abilita l'import da iCal"
 #. Default: "Language"
 #: plone/app/multilingual/browser/interfaces.py:54
 msgid "title_language"
-msgstr "Lingue"
+msgstr "Lingua"
 
 #. Default: "Legacy portlets"
 #: plone.app.portlets/plone/app/portlets/browser/templates/manage-contextual.pt:67
@@ -15399,7 +15698,7 @@ msgstr "Campi per la form di registrazione utenti"
 #. Default: "Username Check"
 #: CMFPlone/browser/login/templates/explainPWResetTool.pt:26
 msgid "title_username_check"
-msgstr "Controllo username"
+msgstr "Controllo nome utente"
 
 #. Default: "View"
 #: plone.app.layout/plone/app/layout/viewlets/content_history.pt:58
@@ -15449,7 +15748,7 @@ msgstr "Traduzioni:"
 #. Default: "Translation to ${language}"
 #: plone/app/multilingual/browser/templates/dexterity_edit.pt:43
 msgid "translation_to"
-msgstr "Traduci in ${language}"
+msgstr "Traduzione in ${language}"
 
 #. Default: "Trouble logging in?"
 #: CMFPlone/browser/login/templates/login.pt:87

--- a/plone/app/locales/locales/it/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/it/LC_MESSAGES/plone.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI +ZONE\n"
-"PO-Revision-Date: 2020-10-04 17:07+0200\n"
+"PO-Revision-Date: 2020-10-04 17:11+0200\n"
 "Last-Translator: Lele Gaifax <lele@metapensiero.it>\n"
 "Language-Team: Italian <Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -2416,7 +2416,7 @@ msgstr "Abilitato di base"
 
 #: CMFPlone/interfaces/controlpanel.py:1396
 msgid "Enabled markdown extensions"
-msgstr "Abilita le estenzioni markdwon"
+msgstr "Abilita le estensioni markdown"
 
 #: CMFPlone/interfaces/controlpanel.py:876
 #: plone.app.portlets/plone/app/portlets/portlets/search.py:18


### PR DESCRIPTION
- fix many typos
- consistently use the masculine gender for "portlet"
- consistently prefer "double quotes" to 'single quotes'