### PR TITLE
Fixes Portuguese integrity break message when deleting a content

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 6.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixes Portuguese integrity break message when deleting a content, to consider the
+  masculine and feminine gender of the content type.
+  [wesleybl]
 
 
 6.0.1 (2021-12-01)

--- a/plone/app/locales/locales/pt_BR/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/pt_BR/LC_MESSAGES/plone.po
@@ -13250,7 +13250,7 @@ msgstr "Com a exclusão deste item, você irá quebrar os link que existem nos i
 #. Default: "This ${portal_type} is referenced by the following items:"
 #: plone.app.linkintegrity/plone/app/linkintegrity/browser/delete_confirmation_info.pt:27
 msgid "linkintegrity_is_referenced"
-msgstr "Este ${portal_type} é referenciado pelos seguintes itens:"
+msgstr "Este(a) ${portal_type} é referenciado(a) pelos seguintes itens:"
 
 #. Default: "The item is not accessible."
 #: plone.app.linkintegrity/plone/app/linkintegrity/browser/delete_confirmation_info.pt:42


### PR DESCRIPTION
In Portuguese, the types of content can be masculine or feminine. And for each gender, the pronoun is a different word. For example:

"Esta Notícia"

"Este Evento"

So we use the abbreviation "(a)" to say that it can be either male or female.