### PR TITLE
Fail the release when pocompile is not available.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 6.0.7 (unreleased)
 ------------------
 
+- Fail the release when ``zest.pocompile`` is not available.  [maurits]
+
 - Fix French translations (fuzzy)
   [mpeeters]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,9 @@ ignore =
     .tx
     .tx/config
 
-
+[zest.releaser]
+# Fail the release when pocompile is not available.
+prereleaser.before = zest.pocompile.available
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
Needs zest.pocompile 1.6.0. I have just added this pin to the Plone 6 coredev buildout.