### PR TITLE
Config with default template 999269c3

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 #
 # EditorConfig Configuration file, for more details see:
@@ -13,7 +13,8 @@
 root = true
 
 
-[*]  # For All Files
+[*]
+# Default settings for all files.
 # Unix-style newlines with a newline ending every file
 end_of_line = lf
 insert_final_newline = true
@@ -29,11 +30,12 @@ max_line_length = off
 # 4 space indentation
 indent_size = 4
 
-[*.{yml,zpt,pt,dtml,zcml}]
+[*.{yml,zpt,pt,dtml,zcml,html,xml}]
 # 2 space indentation
 indent_size = 2
 
-[*.{json,jsonl,js,jsx,ts,tsx,css,less,scss,html}]  # Frontend development
+[*.{json,jsonl,js,jsx,ts,tsx,css,less,scss}]
+# Frontend development
 # 2 space indentation
 indent_size = 2
 max_line_length = 80

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [flake8]
 doctests = 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Generated from:
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# See the inline comments on how to expand/tweak this configuration file
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 name: Meta
 on:
@@ -25,17 +25,17 @@ on:
 
 jobs:
   qa:
-    uses: plone/meta/.github/workflows/qa.yml@main
+    uses: plone/meta/.github/workflows/qa.yml@2.x
   test:
-    uses: plone/meta/.github/workflows/test.yml@main
+    uses: plone/meta/.github/workflows/test.yml@2.x
   coverage:
-    uses: plone/meta/.github/workflows/coverage.yml@main
+    uses: plone/meta/.github/workflows/coverage.yml@2.x
   dependencies:
-    uses: plone/meta/.github/workflows/dependencies.yml@main
+    uses: plone/meta/.github/workflows/dependencies.yml@2.x
   release_ready:
-    uses: plone/meta/.github/workflows/release_ready.yml@main
+    uses: plone/meta/.github/workflows/release_ready.yml@2.x
   circular:
-    uses: plone/meta/.github/workflows/circular.yml@main
+    uses: plone/meta/.github/workflows/circular.yml@2.x
 
 ##
 # To modify the list of default jobs being created add in .meta.toml:
@@ -55,6 +55,13 @@ jobs:
 # when running tests/coverage jobs, add in .meta.toml:
 # [github]
 # os_dependencies = "git libxml2 libxslt"
+##
+
+##
+# To test against a specific matrix of python versions
+# when running tests jobs, add in .meta.toml:
+# [github]
+# py_versions = "['3.12', '3.11']"
 ##
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 # python related
 *.egg-info
@@ -20,6 +20,8 @@ __pycache__/
 .tox
 .vscode/
 node_modules/
+forest.dot
+forest.json
 
 # venv / buildout related
 bin/
@@ -35,6 +37,7 @@ lib64
 parts/
 pyvenv.cfg
 var/
+local.cfg
 
 # mxdev
 /instance/

--- a/.meta.toml
+++ b/.meta.toml
@@ -1,9 +1,9 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "fe7a1752"
+commit-id = "2.0.1.dev0"
 
 [pre_commit]
 codespell_extra_lines = """

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 ci:
     autofix_prs: false
@@ -7,16 +7,16 @@ ci:
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.14.0
+    rev: v3.19.1
     hooks:
     -   id: pyupgrade
         args: [--py38-plus]
 -   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 6.0.0
     hooks:
     -   id: isort
 -   repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 25.1.0
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
@@ -32,7 +32,7 @@ repos:
 #  """
 ##
 -   repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
 
@@ -44,7 +44,7 @@ repos:
 #  """
 ##
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.4.1
     hooks:
     -   id: codespell
         additional_dependencies:
@@ -59,7 +59,7 @@ repos:
 #  """
 ##
 -   repo: https://github.com/mgedmin/check-manifest
-    rev: "0.49"
+    rev: "0.50"
     hooks:
     -   id: check-manifest
 -   repo: https://github.com/regebro/pyroma
@@ -67,12 +67,12 @@ repos:
     hooks:
     -   id: pyroma
 -   repo: https://github.com/mgedmin/check-python-versions
-    rev: "0.21.3"
+    rev: "0.22.1"
     hooks:
     -   id: check-python-versions
         args: ['--only', 'setup.py,pyproject.toml']
 -   repo: https://github.com/collective/i18ndude
-    rev: "6.1.0"
+    rev: "6.2.1"
     hooks:
     -   id: i18ndude
 

--- a/news/+meta.internal
+++ b/news/+meta.internal
@@ -1,0 +1,2 @@
+Update configuration files.
+[plone devs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [build-system]
 requires = ["setuptools>=68.2"]
@@ -71,7 +71,7 @@ target-version = ["py38"]
 ##
 
 [tool.codespell]
-ignore-words-list = "discreet,sie,"
+ignore-words-list = "discreet,assertin,thet,sie,"
 skip = "*.po,"
 ##
 # Add extra configuration options in .meta.toml:
@@ -119,6 +119,7 @@ Zope = [
   'Products.CMFCore', 'Products.CMFDynamicViewFTI',
 ]
 python-dateutil = ['dateutil']
+pytest-plone = ['pytest', 'zope.pytestlayer', 'plone.testing', 'plone.app.testing']
 
 ##
 # Add extra configuration options in .meta.toml:
@@ -133,19 +134,26 @@ python-dateutil = ['dateutil']
 [tool.check-manifest]
 ignore = [
     ".editorconfig",
+    ".flake8",
     ".meta.toml",
     ".pre-commit-config.yaml",
-    "tox.ini",
-    ".flake8",
+    "dependabot.yml",
     "mx.ini",
+    "tox.ini",
 
 ]
+
 ##
 # Add extra configuration options in .meta.toml:
 #  [pyproject]
 #  check_manifest_ignores = """
 #      "*.map.js",
 #      "*.pyc",
+#  """
+#  check_manifest_extra_lines = """
+#  ignore-bad-ideas = [
+#      "some/test/file/PKG-INFO",
+#  ]
 #  """
 ##
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [tox]
 # We need 4.4.0 for constrain_package_deps.
@@ -71,7 +71,7 @@ description = check if the package defines all its dependencies
 skip_install = true
 deps =
     build
-    z3c.dependencychecker==2.11
+    z3c.dependencychecker==2.14.3
 commands =
     python -m build --sdist
     dependencychecker
@@ -109,7 +109,7 @@ set_env =
 deps =
     zope.testrunner
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
-    
+
 ##
 # Specify additional deps in .meta.toml:
 #  [tox]
@@ -152,11 +152,12 @@ deps =
     coverage
     zope.testrunner
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
-    
+
 commands =
     coverage run --branch --source plone.app.locales {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir} -s plone.app.locales {posargs}
     coverage report -m --format markdown
     coverage xml
+    coverage html
 extras =
     test
 
@@ -169,7 +170,7 @@ deps =
     build
     towncrier
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
-    
+
 commands =
     # fake version to not have to install the package
     # we build the change log as news entries might break
@@ -182,6 +183,9 @@ commands =
 description = ensure there are no cyclic dependencies
 use_develop = true
 skip_install = false
+# Here we must always constrain the package deps to what is already installed,
+# otherwise we simply get the latest from PyPI, which may not work.
+constrain_package_deps = true
 set_env =
 
 ##
@@ -197,7 +201,7 @@ deps =
     pipdeptree
     pipforester
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
-    
+
 commands =
     # Generate the full dependency tree
     sh -c 'pipdeptree -j > forest.json'

--- a/utils/admix.py
+++ b/utils/admix.py
@@ -1,5 +1,5 @@
 """
-   Usage: admix.py <target-product> <source-product>
+Usage: admix.py <target-product> <source-product>
 """
 
 from utils import getLanguage

--- a/utils/create.py
+++ b/utils/create.py
@@ -1,12 +1,12 @@
 """
-   Usage: create.py <target-product> <source-product>
+Usage: create.py <target-product> <source-product>
 
-   Creates copies of all existing po files of the source product under the name of the target product.
-   This is useful to preserves headers of the files and to give a starting point for work.
+Creates copies of all existing po files of the source product under the name of the target product.
+This is useful to preserves headers of the files and to give a starting point for work.
 
-   You have to run merge after that, to remove the wrong msgid's and include the one's from the actual product
+You have to run merge after that, to remove the wrong msgid's and include the one's from the actual product
 
-   Using admix.py can then copy over existing translations.
+Using admix.py can then copy over existing translations.
 """
 
 from utils import getLanguage

--- a/utils/filter.py
+++ b/utils/filter.py
@@ -1,7 +1,7 @@
 """
-   Usage: filter.py <target-product> <source-product>
+Usage: filter.py <target-product> <source-product>
 
-   Filter out all msgid's in target product that are already in source product.
+Filter out all msgid's in target product that are already in source product.
 """
 
 import os

--- a/utils/list.py
+++ b/utils/list.py
@@ -1,5 +1,5 @@
 """
-   Usage: list.py
+Usage: list.py
 """
 
 from utils import getLongProductName

--- a/utils/rebuild-pot.py
+++ b/utils/rebuild-pot.py
@@ -1,10 +1,10 @@
 """
-   Usage: rebuild-pot.py <product> <path to products dir>
+Usage: rebuild-pot.py <product> <path to products dir>
 
-   If you are lazy you can also use atct, atrbw etc. as shorthands and if you
-   set your INSTANCE_HOME correctly it will automagically use the right version.
+If you are lazy you can also use atct, atrbw etc. as shorthands and if you
+set your INSTANCE_HOME correctly it will automagically use the right version.
 
-   So 'rebuilt-pot.py atrbw' is a valid shorthand.
+So 'rebuilt-pot.py atrbw' is a valid shorthand.
 """
 
 from utils import getLongProductName

--- a/utils/relocate.py
+++ b/utils/relocate.py
@@ -1,12 +1,12 @@
 """
-   Usage: relocate.py
+Usage: relocate.py
 
-   As we moved quite some messages between domains lately, this script
-   automates this process, so it can be repeatedly and safely called on po
-   files to preserve translations.
+As we moved quite some messages between domains lately, this script
+automates this process, so it can be repeatedly and safely called on po
+files to preserve translations.
 
-   Note that PYTHON and I18NDUDE must have been set as environment variables
-   before calling this script
+Note that PYTHON and I18NDUDE must have been set as environment variables
+before calling this script
 """
 
 from i18ndude import catalog

--- a/utils/setcomment.py
+++ b/utils/setcomment.py
@@ -1,5 +1,5 @@
 """
-   Usage: setcomment.py <product> <comment>
+Usage: setcomment.py <product> <comment>
 """
 
 from i18ndude import catalog

--- a/utils/setdomain.py
+++ b/utils/setdomain.py
@@ -1,5 +1,5 @@
 """
-   Usage: setdomain.py <product> <domain>
+Usage: setdomain.py <product> <domain>
 """
 
 from i18ndude import catalog

--- a/utils/setprojid.py
+++ b/utils/setprojid.py
@@ -1,5 +1,5 @@
 """
-   Usage: setprojid.py <product> <projectid>
+Usage: setprojid.py <product> <projectid>
 """
 
 from i18ndude import catalog

--- a/utils/sync.py
+++ b/utils/sync.py
@@ -1,5 +1,5 @@
 """
-   Usage: sync.py [<product> | <language-code>]
+Usage: sync.py [<product> | <language-code>]
 """
 
 from utils import getLongProductName

--- a/utils/table.py
+++ b/utils/table.py
@@ -1,5 +1,5 @@
 """
-   Usage: table.py
+Usage: table.py
 """
 
 from utils import getLongProductName


### PR DESCRIPTION
Just a regular update with latest plone/meta.  And then `black` made changes.

BTW, locally `check-manifest` complains, but that should only be a problem on my Mac, with (I think) case insensitive file system:

```
check-manifest...........................................................Failed
- hook id: check-manifest
- exit code: 1

lists of files in version control and sdist do not match!
missing from VCS:
  plone/app/locales/locales/sr@Cyrl/LC_MESSAGES/plonefrontpage.po
  plone/app/locales/locales/sr@Latn/LC_MESSAGES/plonefrontpage.po
missing from sdist:
  plone/app/locales/locales/sr@cyrl/LC_MESSAGES/plonefrontpage.po
  plone/app/locales/locales/sr@latn/LC_MESSAGES/plonefrontpage.po
suggested MANIFEST.in rules:
  recursive-include plone *.po
```
