### PR TITLE
Cambios en los strings para indicar fechas en los eventos

### DIFF
--- a/plone/app/locales/locales/es/LC_MESSAGES/plone.po
+++ b/plone/app/locales/locales/es/LC_MESSAGES/plone.po
@@ -8884,21 +8884,21 @@ msgstr "Cuándo"
 #. Default: "${startdate} to ${enddate}"
 #: plone.app.event/plone/app/event/browser/formatted_date.pt:35
 msgid "event_when_differentday"
-msgstr "${startdate} a ${enddate}"
+msgstr "${startdate} - ${enddate}"
 
 #: plone.app.event/plone/app/event/browser/formatted_date.pt:29
 msgid "event_when_differentday_optional_word_between_date_and_time"
-msgstr " a "
+msgstr " "
 
 #. Default: "${date} from ${starttime} to ${endtime}"
 #: plone.app.event/plone/app/event/browser/formatted_date.pt:91
 msgid "event_when_sameday"
-msgstr "${date} de ${starttime} a ${endtime}"
+msgstr "${date} ${starttime}-${endtime}"
 
 #. Default: "${date} from ${starttime}"
 #: plone.app.event/plone/app/event/browser/formatted_date.pt:65
 msgid "event_when_sameday_openend"
-msgstr "${date} a partir de ${starttime}"
+msgstr "${date} ${starttime}"
 
 #. Default: "Where"
 #: plone.app.event/plone/app/event/browser/event_summary.pt:112


### PR DESCRIPTION
@macagua @rber474 @ilopezsmx @UPCNet @libargutxi @gil-cano 

Proponemos cambiar las traducciones de los separadores de las fechas en la vista del evento en la traducción al español de Plone.

Esta es la situación actual:

![evento-dia-completo-varios-dias](https://github.com/user-attachments/assets/a958b098-b7d3-431c-b158-e5bf0f3308af)
![evento-de-dia-completo-un-solo-dia](https://github.com/user-attachments/assets/6764d82b-460f-4555-8806-f468df121159)
![evento-un-solo-dia-horas-diferentes](https://github.com/user-attachments/assets/bfc1190f-21e4-461b-848b-917b0dece580)
![evento-openend](https://github.com/user-attachments/assets/70f14811-c439-4f7c-882b-a02962877695)
![evento-días-diferentes](https://github.com/user-attachments/assets/eb06622e-466b-4c3d-8865-342407b0bcf3)


Sobre todo la formación del último de todos con los `a` no es correcta.

Yo diría que en algún momento han cambiado estas claves, porque recuerdo que en versiones anteriores de Plone estas claves a traducir eran correctas. No sé en qué momento se habrán perdido.

La estructura actual funciona correctamente para el inglés (`from XXXX at XXX to XXXX at XXX`) pero no sirve igual para todos los idiomas.

Por ejemplo en euskara (que además no funciona con preposiciones sino que serían sufijos (XXXX XXXtik XXXra), tenemos quitados los textos y tenemos puestos guiones. Creemos que queda bastante mejor así y evita cualquier tipo de confusión con las preposiciones.

Con las modificaciones que proponemos los ejemplos anteriores quedarían así:

![Pantaila-argazkia 2024-09-06 09-28-48](https://github.com/user-attachments/assets/c5d42bb6-e981-4566-acca-d4a2a3d6172d)
![Pantaila-argazkia 2024-09-06 09-28-38](https://github.com/user-attachments/assets/b772a0a3-4be4-43eb-a6bc-b847c6fedd8f)
![Pantaila-argazkia 2024-09-06 09-28-28](https://github.com/user-attachments/assets/ee61c904-7875-4f46-ac75-c6ab1ebba171)
![Pantaila-argazkia 2024-09-06 09-28-19](https://github.com/user-attachments/assets/4cf52f54-7423-4431-85f0-687d6658ace6)
![Pantaila-argazkia 2024-09-06 09-28-08](https://github.com/user-attachments/assets/b9822dd6-e39c-4cf9-accf-34581dcb8a36)
![Pantaila-argazkia 2024-09-06 09-27-52](https://github.com/user-attachments/assets/7788ee82-0df1-4ee9-8d3f-d7d82dd5c227)

