### PR TITLE
Update pt_BR translations for plone and widgets domains

### DIFF
--- a/news/+pt-br-translations.feature
+++ b/news/+pt-br-translations.feature
@@ -1,0 +1,1 @@
+Update Brazilian Portuguese (pt_BR) translations for ``plone`` and ``widgets`` domains. @ericof

--- a/src/plone/app/locales/locales/pt_BR/LC_MESSAGES/plone.po
+++ b/src/plone/app/locales/locales/pt_BR/LC_MESSAGES/plone.po
@@ -90,11 +90,11 @@ msgstr "${name} é reservado."
 
 #: plone/namedfile/test.pt:100
 msgid "${python:round(size/1024, 1)} KB"
-msgstr ""
+msgstr "${python:round(size/1024, 1)} KB"
 
 #: plone/namedfile/test.pt:97
 msgid "${python:round(size/1024/1024, 1)} MB"
-msgstr ""
+msgstr "${python:round(size/1024/1024, 1)} MB"
 
 #: CMFPlone/RegistrationTool.py:226
 msgid "${sentences}. ${sentence}"
@@ -414,7 +414,7 @@ msgstr "Um portlet que pode exibir uma árvore de navegação"
 
 #: plone/portlet/collection/profiles/default/portlets.xml
 msgid "A portlet which displays the results of a collection query"
-msgstr ""
+msgstr "Um portlet que exibe os resultados de uma consulta de coleção"
 
 #: CMFPlone/profiles/dependencies/portlets.xml
 msgid "A portlet which shows a search box."
@@ -460,7 +460,7 @@ msgstr "Um portlet simples que exibe HTML estático"
 
 #: plone/portlet/collection/configure.zcml:17
 msgid "A simple portlet that displays the results of a collection object"
-msgstr ""
+msgstr "Um portlet simples que exibe os resultados de um objeto coleção"
 
 #: plone/app/discussion/profiles/default/workflows/comment_review_workflow/definition.xml
 msgid "A simple review workflow for comments"
@@ -588,7 +588,7 @@ msgstr "Adicionar Clone do Modificador de Blobs"
 
 #: plone/portlet/collection/collection.py:308
 msgid "Add Collection Portlet"
-msgstr ""
+msgstr "Adicionar portlet de coleção"
 
 #: plone/app/dexterity/browser/add_type.py:12
 msgid "Add Content Type"
@@ -1468,7 +1468,7 @@ msgstr "Apagar Cache"
 
 #: plone/namedfile/test.pt:272
 msgid "Clear scales"
-msgstr ""
+msgstr "Remover escalas"
 
 #: CMFPlone/browser/templates/plone-upgrade.pt:85
 msgid "Click here if you want to learn more."
@@ -1499,7 +1499,7 @@ msgstr "Coleção"
 #: plone/portlet/collection/configure.zcml:17
 #: plone/portlet/collection/profiles/default/portlets.xml
 msgid "Collection portlet"
-msgstr ""
+msgstr "Portlet de coleção"
 
 #: plone/base/interfaces/resources.py:31
 msgid "Comma separated values of resource for shim"
@@ -2192,7 +2192,7 @@ msgstr "Item de Discussão"
 
 #: plone/app/discussion/profiles/default/types/Discussion_Item.xml
 msgid "Discussion Items are documents which reply to other content."
-msgstr ""
+msgstr "Itens de discussão são documentos em resposta a outros conteúdos."
 
 #. Default: "Discussion Items are documents which reply to other content.They should *not* be addable through the standard 'folder_factories' interface."
 #: portal type description of type with title Discussion Item
@@ -2331,7 +2331,7 @@ msgstr "Editar Portlet Clássico"
 
 #: plone/portlet/collection/collection.py:317
 msgid "Edit Collection Portlet"
-msgstr ""
+msgstr "Editar portlet de coleção"
 
 #: plone/app/contentrules/conditions/portaltype.py:111
 msgid "Edit Content Type Condition"
@@ -2761,7 +2761,7 @@ msgstr "Eventos podem ser mostrados nos calendários."
 
 #: plone/namedfile/test.pt:119
 msgid "Examples with mode"
-msgstr ""
+msgstr "Exemplos com modo"
 
 msgid "Excel spreadsheet"
 msgstr "Planilha Excel"
@@ -2776,7 +2776,7 @@ msgstr "Excluir ator de destinatários"
 
 #: plone/portlet/collection/collection.py:88
 msgid "Exclude the Current Context"
-msgstr ""
+msgstr "Excluir o contexto atual"
 
 #: plone/app/vocabularies/metadatafields.py:15
 msgid "Excluded from navigation"
@@ -3032,7 +3032,7 @@ msgstr "Procurar itens que podem conter outros objetos"
 
 #: plone/portlet/collection/collection.py:43
 msgid "Find the collection which provides the items to list"
-msgstr ""
+msgstr "Encontre a coleção que fornece os itens para listar"
 
 #: CMFPlone/controlpanel/browser/relations.py:27
 msgid "Finished! See log for details."
@@ -3122,19 +3122,19 @@ msgstr "Configurações gerais dos tipos"
 
 #: plone/namedfile/test.pt:166
 msgid "Generate a picture tag from configured picture_variant `large`."
-msgstr ""
+msgstr "Gerar uma tag de imagem a partir da variante de imagem configurada `large`."
 
 #: plone/namedfile/test.pt:176
 msgid "Generate a picture tag from configured picture_variant `medium`. This picture tag contains multiple source tags with media queries for art direction."
-msgstr ""
+msgstr "Gerar uma tag de imagem a partir da variante de imagem configurada `medium`. Esta tag de imagem contém múltiplas tags de fonte com consultas de mídia para direção artística."
 
 #: plone/namedfile/test.pt:197
 msgid "Generate a picture tag from configured picture_variant `small` with title and alt attributes set."
-msgstr ""
+msgstr "Gerar uma tag de imagem a partir da variante de imagem configurada `small` com os atributos title e alt definidos."
 
 #: plone/namedfile/test.pt:187
 msgid "Generate a picture tag from configured picture_variant `small`."
-msgstr ""
+msgstr "Gerar uma tag de imagem a partir da variante de imagem configurada `small`."
 
 #: plone/base/interfaces/controlpanel.py:812
 msgid "Generate tabs for items other than folders."
@@ -3190,7 +3190,7 @@ msgstr "Ir para sua instância"
 
 #: plone/namedfile/test.pt:53
 msgid "Go to: <a href=\"#examples\">x</a>, <a href=\"#cover\">x</a>, <a href=\"#contain\">x</a>, <a href=\"#picture\">x</a>, <a href=\"#srcset\" i18n=\"name\">x</a>, <a href=\"#stored\">x</a>, <a href=\"#clear\">x</a>"
-msgstr ""
+msgstr "Ir para: <a href=\"#examples\">x</a>, <a href=\"#cover\">x</a>, <a href=\"#contain\">x</a>, <a href=\"#picture\">x</a>, <a href=\"#srcset\" i18n=\"name\">x</a>, <a href=\"#stored\">x</a>, <a href=\"#clear\">x</a>"
 
 #: CMFPlone/controlpanel/browser/usergroups_groupdetails.py:68
 msgid "Group ${name} has been added."
@@ -3354,19 +3354,19 @@ msgstr "Caso desativado, a purga não acontecerá"
 
 #: plone/portlet/collection/collection.py:69
 msgid "If enabled, a more... link will appear in the footer of the portlet, linking to the underlying Collection."
-msgstr ""
+msgstr "Caso ativado, um link 'mais...' aparecerá no rodapé do portlet, ligando para a coleção subjacente."
 
 #: plone/portlet/collection/collection.py:80
 msgid "If enabled, effective dates will be shown underneath the items listed."
-msgstr ""
+msgstr "Caso ativado, as datas efetivas serão mostradas abaixo dos itens listados."
 
 #: plone/portlet/collection/collection.py:59
 msgid "If enabled, items will be selected randomly from the collection, rather than based on its sort order."
-msgstr ""
+msgstr "Caso ativado, os itens serão selecionados aleatoriamente da coleção, em vez de serem baseados na ordem de classificação."
 
 #: plone/portlet/collection/collection.py:89
 msgid "If enabled, the listing will not include the current item the portlet is rendered for if it otherwise would be."
-msgstr ""
+msgstr "Caso ativado, a listagem não incluirá o item atual para o qual o portlet é renderizado, se ele de outra forma seria incluído."
 
 #: plone/app/portlets/portlets/recent.py:34
 #: plone/app/portlets/portlets/review.py:23
@@ -4288,15 +4288,15 @@ msgstr "Documento do Microsoft Word"
 
 #: plone/namedfile/test.pt:121
 msgid "Mini"
-msgstr ""
+msgstr "Mini"
 
 #: plone/namedfile/test.pt:143
 msgid "Mini mode=contain"
-msgstr ""
+msgstr "Mini modo=contain"
 
 #: plone/namedfile/test.pt:131
 msgid "Mini mode=cover"
-msgstr ""
+msgstr "Mini modo=cover"
 
 #: plone/stringinterp/browser.py:45
 msgid "Miscellaneous"
@@ -4708,7 +4708,7 @@ msgstr "Abrir links externos em nova janela"
 
 #: plone/namedfile/test.pt:259
 msgid "Open in new tab"
-msgstr ""
+msgstr "Abrir em uma nova aba"
 
 #: CMFPlone/browser/login/templates/explainPWResetTool.pt:42
 msgid "Open reset requests: ${n}"
@@ -4915,27 +4915,27 @@ msgstr "Preferências Pessoais"
 
 #: plone/namedfile/test.pt:163
 msgid "Picture Tag Large"
-msgstr ""
+msgstr "Tag de Imagem Grande"
 
 #: plone/namedfile/test.pt:173
 msgid "Picture Tag Medium"
-msgstr ""
+msgstr "Tag de Imagem Média"
 
 #: plone/namedfile/test.pt:184
 msgid "Picture Tag Small"
-msgstr ""
+msgstr "Tag de Imagem Pequena"
 
 #: plone/namedfile/test.pt:194
 msgid "Picture Tag Small with title/alt"
-msgstr ""
+msgstr "Tag de Imagem Pequena com título/alt"
 
 #: plone/namedfile/test.pt:157
 msgid "Picture tags"
-msgstr ""
+msgstr "Tags de Imagem"
 
 #: plone/namedfile/test.pt:158
 msgid "Picture tags only work on Plone 6. If not available (like on Plone 5.2), an ordinary image tag is created."
-msgstr ""
+msgstr "As tags de imagem funcionam apenas no Plone 6. Se não estiverem disponíveis (como no Plone 5.2), uma tag de imagem comum é criada."
 
 #: plone/base/interfaces/controlpanel.py:1691
 msgid "Picture variants"
@@ -5820,7 +5820,7 @@ msgstr ""
 
 #: plone/portlet/collection/collection.py:58
 msgid "Select random items"
-msgstr ""
+msgstr "Selecionar itens aleatórios"
 
 #. Default: "Select referenced content"
 #: criterion description of criterion ATReferenceCriterion
@@ -6037,7 +6037,7 @@ msgstr "Exibir diferenças de código"
 
 #: plone/portlet/collection/collection.py:79
 msgid "Show dates"
-msgstr ""
+msgstr "Exibir datas"
 
 #: plone/base/interfaces/syndication.py:221
 msgid "Show feed link"
@@ -6069,7 +6069,7 @@ msgstr ""
 
 #: plone/portlet/collection/collection.py:68
 msgid "Show more... link"
-msgstr ""
+msgstr "Exibir link de 'mais...'"
 
 #: plone/base/interfaces/syndication.py:211
 msgid "Show settings button"
@@ -6248,7 +6248,7 @@ msgstr ""
 
 #: plone/portlet/collection/collection.py:50
 msgid "Specify the maximum number of items to show in the portlet. Leave this blank to show all items."
-msgstr ""
+msgstr "Especifique o número máximo de itens a serem exibidos no portlet. Deixe em branco para exibir todos os itens."
 
 #: plone/app/caching/caching.zcml:43
 msgid "Stable file and image resources"
@@ -6256,7 +6256,7 @@ msgstr "Imagens e arquivos de interface estáveis"
 
 #: plone/namedfile/test.pt:60
 msgid "Standard display of Image content type, but using thumb scale"
-msgstr ""
+msgstr "Exibição padrão do tipo de conteúdo Imagem, mas usando a escala thumb"
 
 #. Default: "Standard view"
 #: plone/app/contenttypes/browser/configure.zcml:22
@@ -6302,7 +6302,7 @@ msgstr "Armazenar uma nova versão do objeto"
 
 #: plone/namedfile/test.pt:228
 msgid "Stored scales"
-msgstr ""
+msgstr "Escalas armazenadas"
 
 #: plone/app/caching/operations/default.py:300
 msgid "Strong caching"
@@ -6500,7 +6500,7 @@ msgstr "Destino"
 
 #: plone/portlet/collection/collection.py:42
 msgid "Target collection"
-msgstr ""
+msgstr "Coleção de destino"
 
 #: plone/app/contentrules/actions/copy.py:32
 #: plone/app/contentrules/actions/move.py:34
@@ -7128,7 +7128,7 @@ msgstr ""
 
 #: plone/portlet/collection/collection.py:309
 msgid "This portlet displays a listing of items from a Collection."
-msgstr ""
+msgstr "Esse portlet exibe uma listagem de itens de uma Coleção."
 
 #: plone/app/portlets/portlets/navigation.py:379
 msgid "This portlet displays a navigation tree."
@@ -7234,7 +7234,7 @@ msgstr "Visibilidade de miniaturas"
 
 #: plone/namedfile/test.pt:59
 msgid "Thumb with info"
-msgstr ""
+msgstr "Thumb com informações"
 
 #: plone/app/contenttypes/behaviors/configure.zcml:69
 msgid "Thumbs and icon handling"
@@ -7494,7 +7494,7 @@ msgstr "Desinstalar suporte para discussões"
 
 #: plone/app/caching/profiles.zcml:26
 msgid "Uninstall HTTP caching support"
-msgstr ""
+msgstr "Remover suporte de cache HTTP"
 
 #: plone/app/multilingual/configure.zcml:179
 msgid "Uninstall, removes multilingual content support with plone.app.multilingual"
@@ -8257,7 +8257,7 @@ msgstr "Já adicionado"
 #. Default: "(Guest)"
 #: plone/app/discussion/browser/utils.py:10
 msgid "anonymous_user_suffix"
-msgstr ""
+msgstr "(Convidado)"
 
 #. Default: "assets"
 #: plone/app/multilingual/browser/setup.py:140
@@ -8472,7 +8472,7 @@ msgstr ""
 
 #: plone/namedfile/test.pt:53
 msgid "clear"
-msgstr ""
+msgstr "limpar"
 
 #. Default: "Clear filter"
 #: plone/app/registry/browser/templates/records.pt:113
@@ -8604,7 +8604,7 @@ msgstr "Telefone do contato"
 
 #: plone/namedfile/test.pt:37
 msgid "contain"
-msgstr ""
+msgstr "contain"
 
 #: plone/app/multilingual/browser/interfaces.py:100
 msgid "content"
@@ -8693,7 +8693,7 @@ msgstr "Direitos autorais"
 
 #: plone/namedfile/test.pt:33
 msgid "cover"
-msgstr ""
+msgstr "cover"
 
 #. Default: "If you want to create this object without being a translation press ${url}"
 #: plone/app/multilingual/browser/templates/add-form-is-translation.pt:35
@@ -10024,7 +10024,7 @@ msgstr "Exemplo:"
 
 #: plone/namedfile/test.pt:29
 msgid "examples"
-msgstr ""
+msgstr "exemplos"
 
 #: plone/formwidget/recurrence/browser/i18n.py:167
 msgid "except"
@@ -10937,7 +10937,7 @@ msgstr ""
 #. Default: "Starting with Plone 6.1, default content is not loaded into the site. If you want to load the default content, you should install the <code>plone.classicui</code> package. If you see this text, that means you have not installed that package yet."
 #: CMFPlone/browser/templates/plone-overview.pt:105
 msgid "help_create_plone_site_buttons_3"
-msgstr ""
+msgstr "A partir do Plone 6.1, o conteúdo de exemplo não é carregado no site. Se você deseja carregar o conteúdo de exemplo, deve instalar o pacote <code>plone.classicui</code>. Se você está vendo este texto, isso significa que você ainda não instalou esse pacote."
 
 #. Default: "Date this object was created"
 #: widget description of CalendarWidget for label Creation Date
@@ -12151,11 +12151,11 @@ msgstr "Tamanho do arquivo"
 
 #: plone/namedfile/test.pt:45
 msgid "img tag with srcset"
-msgstr ""
+msgstr "tag img com srcset"
 
 #: plone/namedfile/test.pt:208
 msgid "img with srcset attributes"
-msgstr ""
+msgstr "img com atributos srcset"
 
 #. Default: "Import"
 #: plone/app/registry/browser/templates/records.pt:218
@@ -14928,7 +14928,7 @@ msgstr " "
 #. Default: "More…"
 #: plone/portlet/collection/collection.pt:102
 msgid "more_url"
-msgstr ""
+msgstr "Mais..."
 
 #. Default: "Delimiter detected: ${delimiter}"
 #: CMFPlone/controlpanel/browser/redirects.py:481
@@ -14943,7 +14943,7 @@ msgstr "As configurações importadas foram salvas."
 #. Default: "To do so, the @@images view provides a srcset method, that will output the full srcset of this image, using all available image scales. It has as required parameter the value of the sizes attribute that the user of this method has to provide and will be output as is in the generated HTML."
 #: plone/namedfile/test.pt:212
 msgid "msg_images_test_srcset"
-msgstr ""
+msgstr "Para isso, a visualização @@images fornece um método srcset, que irá gerar o srcset completo desta imagem, usando todas as escalas de imagem disponíveis. Ele tem como parâmetro obrigatório o valor do atributo sizes que o usuário deste método deve fornecer e será gerado como está no HTML gerado."
 
 #. Default: "The following login names would be used by more than one account:"
 #: CMFPlone/controlpanel/browser/emaillogin.pt:31
@@ -15180,7 +15180,7 @@ msgstr "pendente"
 
 #: plone/namedfile/test.pt:41
 msgid "picture tags"
-msgstr ""
+msgstr "tags de imagem"
 
 #. Default: "Plain Text"
 #: CMFPlone/skins/plone_wysiwyg/wysiwyg_support.pt:55
@@ -15514,7 +15514,7 @@ msgstr "Ordenar por"
 
 #: plone/namedfile/test.pt:209
 msgid "srcset allows the browser to select the correct image, depending on the space the image has on a page."
-msgstr ""
+msgstr "srcset permite que o navegador selecione a imagem correta, dependendo do espaço que a imagem ocupa em uma página."
 
 #. Default: "Failed to create your account: we were unable to send instructions for setting a password to your email address: ${address}"
 #: plone/app/users/browser/register.py:479
@@ -15567,7 +15567,7 @@ msgstr "Um e-mail foi enviado com o seu nome de usuário."
 
 #: plone/namedfile/test.pt:49
 msgid "stored scales"
-msgstr ""
+msgstr "escalas armazenadas"
 
 #. Default: "Structured Text"
 #: CMFPlone/skins/plone_wysiwyg/wysiwyg_support.pt:37

--- a/src/plone/app/locales/locales/pt_BR/LC_MESSAGES/widgets.po
+++ b/src/plone/app/locales/locales/pt_BR/LC_MESSAGES/widgets.po
@@ -21,11 +21,11 @@ msgstr ""
 
 #: pat/structure/js/views/app.js
 msgid "${current} of ${total} selected"
-msgstr ""
+msgstr "${current} de ${total} selecionados"
 
 #: pat/contentbrowser/src/ContentBrowser.svelte
 msgid "${item_count} items selected"
-msgstr ""
+msgstr "${item_count} itens selecionados"
 
 #: pat/structure/templates/actionmenu.xml
 msgid "Actions"
@@ -61,7 +61,7 @@ msgstr "Cancelar"
 
 #: pat/structure/js/views/selectionwell.js
 msgid "Cancel selection"
-msgstr ""
+msgstr "Cancelar seleção"
 
 #: pat/upload/templates/upload.xml
 msgid "Choose File"
@@ -73,7 +73,7 @@ msgstr "Limpar"
 
 #: pat/modal/modal.js
 msgid "Close"
-msgstr ""
+msgstr "Fechar"
 
 #: pat/structure/js/views/columns.js
 msgid "Columns"
@@ -101,7 +101,7 @@ msgstr "Recortar"
 
 #: pat/contentbrowser/src/ContentBrowser.svelte
 msgid "Description"
-msgstr ""
+msgstr "Descrição"
 
 #: pat/formunloadalert/formunloadalert.js
 msgid "Discard changes? If you click OK, any changes you have made will be lost."
@@ -193,7 +193,7 @@ msgstr "Ir para um nível acima"
 
 #: pat/contentbrowser/src/ContentBrowser.svelte
 msgid "Id"
-msgstr ""
+msgstr "Id"
 
 #: pat/tinymce/tinymce.js
 msgid "Image"
@@ -385,11 +385,11 @@ msgstr "Selecionar"
 
 #: pat/structure/js/views/selectionwell.js
 msgid "Select all items in the folder"
-msgstr ""
+msgstr "Selecionar todos os itens na pasta"
 
 #: pat/structure/js/views/selectionwell.js
 msgid "Select all items on this page"
-msgstr ""
+msgstr "Selecionar todos os itens nesta página"
 
 #: pat/tinymce/tinymce.js
 msgid "Select an anchor"
@@ -409,7 +409,7 @@ msgstr "Selecione um critério"
 
 #: pat/contentbrowser/src/SelectedItems.svelte
 msgid "Select or Upload"
-msgstr ""
+msgstr "Selecionar ou Carregar"
 
 #: pat/structure/js/actionmenu.js
 msgid "Set as default page"
@@ -501,11 +501,11 @@ msgstr "Você já clicou no botão enviar. Você realmente deseja enviar este fo
 
 #: pat/contentbrowser/src/ContentBrowser.svelte
 msgid "add selected items"
-msgstr ""
+msgstr "Adicionar itens selecionados"
 
 #: pat/contentbrowser/src/ContentBrowser.svelte
 msgid "clear filter"
-msgstr ""
+msgstr "Limpar filtro"
 
 #: pat/structure/js/actions.js
 msgid "copying"
@@ -513,7 +513,7 @@ msgstr "Copiando"
 
 #: pat/contentbrowser/src/ContentBrowser.svelte
 msgid "created"
-msgstr ""
+msgstr "criado"
 
 #: pat/relateditems/relateditems.js
 msgid "current directory:"
@@ -537,27 +537,27 @@ msgstr "Encontrado"
 
 #: pat/contentbrowser/src/ContentBrowser.svelte
 msgid "grid view"
-msgstr ""
+msgstr "visão em grade"
 
 #: pat/contentbrowser/src/ContentBrowser.svelte
 msgid "level filter"
-msgstr ""
+msgstr "filtro de nível"
 
 #: pat/contentbrowser/src/ContentBrowser.svelte
 msgid "list view"
-msgstr ""
+msgstr "visão em lista"
 
 #: pat/contentbrowser/src/ContentBrowser.svelte
 msgid "loading content items"
-msgstr ""
+msgstr "Carregando itens de conteúdo"
 
 #: pat/contentbrowser/src/SelectedItems.svelte
 msgid "loading selected items"
-msgstr ""
+msgstr "Carregando itens selecionados"
 
 #: pat/contentbrowser/src/ContentBrowser.svelte
 msgid "modified"
-msgstr ""
+msgstr "modificado"
 
 #: pat/contentbrowser/src/ContentBrowser.svelte
 msgid "no results found"
@@ -577,7 +577,7 @@ msgstr "Resultados"
 
 #: pat/contentbrowser/src/ContentBrowser.svelte
 msgid "review_state"
-msgstr ""
+msgstr "estado de revisão"
 
 #: pat/livesearch/livesearch.js
 msgid "searching…"
@@ -585,11 +585,11 @@ msgstr "Procurando…"
 
 #: pat/contentbrowser/src/ContentBrowser.svelte
 msgid "select ${level_path}"
-msgstr ""
+msgstr "selecionar ${level_path}"
 
 #: pat/contentbrowser/src/ContentBrowser.svelte
 msgid "select ${preview_path}"
-msgstr ""
+msgstr "selecionar ${preview_path}"
 
 #: pat/structure/templates/paging.xml
 msgid "shown"
@@ -605,7 +605,7 @@ msgstr "para"
 
 #: pat/contentbrowser/src/ContentBrowser.svelte
 msgid "upload to ${current_path}"
-msgstr ""
+msgstr "enviar para ${current_path}"
 
 #: pat/upload/upload.js
 msgid "uploading..."


### PR DESCRIPTION
## Summary

Updates Brazilian Portuguese (pt_BR) translations for the `plone` and `widgets` i18n domains. Roughly 58 previously empty `msgstr ""` entries are now filled in.

### Files

- `src/plone/app/locales/locales/pt_BR/LC_MESSAGES/plone.po` — translations for `plone.portlet.collection`, `plone.namedfile` test page strings, and miscellaneous CMFPlone messages.
- `src/plone/app/locales/locales/pt_BR/LC_MESSAGES/widgets.po` — translations for the `pat-contentbrowser`, `pat-structure`, and `pat-modal` mockup widgets.

## Test plan

- [X] CI passes (`.po` validation, pre-commit).
- [X] `uvx towncrier build --draft --yes --version 7.0.2` renders the news fragment correctly.