### PR TITLE
User/Contributor mismatch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 5.1.27 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Use different translations for "User" and "Contributor" in the Italian translation,
+  using respectively "Utente" and "Collaboratore".
+  [lelit]
 
 
 5.1.26 (2020-10-12)

--- a/plone/app/locales/locales/it/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/it/LC_MESSAGES/plone.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI +ZONE\n"
-"PO-Revision-Date: 2020-10-09 09:36+0200\n"
+"PO-Revision-Date: 2020-11-05 18:37+0100\n"
 "Last-Translator: Lele Gaifax <lele@metapensiero.it>\n"
 "Language-Team: Italian <Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -171,7 +171,15 @@ msgstr "- Usato con il workflow Comunità. - Non esiste alcun processo di revisi
 #. Default: "- Users can create content that is immediately publicly accessible. - Content can be submitted for publication by the content's creator or a Manager, which is typically done to promote events or news to the front page. - Reviewers can publish or reject content, content owners can retract their submissions. - While the content is awaiting review it is readable by anybody. - If content is published, it can only be retracted by a Manager."
 #: CMFPlone/profiles/default/workflows/plone_workflow/definition.xml
 msgid "- Users can create content that is immediately publicly accessible. - Content can be submitted for publication by the content's creator or a Manager, which is typically done to promote events or news to the front page. - Reviewers can publish or reject content, content owners can retract their submissions. - While the content is awaiting review it is readable by anybody. - If content is published, it can only be retracted by a Manager."
-msgstr "- I collaboratori possono creare nuovi contenuti che sono immediatamente accessibili pubblicamente. - I contenuti possono essere sottoposti a revisione per la pubblicazione dal rispettivo autore o da un Manager, tipicamente per poter promuovere eventi o notizie sulla pagina principale. - I revisori possono pubblicare o rigettare la richiesta, che può essere ritirata dagli autori. - Durante il processo di revisione il contenuto rimane visibile a chiunque. - Una volta che il contenuto è stato pubblicato, può essere ritirato solo da un Manager."
+msgstr ""
+"- Gli utenti possono creare nuovi contenuti che sono immediatamente "
+"accessibili pubblicamente. - I contenuti possono essere sottoposti a "
+"revisione per la pubblicazione dal rispettivo autore o da un Manager, "
+"tipicamente per poter promuovere eventi o notizie sulla pagina principale. - "
+"I revisori possono pubblicare o rigettare la richiesta, che può essere "
+"ritirata dagli autori. - Durante il processo di revisione il contenuto rimane "
+"visibile a chiunque. - Una volta che il contenuto è stato pubblicato, può "
+"essere ritirato solo da un Manager."
 
 #: plone.locking/plone/locking/browser/locking.py:151
 msgid "1 minute"
@@ -3857,7 +3865,7 @@ msgstr "Rendere un elemento privato significa che non sarà visibile a nessuno t
 #. Default: "Manage members"
 #: action defined in portal_membership
 msgid "Manage members"
-msgstr "Gestione dei collaboratori"
+msgstr "Gestione degli utenti"
 
 #: CMFPlone/profiles/default/controlpanel.xml
 msgid "Management Interface"
@@ -3938,7 +3946,7 @@ msgid "May be None if the transform cannot be completed"
 msgstr "Può essere \"None\" se nessuna trasformazione può essere completata"
 
 msgid "Member"
-msgstr "Collaboratore"
+msgstr "Utente"
 
 #: plone.app.users/plone/app/users/browser/schemaeditor.py:111
 msgid "Member Fields"
@@ -3948,42 +3956,42 @@ msgstr "Campi utente"
 #. Default: "Member Preferences"
 #: controlpanel category-id Member
 msgid "Member Preferences"
-msgstr "Preferenze del collaboratore"
+msgstr "Preferenze dell'utente"
 
 #. Default: "Member makes content private"
 #: CMFPlone/profiles/default/workflows/intranet_folder_workflow/definition.xml
 #: CMFPlone/profiles/default/workflows/intranet_workflow/definition.xml
 #: CMFPlone/profiles/default/workflows/plone_workflow/definition.xml
 msgid "Member makes content private"
-msgstr "Collaboratore rende privato il contenuto"
+msgstr "Utente rende privato il contenuto"
 
 #. Default: "Member makes content visible to other internal users"
 #: CMFPlone/profiles/default/workflows/intranet_folder_workflow/definition.xml
 msgid "Member makes content visible to other internal users"
-msgstr "Collaboratore rende visibile il contenuto agli altri collaboratori"
+msgstr "Utente rende visibile il contenuto ad altri utenti interni"
 
 #. Default: "Member promotes content to internal draft"
 #: CMFPlone/profiles/default/workflows/intranet_workflow/definition.xml
 msgid "Member promotes content to internal draft"
-msgstr "Collaboratore promuove il contenuto a bozza interna"
+msgstr "Utente promuove il contenuto a bozza interna"
 
 #. Default: "Member promotes content to public draft"
 #: CMFPlone/profiles/default/workflows/plone_workflow/definition.xml
 msgid "Member promotes content to public draft"
-msgstr "Collaboratore promuove il contenuto a bozza pubblica"
+msgstr "Utente promuove il contenuto a bozza pubblica"
 
 #. Default: "Member retracts submission"
 #: CMFPlone/profiles/default/workflows/intranet_workflow/definition.xml
 #: CMFPlone/profiles/default/workflows/plone_workflow/definition.xml
 #: CMFPlone/profiles/default/workflows/simple_publication_workflow/definition.xml
 msgid "Member retracts submission"
-msgstr "Collaboratore ritira la pubblicazione"
+msgstr "Utente ritira la pubblicazione"
 
 #. Default: "Member submits content for publication"
 #: CMFPlone/profiles/default/workflows/plone_workflow/definition.xml
 #: CMFPlone/profiles/default/workflows/simple_publication_workflow/definition.xml
 msgid "Member submits content for publication"
-msgstr "Collaboratore sottopone il contenuto a pubblicazione"
+msgstr "Utente sottopone il contenuto a pubblicazione"
 
 #: plone.stringinterp/plone/stringinterp/adapters.py:561
 msgid "Members E-Mails"
@@ -5012,7 +5020,7 @@ msgstr "Pubblicato"
 #. Default: "Published and visible to intranet users, not editable by the owner."
 #: CMFPlone/profiles/default/workflows/intranet_workflow/definition.xml
 msgid "Published and visible to intranet users, not editable by the owner."
-msgstr "Pubblicato e visibile ai collaboratori interni, non modificabile dal proprietario."
+msgstr "Pubblicato e visibile agli utenti interni, non modificabile dal proprietario."
 
 #: plone.app.linkintegrity/plone/app/linkintegrity/browser/info.py:196
 msgid "Published objects"
@@ -5023,7 +5031,7 @@ msgstr "Contenuti pubblicati"
 #: CMFPlone/profiles/default/workflows/intranet_workflow/definition.xml
 #: CMFPlone/profiles/default/workflows/plone_workflow/definition.xml
 msgid "Publishing the item makes it visible to other users."
-msgstr "Pubblicare un elemento lo rende visibile agli altri collaboratori."
+msgstr "La pubblicazione di un elemento lo rende visibile agli altri utenti."
 
 #: plone.app.caching/plone/app/caching/browser/purge.pt:117
 #: plone.app.caching/plone/app/caching/browser/ramcache.pt:86
@@ -6326,12 +6334,12 @@ msgstr ""
 #: CMFPlone/profiles/default/workflows/intranet_folder_workflow/definition.xml
 #: CMFPlone/profiles/default/workflows/intranet_workflow/definition.xml
 msgid "The ID of the user who performed the last transition"
-msgstr "L'ID del collaboratore che ha effettuato l'ultima transizione"
+msgstr "L'ID dell'utente che ha effettuato l'ultima transizione"
 
 #. Default: "The ID of the user who performed the previous transition"
 #: CMFPlone/profiles/default/workflows/one_state_workflow/definition.xml
 msgid "The ID of the user who performed the previous transition"
-msgstr "L'ID del collaboratore che ha effettuato la transizione precedente"
+msgstr "L'ID dell'utente che ha effettuato la transizione precedente"
 
 #: plone.schema/plone/schema/jsonfield.py:31
 msgid "The JSON schema string serialization."
@@ -7423,12 +7431,12 @@ msgstr "Vai al tuo sito Plone"
 #. Default: "Visible to all intranet users, editable by the owner."
 #: CMFPlone/profiles/default/workflows/intranet_workflow/definition.xml
 msgid "Visible to all intranet users, editable by the owner."
-msgstr "Visibile a tutti i collaboratori interni, modificabile dal proprietario."
+msgstr "Visibile a tutti gli utenti interni, modificabile dal proprietario."
 
 #. Default: "Visible to all intranet users."
 #: CMFPlone/profiles/default/workflows/intranet_folder_workflow/definition.xml
 msgid "Visible to all intranet users."
-msgstr "Visibile a tutti i collaboratori interni."
+msgstr "Visibile a tutti gli utenti interni."
 
 #. Default: "Visible to everyone, but not approved by the reviewers."
 #: CMFPlone/profiles/default/workflows/folder_workflow/definition.xml
@@ -8037,7 +8045,7 @@ msgstr "Tutte le modifiche recenti…"
 #. Default: "New user?"
 #: plone.app.portlets/plone/app/portlets/portlets/login.pt:105
 msgid "box_new_user_option"
-msgstr "Nuovo collaboratore?"
+msgstr "Nuovo utente?"
 
 #. Default: "News"
 #: plone.app.portlets/plone/app/portlets/portlets/news.pt:9
@@ -8615,7 +8623,10 @@ msgstr "Il checkin di questa copia di lavoro sostituirà l'elemento esistente co
 #. Default: "On check-out, a working copy of the content item will be created in the selected container, and the original will be locked to prevent other users from editing it."
 #: plone.app.iterate/plone/app/iterate/browser/checkout.pt:22
 msgid "description_checkout"
-msgstr "Al checkout, verrà creata una copia di lavoro dell'elemento nel contenitore selezionato e l'originale verrà bloccato per prevenire ulteriori modifiche da parte di altri collaboratori."
+msgstr ""
+"Al checkout, verrà creata una copia di lavoro dell'elemento nel contenitore "
+"selezionato e l'originale verrà bloccato per prevenire ulteriori modifiche da "
+"parte di altri utenti."
 
 #. Default: "Fill in this form to contact the site owners."
 #: CMFPlone/browser/templates/contact-info.pt:36
@@ -8868,7 +8879,9 @@ msgstr ""
 #. Default: "This search form enables you to find users by specifying one or more search criteria."
 #: plone.app.users/plone/app/users/browser/membersearch.py:89
 msgid "description_member_search"
-msgstr "Questa maschera di ricerca consente di trovare i collaboratori specificando vari criteri di selezione."
+msgstr ""
+"Questa maschera di ricerca consente di trovare gli utenti specificando vari "
+"criteri di selezione."
 
 #. Default: "The migration process is divided into four steps, listed below. Each one of the steps has a well defined purpose explained. Some of them are destructive, so please read each one of it and do not try to run it on production servers without testing it previously."
 #: plone/app/multilingual/browser/templates/migration.pt:99
@@ -8911,7 +8924,9 @@ msgstr "Preferenze personali."
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:34
 #: CMFPlone/skins/plone_login/login_form.cpt:293
 msgid "description_no_account"
-msgstr "Se non ti sei ancora iscritto, compila il ${registration_form} per diventare un collaboratore."
+msgstr ""
+"Se non ti sei ancora iscritto, compila il ${registration_form} per diventare "
+"un utente."
 
 #. Default: "registration form"
 #: CMFPlone/skins/plone_login/failsafe_login_form.cpt:35
@@ -9904,7 +9919,7 @@ msgstr "Password smarrita"
 #. Default: "Search for users"
 #: plone.app.users/plone/app/users/browser/membersearch.py:88
 msgid "heading_member_search"
-msgstr "Ricerca tra i collaboratori"
+msgstr "Ricerca tra gli utenti"
 
 #. Default: "Member tools"
 #: plone.app.layout/plone/app/layout/viewlets/membertools.pt:7
@@ -9949,7 +9964,7 @@ msgstr "Nome"
 #. Default: "New user?"
 #: CMFPlone/skins/plone_login/login_form.cpt:287
 msgid "heading_new_user"
-msgstr "Nuovo collaboratore?"
+msgstr "Nuovo utente?"
 
 #. Default: "Insufficient Privileges"
 #: CMFPlone/browser/login/templates/insufficient_privileges.pt:18
@@ -10069,7 +10084,7 @@ msgstr "Cerca gruppi"
 #. Default: "Search for new group members"
 #: CMFPlone/controlpanel/browser/usergroups_groupmembership.pt:171
 msgid "heading_search_newmembers"
-msgstr "Cerca nuovi collaboratori da associare al gruppo"
+msgstr "Cerca nuovi utenti da associare al gruppo"
 
 #. Default: "Search results"
 #: plone.app.users/plone/app/users/browser/membersearch_form.pt:26
@@ -11037,17 +11052,17 @@ msgstr "Inserisci il percorso o l'URL del file con regole del tema."
 #. Default: "Find users whose email address contain"
 #: plone.app.users/plone/app/users/browser/membersearch.py:30
 msgid "help_search_email"
-msgstr "Trova i collaboratori il cui indirizzo e-mail contiene"
+msgstr "Trova gli utenti il cui indirizzo e-mail contiene"
 
 #. Default: "Find users whose full names contain"
 #: plone.app.users/plone/app/users/browser/membersearch.py:37
 msgid "help_search_fullname"
-msgstr "Trova i collaboratori il cui nome completo contiene"
+msgstr "Trova gli utenti il cui nome completo contiene"
 
 #. Default: "Find users whose login name contain"
 #: plone.app.users/plone/app/users/browser/membersearch.py:23
 msgid "help_search_name"
-msgstr "Trova i collaboratori il cui nome utente contiene"
+msgstr "Trova gli utenti il cui nome utente contiene"
 
 #. Default: "Select what content type you wish to create."
 #: Archetypes/skins/archetypes/widgets/addable_support.pt:45
@@ -13774,7 +13789,7 @@ msgstr "Abilita notifica via e-mail"
 #. Default: "User Search"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.pt:82
 msgid "label_user_search"
-msgstr "Ricerca collaboratore"
+msgstr "Ricerca utente"
 
 #. Default: "Settings"
 #: CMFPlone/controlpanel/browser/controlpanel_usergroups_layout.pt:34
@@ -13923,7 +13938,7 @@ msgstr "Operazioni di caching"
 #. Default: "User Search Criteria"
 #: plone.app.users/plone/app/users/browser/membersearch.py:16
 msgid "legend_member_search_criteria"
-msgstr "Criteri di ricerca dei collaboratori"
+msgstr "Criteri di ricerca degli utenti"
 
 #. Default: "New Password"
 #: CMFPlone/browser/login/templates/pwreset_form.pt:30
@@ -15237,7 +15252,7 @@ msgstr ""
 #. Default: "Enter a group or user name to search for."
 #: CMFPlone/controlpanel/browser/usergroups_groupmembership.pt:268
 msgid "text_no_searchstring_large"
-msgstr "Inserisci il nome di un gruppo o di un collaboratore da cercare."
+msgstr "Inserisci il nome di un gruppo o di un utente da cercare."
 
 #. Default: "You have not set the portal timezone. Date/Time handling will not work properly for timezone aware date/time values. Go to the ${label_mail_event_settings_link} to fix this."
 #: CMFPlone/controlpanel/browser/overview.pt:75
@@ -15266,7 +15281,7 @@ msgstr "Inserisci il nome utente da cercare"
 #. Default: "Enter a username to search for, or click 'Show All'"
 #: CMFPlone/controlpanel/browser/usergroups_usersoverview.pt:185
 msgid "text_no_user_searchstring_largesite"
-msgstr "Inserisci il nome di un collaboratore da cercare, o clicca su \"Mostra tutti\""
+msgstr "Inserisci il nome di un utente da cercare, o clicca su \"Mostra tutti\""
 
 #. Default: "No matches"
 #: CMFPlone/controlpanel/browser/usergroups_groupmembership.pt:263


### PR DESCRIPTION
In the Italian translation there's currently a mismatch caused by the fact that in many places we translated both "user", "member" and "contributor" as "collaboratore". While the difference between a "user" and one user that has the "Member" role may be minimal, it obviously wrong to collapse all three "concepts" into a single one, "collaboratore".
This isn't perfect, as it does not address the difference between "user" and "member" in many places, but at least it avoids having two columns with the same header in the `@@usergroup-userprefs` view.
We shall find an acceptable translation for "Member": the literal translation, "Membro", has been criticized by several customers in the past...