### PR TITLE
Minor fixes to Italian translations

### DIFF
--- a/plone/app/locales/locales/it/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/it/LC_MESSAGES/plone.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI +ZONE\n"
-"PO-Revision-Date: 2020-10-04 17:11+0200\n"
+"PO-Revision-Date: 2020-10-09 06:18+0200\n"
 "Last-Translator: Lele Gaifax <lele@metapensiero.it>\n"
 "Language-Team: Italian <Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -1100,11 +1100,24 @@ msgstr "Usa la cache nel browser e nel proxy (predefinito: 24 ore). Attenzione: 
 
 #: plone.app.caching/plone/app/caching/operations/default.py:264
 msgid "Cache in browser but expire immediately (same as 'weak caching'), and cache in proxy (default: 24 hrs). Use a purgable caching reverse proxy for best results. Caution: If proxy cannot be purged, or cannot be configured to remove the 's-maxage' token from the response, then stale responses might be seen until the cached entry expires."
-msgstr "Cache nel browser ma che scade immediatamente (come la 'cache debole'), e cache nel proxy (default: 24 ore). Utilizza un caching reverse proxy per risultati migliori. Attenzione: Se il proxy non può essere svuotato, o non può essere configurato per rimuovere il token 's-maxage' dalla risposta, allora potrebbero presentarsi delle incongruenze nelle risposte finché la cache non scade."
+msgstr ""
+"Cache nel browser ma con scadenza immediata (come la \"cache debole\"), e "
+"cache nel proxy (default: 24 ore). Utilizza un caching reverse proxy che "
+"consenta lo svuotamento per risultati migliori. Attenzione: Se il proxy non "
+"può essere svuotato, o non può essere configurato per rimuovere il token "
+"\"s-maxage\" dalla risposta, allora potrebbero presentarsi delle incongruenze "
+"nelle risposte finché la cache non scade."
 
 #: plone.app.caching/plone/app/caching/operations/default.py:236
 msgid "Cache in browser but expire immediately and enable 304 responses on subsequent requests. 304's require configuration of the 'Last-modified' and/or 'ETags' settings. If Last-Modified  header is insufficient to ensure freshness, turn on ETag checking by listing each ETag components that should be used to construct the ETag header. To also cache public responses in Zope memory, set 'RAM cache' to True."
-msgstr "Cache nel browser ma che scade immediatamente e abilita risposte con stato HTTP 304 per le richieste suggessive. Lo stato 304 richiede la configurazione delle impostazioni per 'Last-modified' e/o 'ETags'. Se l'header Last-Modified è insufficiente ad assicurare che il contenuto sia attuale, abilita il controllo ETag elencando i componenenti ETag che dovrebbero essere utilizzati per costruire l'header ETag header. Per salvare le risposte pubbliche anche nella cache di Zope, seleziona 'RAM cache'."
+msgstr ""
+"Cache nel browser ma con scadenza immediata e abilita risposte con stato HTTP "
+"304 per le richieste suggessive. Lo stato 304 richiede la configurazione "
+"delle impostazioni per \"Last-modified\" e/o \"ETags\". Se l'header "
+"Last-Modified è insufficiente ad assicurare che il contenuto sia attuale, "
+"abilita il controllo ETag elencando i componenti ETag che dovrebbero essere "
+"utilizzati per costruire l'header ETag. Per salvare le risposte pubbliche "
+"anche nella cache di Zope, seleziona \"RAM cache\"."
 
 #: plone.app.caching/plone/app/caching/browser/controlpanel.py:652
 msgid "Cache purged."
@@ -1543,7 +1556,7 @@ msgstr "Lista contenuti"
 
 #: plone.app.contentmenu/plone/app/contentmenu/configure.zcml:11
 msgid "Content menu - contains contextual actions related to the content"
-msgstr "Menù Contenuto - contiene azioni relative al contenuto corrente"
+msgstr "Menu Contenuto - contiene azioni relative al contenuto corrente"
 
 #: plone.app.contentrules/plone/app/contentrules/browser/templates/controlpanel.pt:35
 msgid "Content rule settings updated."
@@ -1754,7 +1767,7 @@ msgstr "Plugin personalizzati"
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/custom_migration.pt:21
 msgid "Custom types migration control panel"
-msgstr "Panello di controllo per la migrazione dei tipi di contenuto personalizzati"
+msgstr "Pannello di controllo per la migrazione dei tipi di contenuto personalizzati"
 
 #. Default: "Cut"
 #: CMFPlone/profiles/default/actions.xml
@@ -1764,7 +1777,7 @@ msgstr "Taglia"
 
 #: CMFPlone/profiles/default/actions.xml
 msgid "Dashboard"
-msgstr "Dashboard"
+msgstr "Bacheca"
 
 #: CMFPlone/browser/templates/author.pt:200
 msgid "Date"
@@ -5554,7 +5567,7 @@ msgstr "Seleziona quali ID (nomi brevi) dei content-type possono comportarsi com
 msgid "Select which fields to display when 'Tabular view' is selected in the display menu."
 msgstr ""
 "Seleziona quali campi devono essere mostrati quando \"Vista tabellare\" è "
-"selezionato nel menù display"
+"selezionato nel menu visualizzazione."
 
 #: CMFPlone/interfaces/controlpanel.py:1370
 msgid "Select which formats are available for users as alternative to the default format. Note that if new formats are installed, they will be enabled for text fields by default unless explicitly turned off here or by the relevant installer."
@@ -6319,7 +6332,7 @@ msgstr "La serializzazione di una stringa JSON."
 
 #: plone.app.contentrules/plone/app/contentrules/conditions/talesexpression.py:27
 msgid "The TALES expression to check."
-msgstr "L'espressione TALES da controllare'"
+msgstr "L'espressione TALES da controllare."
 
 #: plone.app.contentrules/plone/app/contentrules/actions/versioning.py:24
 msgid "The comment added to the history while versioning the content."
@@ -7729,7 +7742,17 @@ msgstr "Il tuo sito è aggiornato."
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:105
 msgid "Your site seems to use the addon ${contentleadimage}. This addons allows you to add images to any content in your site. These images will <strong>not</strong> be migrated unless you enable the behavior \"Lead Image\" on all those types where you want to migrate images added using collective.contentleadimage. Depending on the way you installed plone.app.contenttypes you might have to first install these types by (re-)installing plone.app.contenttypes. The old types that use leadimages are listed in the navigation-form with the comment <em>\"extended fields: 'leadImage', 'leadImage_caption'\"</em>"
-msgstr "Sembra che il tuo sito utilizzi ${contentleadimage}. Questo prodotto aggiuntivo ti consente di aggiungere immagini ad ogni contenuto del tuo sito. Queste immagini <strong>non</strong> saranno migrate a meno che non sia abilitato il behavior \"Immagine in testata\" su tutti i tipi di contenuto di cui ti interessa mantenere l'immagine aggiunta concollective.contentleadimage. A seconda di come hai installato plone.app.contenttypes potresti prima dover installare questi tipi reinstallando plone.app.contenttypes. I tipi vecchi che utilizzavano le immagini in testata sono elencati nel modulo di navigazione con il commento <em>\"campi estensione: 'leadImage', 'leadImage_caption'\"</em>"
+msgstr ""
+"Sembra che il tuo sito utilizzi ${contentleadimage}. Questo prodotto "
+"aggiuntivo ti consente di aggiungere immagini ad ogni contenuto del tuo sito. "
+"Queste immagini <strong>non</strong> saranno migrate a meno che non sia "
+"abilitato il behavior \"Immagine in testata\" su tutti i tipi di contenuto di "
+"cui ti interessa mantenere l'immagine aggiunta con "
+"collective.contentleadimage. A seconda di come hai installato "
+"plone.app.contenttypes potresti prima dover installare questi tipi "
+"reinstallando plone.app.contenttypes. I tipi vecchi che utilizzavano le "
+"immagini in testata sono elencati nel modulo di navigazione con il commento "
+"<em>\"campi estensione: 'leadImage', 'leadImage_caption'\"</em>"
 
 #: plone.app.contenttypes/plone/app/contenttypes/migration/atct_migrator.pt:86
 msgid "Your subtopics:"
@@ -11161,7 +11184,7 @@ msgstr "Il fuso orario che utilizzi"
 #. Default: "Enter what items you would like in the menu bar."
 #: CMFPlone/interfaces/controlpanel.py:485
 msgid "help_tinymce_menubar"
-msgstr "Specifica gli elementi da utilizzare nella barra dei menù."
+msgstr "Specifica gli elementi da utilizzare nella barra dei menu."
 
 #. Default: "Select plugins to include with tinymce"
 #: CMFPlone/interfaces/controlpanel.py:440
@@ -11249,7 +11272,7 @@ msgstr "nascondi"
 #. Default: "JSON formatted Menu configuration."
 #: CMFPlone/interfaces/controlpanel.py:496
 msgid "hint_tinymce_menu"
-msgstr "Configurazione dei menù in formato JSON."
+msgstr "Configurazione dei menu in formato JSON."
 
 #. Default: "Other TinyMCE configuration formatted as JSON."
 #: CMFPlone/interfaces/controlpanel.py:698
@@ -13573,12 +13596,12 @@ msgstr "Fuso orario"
 #. Default: "Menu"
 #: CMFPlone/interfaces/controlpanel.py:495
 msgid "label_tinymce_menu"
-msgstr "Menù"
+msgstr "Menu"
 
 #. Default: "Menubar"
 #: CMFPlone/interfaces/controlpanel.py:484
 msgid "label_tinymce_menubar"
-msgstr "Barra dei menù"
+msgstr "Barra dei menu"
 
 #. Default: "Other settings"
 #: CMFPlone/interfaces/controlpanel.py:697
@@ -14801,8 +14824,7 @@ msgid "relation_migration_with_lp_not_posible"
 msgstr ""
 "Non è possibile eseguire questo step senza disinstallare prima LinguaPlone. "
 "Disinstallalo nel pannello di controllo dei prodotti aggiuntivi, rimuovilo "
-"dal buildout e riesegui il buildout. A questo punto puoi tornare qui e "
-"continuare."
+"dal buildout e riesegui il buildout. A quel punto torna qui e riprova."
 
 #. Default: "Your site has no relation catalog, and therefore this migration step is not needed"
 #: plone/app/multilingual/browser/templates/migration.pt:242


### PR DESCRIPTION
- prefer "menu" to "menù" for consistency, as the former is used more often than the latter
- translate "dashboard" also in the user's menu
- fix some whitespace/punctuation issues